### PR TITLE
GithubActionsでaptをやめてapt-getを使うようにした

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -25,7 +25,7 @@ jobs:
         ruby-version: 2.7
     - name: Install sqlite3
       run:
-        sudo apt install -y libsqlite3-dev
+        sudo apt-get install -y --no-install-recommends libsqlite3-dev
     - name: Cache gems
       uses: actions/cache@v2
       with:


### PR DESCRIPTION
aptはCLIでの使用を非推奨のため、GithubActionsに警告ログが出る。
そのため、apt-getを使うように変更した。

ついでにオプションを追加し、推奨依存関係をインストールしないようにした