### PR TITLE
酒一覧を少しかっこよくした

### DIFF
--- a/app/assets/stylesheets/sakes.scss
+++ b/app/assets/stylesheets/sakes.scss
@@ -2,6 +2,10 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: https://sass-lang.com/
 
+.clickable {
+  cursor: pointer;
+}
+
 #notice {
   color: green;
 }

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -20,21 +20,18 @@
       <th><%= @sakes.human_attribute_name :taste_value %></th>
       <th><%= @sakes.human_attribute_name :aroma_value %></th>
       <th><%= @sakes.human_attribute_name :tokutei_meisho %></th>
-      <th colspan="3"></th>
     </tr>
   </thead>
   <tbody>
     <% @sakes.each do |sake| %>
-      <tr>
+      <tr class="clickable"
+        onclick='window.location="/sakes/<%= sake.id.to_s %>"' role="link">
         <td><%= sake.name %></td>
         <td><%= sake.kura %></td>
         <td><%= sake.photo %></td>
         <td><%= sake.taste_value %></td>
         <td><%= sake.aroma_value %></td>
         <td><%= sake.tokutei_meisho_i18n %></td>
-        <td><%= link_to '詳細', sake %></td>
-        <td><%= link_to '編集', edit_sake_path(sake) %></td>
-        <td><%= link_to '削除', sake, method: :delete, data: { confirm: 'Are you sure?' } %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/sakes/show.html.erb
+++ b/app/views/sakes/show.html.erb
@@ -171,4 +171,8 @@
 </p>
 
 <%= link_to 'Edit', edit_sake_path(@sake) %> |
+<%= link_to 'Remove',
+             @sake,
+             method: :delete,
+             data: { confirm: 'Are you sure?' } %> |
 <%= link_to 'Back', sakes_path %>


### PR DESCRIPTION
Fix #37 

- テーブルの行全体をクリックして詳細が見れるようにした
    - jQueryとcssで実現した
    - 参考：https://qiita.com/Kohei_Kishimoto0214/items/2e56985552926d025c35
- 各酒の削除・編集は詳細ページに異動した
