### PR TITLE
味・香りグラフを追加した

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -7,6 +7,7 @@ require("@rails/ujs").start()
 require("turbolinks").start()
 require("@rails/activestorage").start()
 require("channels")
+require("chart.js")
 
 import 'bootstrap'
 import '../src/application.scss'

--- a/app/javascript/packs/taste_graph.ts
+++ b/app/javascript/packs/taste_graph.ts
@@ -1,0 +1,183 @@
+import { Chart } from 'chart.js'
+
+interface ClickableChart extends Chart {
+  chart: {
+    scales: {
+      'x-axis-1': { getValueForPixel: (x: number) => number | undefined }
+      'y-axis-1': { getValueForPixel: (y: number) => number | undefined }
+    }
+  }
+}
+
+const middle = 3
+
+function toGraphData(documentData: Chart.Point) {
+  return { x: documentData.x - middle, y: documentData.y - middle }
+}
+
+function toDocumentData(graphData: Chart.Point) {
+  return { x: graphData.x + middle, y: graphData.y + middle }
+}
+
+const graphZeroP = { x: 0, y: 0 }
+const documentZeroP = toDocumentData(graphZeroP)
+
+interface InteractiveGraph {
+  update(data: Chart.Point): void
+}
+
+function updateDocumentData(data: Chart.Point) {
+  const tasteInput = document.getElementById(
+    'sake_taste_value'
+  ) as HTMLInputElement
+  const aromaInput = document.getElementById(
+    'sake_aroma_value'
+  ) as HTMLInputElement
+  tasteInput.setAttribute('value', data.x.toString())
+  aromaInput.setAttribute('value', data.y.toString())
+}
+
+class TasteGraph implements InteractiveGraph {
+  public graph: Chart
+
+  /*
+   * HACk:
+   *   graphは常に1点データしか持たないという制約をしている。
+   *   そのため、popを1回すれば全データが消える。
+   */
+  private popData(): void {
+    this.graph.data.datasets?.forEach((dataset) => {
+      dataset.data?.pop()
+    })
+  }
+
+  private pushData(newData: Chart.Point) {
+    const datasets = this.graph.data.datasets
+    if (datasets != null) {
+      datasets.forEach((dataset: Chart.ChartDataSets) => {
+        const d = dataset.data as Chart.ChartPoint[]
+        d.push(newData)
+      })
+    }
+  }
+
+  public update(data: Chart.Point) {
+    this.popData()
+    this.pushData(data)
+    updateDocumentData(toDocumentData(data))
+    this.graph.update()
+  }
+
+  private getClickedData(event: MouseEvent): Chart.Point {
+    // @types/chart.jsに型宣言がないので型を潰して独自宣言で上書きする
+    const g = this.graph as ClickableChart
+    let x = g.chart.scales['x-axis-1'].getValueForPixel(event.offsetX)
+    let y = g.chart.scales['y-axis-1'].getValueForPixel(event.offsetY)
+    // undefinedチェック
+    if (x != null && y != null) {
+      x = Math.round(x)
+      y = Math.round(y)
+      return { x, y }
+    } else return graphZeroP
+  }
+
+  // JSに渡すときにthis問題を防ぐため、アロー関数で書いておく
+  private onClickFn = (event: MouseEvent): void => {
+    const data = this.getClickedData(event)
+    this.update(data)
+  }
+
+  private makeChartData(data: Chart.Point): Chart.ChartData {
+    const points = [data]
+    const datasets: Chart.ChartDataSets = {
+      data: points,
+      pointBackgroundColor: 'rgba(190, 20, 20, 0.7)',
+      pointBorderColor: 'rgba(190, 20, 20, 0.9)',
+    }
+    const cd: Chart.ChartData = {
+      datasets: [datasets],
+    }
+    return cd
+  }
+
+  private makeChartConfiguration(
+    dataset: Chart.ChartData
+  ): Chart.ChartConfiguration {
+    const margin = 0.2
+    const ticks: Chart.TickOptions = {
+      display: false,
+      max: middle + margin,
+      min: -middle - margin,
+      maxTicksLimit: 2,
+    }
+    const gridLines: Chart.GridLineOptions = {
+      drawBorder: true,
+      drawTicks: false,
+      drawOnChartArea: true,
+      zeroLineWidth: 7,
+    }
+    const options: Chart.ChartOptions = {
+      onClick: this.onClickFn,
+      legend: { display: false },
+      elements: { point: { radius: 10 } },
+      scales: {
+        xAxes: [
+          {
+            ticks: ticks,
+            gridLines: gridLines,
+            scaleLabel: {
+              display: true,
+              labelString: '香',
+            },
+          },
+        ],
+        yAxes: [
+          {
+            ticks: ticks,
+            gridLines: gridLines,
+            scaleLabel: {
+              display: true,
+              labelString: '味',
+            },
+          },
+        ],
+      },
+    }
+    const config: Chart.ChartConfiguration = {
+      type: 'scatter',
+      data: dataset,
+      options: options,
+    }
+    return config
+  }
+
+  constructor(canvas: HTMLCanvasElement, public data: Chart.Point) {
+    const cd = this.makeChartData(toGraphData(data))
+    const config = this.makeChartConfiguration(cd)
+    this.graph = new Chart(canvas, config)
+  }
+}
+
+function getDocumentData(): Chart.Point {
+  const tasteInput = document.getElementById(
+    'sake_taste_value'
+  ) as HTMLInputElement
+  const aromaInput = document.getElementById(
+    'sake_aroma_value'
+  ) as HTMLInputElement
+  if (aromaInput.value != '' && tasteInput.value != '') {
+    return { x: Number(tasteInput.value), y: Number(aromaInput.value) }
+  } else {
+    updateDocumentData(documentZeroP)
+    return documentZeroP
+  }
+}
+
+// Main
+{
+  // get datas from DOM
+  const canvas = document.getElementById('taste_graph') as HTMLCanvasElement
+  const documentData = getDocumentData() // dataは0~6の二次元データ
+  // make graph
+  new TasteGraph(canvas, documentData)
+}

--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -178,26 +178,23 @@
   </div>
 
   <div class="form-group row">
-    <%= form.label :aroma_value, { class: "col-4" } %>
-    <%= form.number_field(:aroma_value,
-                          { type: "range",
-                            min: "0",
-                            max: "10",
-                            class: "custom-range col-8" }) %>
+    <%= form.label((t("activerecord.attributes.sake.taste_value") + ", " +
+                    t("activerecord.attributes.sake.aroma_value")),
+                   { class: "col-4" }) %>
+    <div class="col-8">
+      <canvas id="taste_graph"></canvas>
+      <%= form.number_field(:taste_value,
+                            hidden: true,
+                            data: { taste_value: @sake.taste_value }) %>
+      <%= form.number_field(:aroma_value,
+                            hidden: true,
+                            data: { aroma_value: @sake.aroma_value }) %>
+    </div>
   </div>
 
   <div class="form-group row">
     <%= form.label :aroma_impression, { class: "col-4" } %>
     <%= form.text_area :aroma_impression, { class: "form-control col-8" } %>
-  </div>
-
-  <div class="form-group row">
-    <%= form.label :taste_value, { class: "col-4" } %>
-    <%= form.number_field(:taste_value,
-                          { type: "range",
-                            min: "0",
-                            max: "10",
-                            class: "custom-range col-8" }) %>
   </div>
 
   <div class="form-group row">
@@ -223,3 +220,5 @@
   </div>
 
 <% end %>
+
+<%= javascript_pack_tag 'taste_graph' %>

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "4.2.2",
     "bootstrap": "^4.5.0",
+    "chart.js": "^2.9.3",
     "jquery": "^3.5.1",
     "popper.js": "^1.16.1",
     "ts-loader": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^3.8.0",
     "@typescript-eslint/parser": "^3.8.0",
+    "@types/chart.js": "^2.9.23",
     "eslint": "^7.6.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-prettier": "^3.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -839,6 +839,13 @@
     webpack-cli "^3.3.10"
     webpack-sources "^1.4.3"
 
+"@types/chart.js@^2.9.23":
+  version "2.9.23"
+  resolved "https://registry.yarnpkg.com/@types/chart.js/-/chart.js-2.9.23.tgz#5de713e801f5aff4d042c7d49ab9691489c11848"
+  integrity sha512-4QQNE/b+digosu3mnj4E7aNQGKnlpzXa9JvQYPtexpO7v9gnDeqwc1DxF8vLJWLDCNoO6hH0EgO8K/7PtJl8wg==
+  dependencies:
+    moment "^2.10.2"
+
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1842,6 +1842,29 @@ chalk@^4.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chart.js@^2.9.3:
+  version "2.9.3"
+  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-2.9.3.tgz#ae3884114dafd381bc600f5b35a189138aac1ef7"
+  integrity sha512-+2jlOobSk52c1VU6fzkh3UwqHMdSlgH1xFv9FKMqHiNCpXsGPQa/+81AFa+i3jZ253Mq9aAycPwDjnn1XbRNNw==
+  dependencies:
+    chartjs-color "^2.1.0"
+    moment "^2.10.2"
+
+chartjs-color-string@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/chartjs-color-string/-/chartjs-color-string-0.6.0.tgz#1df096621c0e70720a64f4135ea171d051402f71"
+  integrity sha512-TIB5OKn1hPJvO7JcteW4WY/63v6KwEdt6udfnDE9iCAZgy+V4SrbSxoIbTw/xkUIapjEI4ExGtD0+6D3KyFd7A==
+  dependencies:
+    color-name "^1.0.0"
+
+chartjs-color@^2.1.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/chartjs-color/-/chartjs-color-2.4.1.tgz#6118bba202fe1ea79dd7f7c0f9da93467296c3b0"
+  integrity sha512-haqOg1+Yebys/Ts/9bLo/BqUcONQOdr/hoEr2LLTRl6C5LXctUdHxsCYfvQVg5JIxITrfCNUDr4ntqmQk9+/0w==
+  dependencies:
+    chartjs-color-string "^0.6.0"
+    color-convert "^1.9.3"
+
 chokidar@^2.1.8:
   version "2.1.8"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.8.tgz#804b3a7b6a99358c3c5c61e71d8728f041cff917"
@@ -1936,7 +1959,7 @@ collection-visit@^1.0.0:
     map-visit "^1.0.0"
     object-visit "^1.0.0"
 
-color-convert@^1.9.0, color-convert@^1.9.1:
+color-convert@^1.9.0, color-convert@^1.9.1, color-convert@^1.9.3:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
   integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
@@ -4765,6 +4788,11 @@ mixin-deep@^1.2.0:
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
   dependencies:
     minimist "^1.2.5"
+
+moment@^2.10.2:
+  version "2.27.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.27.0.tgz#8bff4e3e26a236220dfe3e36de756b6ebaa0105d"
+  integrity sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ==
 
 move-concurrently@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
登録と編集で味・香りをグラフで入力できるようにするぞ

# TODO

一部は別PRにする

- [x] TSを使う環境をdevへ整備
    - [x] TSのインストール
    - [x] linter
    - [x] 追加のreccomend linterの追加
    - [x] GithubActionsの追加
- [x] TS使ってグラフの表示
- [x] TS使ってグラフのクリック変更
- [ ] ~~TS使ってグラフの画像化~~
- [x] _formへグラフの埋め込み
- [ ] ~~indexへのグラフ画像の埋め込み~~

# 変更点

- chart.jsとchart.js用のTypeScript型を導入した
- 味香りグラフでの入力を実装した
    - chart.jsを使いTypeScriptで実装した
    - 味・香りは0~6の7段階で、3を中央値としている
    - 画像表示はまだ

#　試し方

- TypeScriptが含まれるため、`bundle exec rails server`の前に1度`./bin/webpack`でコンパイルをすること