### PR TITLE
ERB Lintを追加した

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -1,0 +1,31 @@
+---
+glob: "app/**/*.{html,text,js}{+*,}.erb"
+EnableDefaultLinters: true
+linters:
+  DeprecatedClasses:
+    enabled: true
+  ErbSafety:
+    enabled: true
+  Rubocop:
+    enabled: true
+    rubocop_config:
+      inherit_from:
+        - .rubocop.yml
+      # ERBでは120文字を採用する
+      Layout/LineLength:
+        Enabled: true
+        Max: 120
+      # ERBでは<% %>が分離するため誤検知が多い
+      # 以下、公式おすすめのオフ設定を持ってきた
+      Layout/InitialIndentation:
+        Enabled: false
+      Layout/TrailingEmptyLines:
+        Enabled: false
+      Layout/TrailingWhitespace:
+        Enabled: false
+      Naming/FileName:
+        Enabled: false
+      Lint/UselessAssignment:
+        Enabled: false
+      Rails/OutputSafety:
+        Enabled: false

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -37,6 +37,8 @@ jobs:
         bundle install
     - name: Run Rubocop
       run: bundle exec rubocop
+    - name: Run ERB Lint
+      run: bundle exec erblint --lint-all
     # 将来的には使いたいね
     # - name: Run tests
     #   run: bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ group :development, :test do
 end
 
 group :development do
+  gem "erb_lint", require: false
   # Access an interactive console on exception pages or by calling 'console'
   # anywhere in the code.
   gem "listen", ">= 3.0.5", "< 3.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,14 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.1)
     bcrypt (3.1.15)
+    better_html (1.0.15)
+      actionview (>= 4.0)
+      activesupport (>= 4.0)
+      ast (~> 2.0)
+      erubi (~> 1.4)
+      html_tokenizer (~> 0.0.6)
+      parser (>= 2.4)
+      smart_properties
     bindex (0.8.1)
     bootsnap (1.4.6)
       msgpack (~> 1.0)
@@ -128,10 +136,19 @@ GEM
       dry-schema (~> 1.5)
     enum_help (0.0.17)
       activesupport (>= 3.0.0)
+    erb_lint (0.0.35)
+      activesupport
+      better_html (~> 1.0.7)
+      html_tokenizer
+      parser (>= 2.7.1.4)
+      rainbow
+      rubocop (~> 0.79)
+      smart_properties
     erubi (1.9.0)
     ffi (1.13.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    html_tokenizer (0.0.7)
     i18n (1.8.3)
       concurrent-ruby (~> 1.0)
     jbuilder (2.10.0)
@@ -238,6 +255,7 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
+    smart_properties (1.15.0)
     spring (2.1.0)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -293,6 +311,7 @@ DEPENDENCIES
   devise
   devise-i18n
   enum_help
+  erb_lint
   jbuilder (~> 2.7)
   listen (>= 3.0.5, < 3.2)
   puma (~> 4.3)

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,8 @@
-<p><%= t('.greeting', recipient: @resource.email) %></p>
+<p><%= t(".greeting", recipient: @resource.email) %></p>
 
-<p><%= t('.instruction') %></p>
+<p><%= t(".instruction") %></p>
 
-<p><%= link_to t('.action'), edit_password_url(@resource, reset_password_token: @token) %></p>
+<p><%= link_to t(".action"), edit_password_url(@resource, reset_password_token: @token) %></p>
 
-<p><%= t('.instruction_2') %></p>
-<p><%= t('.instruction_3') %></p>
+<p><%= t(".instruction_2") %></p>
+<p><%= t(".instruction_3") %></p>

--- a/app/views/devise/mailer/unlock_instructions.html.erb
+++ b/app/views/devise/mailer/unlock_instructions.html.erb
@@ -1,7 +1,7 @@
-<p><%= t('.greeting', recipient: @resource.email) %></p>
+<p><%= t(".greeting", recipient: @resource.email) %></p>
 
-<p><%= t('.message') %></p>
+<p><%= t(".message") %></p>
 
-<p><%= t('.instruction') %></p>
+<p><%= t(".instruction") %></p>
 
-<p><%= link_to t('.action'), unlock_url(@resource, unlock_token: @token) %></p>
+<p><%= link_to t(".action"), unlock_url(@resource, unlock_token: @token) %></p>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,24 +1,24 @@
-<h2><%= t('.change_your_password') %></h2>
+<h2><%= t(".change_your_password") %></h2>
 
 <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
   <%= f.hidden_field :reset_password_token %>
 
   <div class="field">
-    <%= f.label :password, t('.new_password') %><br />
+    <%= f.label :password, t(".new_password") %><br>
     <% if @minimum_password_length %>
-      <em><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></em><br />
+      <em><%= t("devise.shared.minimum_password_length", count: @minimum_password_length) %></em><br>
     <% end %>
     <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
   </div>
 
   <div class="field">
-    <%= f.label :password_confirmation, t('.confirm_new_password') %><br />
+    <%= f.label :password_confirmation, t(".confirm_new_password") %><br>
     <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
   </div>
 
   <div class="actions">
-    <%= f.submit t('.change_my_password') %>
+    <%= f.submit t(".change_my_password") %>
   </div>
 <% end %>
 

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,15 +1,15 @@
-<h2><%= t('.forgot_your_password') %></h2>
+<h2><%= t(".forgot_your_password") %></h2>
 
 <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">
-    <%= f.label :email %><br />
+    <%= f.label :email %><br>
     <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
   </div>
 
   <div class="actions">
-    <%= f.submit t('.send_me_reset_password_instructions') %>
+    <%= f.submit t(".send_me_reset_password_instructions") %>
   </div>
 <% end %>
 

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,43 +1,49 @@
-<h2><%= t('.title', resource: resource.model_name.human) %></h2>
+<h2><%= t(".title", resource: resource.model_name.human) %></h2>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">
-    <%= f.label :email %><br />
+    <%= f.label :email %><br>
     <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
   </div>
 
   <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div><%= t('.currently_waiting_confirmation_for_email', email: resource.unconfirmed_email) %></div>
+    <div><%= t(".currently_waiting_confirmation_for_email", email: resource.unconfirmed_email) %></div>
   <% end %>
 
   <div class="field">
-    <%= f.label :password %> <i>(<%= t('.leave_blank_if_you_don_t_want_to_change_it') %>)</i><br />
+    <%= f.label :password %> <i>(<%= t(".leave_blank_if_you_don_t_want_to_change_it") %>)</i><br>
     <%= f.password_field :password, autocomplete: "new-password" %>
     <% if @minimum_password_length %>
-      <br />
-      <em><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></em>
+      <br>
+      <em><%= t("devise.shared.minimum_password_length", count: @minimum_password_length) %></em>
     <% end %>
   </div>
 
   <div class="field">
-    <%= f.label :password_confirmation %><br />
+    <%= f.label :password_confirmation %><br>
     <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
   </div>
 
   <div class="field">
-    <%= f.label :current_password %> <i>(<%= t('.we_need_your_current_password_to_confirm_your_changes') %>)</i><br />
+    <%= f.label :current_password %> <i>(<%= t(".we_need_your_current_password_to_confirm_your_changes") %>)</i><br>
     <%= f.password_field :current_password, autocomplete: "current-password" %>
   </div>
 
   <div class="actions">
-    <%= f.submit t('.update') %>
+    <%= f.submit t(".update") %>
   </div>
 <% end %>
 
-<h3><%= t('.cancel_my_account') %></h3>
+<h3><%= t(".cancel_my_account") %></h3>
 
-<p><%= t('.unhappy') %> <%= button_to t('.cancel_my_account'), registration_path(resource_name), data: { confirm: t('.are_you_sure') }, method: :delete %></p>
+<p>
+  <%= t(".unhappy") %>
+  <%= button_to(t(".cancel_my_account"),
+                registration_path(resource_name),
+                data: { confirm: t(".are_you_sure") },
+                method: :delete) %>
+</p>
 
-<%= link_to t('devise.shared.links.back'), :back %>
+<%= link_to t("devise.shared.links.back"), :back %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,13 +1,13 @@
-<h2><%= t('.sign_in') %></h2>
+<h2><%= t(".sign_in") %></h2>
 
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <div class="field">
-    <%= f.label :email %><br />
+    <%= f.label :email %><br>
     <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
   </div>
 
   <div class="field">
-    <%= f.label :password %><br />
+    <%= f.label :password %><br>
     <%= f.password_field :password, autocomplete: "current-password" %>
   </div>
 
@@ -19,7 +19,7 @@
   <% end %>
 
   <div class="actions">
-    <%= f.submit t('.sign_in') %>
+    <%= f.submit t(".sign_in") %>
   </div>
 <% end %>
 

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -3,8 +3,7 @@
     <h2>
       <%= I18n.t("errors.messages.not_saved",
                  count: resource.errors.count,
-                 resource: resource.class.model_name.human.downcase)
-       %>
+                 resource: resource.class.model_name.human.downcase) %>
     </h2>
     <ul>
       <% resource.errors.full_messages.each do |message| %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,21 +1,23 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to t(".sign_in"), new_session_path(resource_name) %><br />
+  <%= link_to t(".sign_in"), new_session_path(resource_name) %><br>
 <% end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to t(".forgot_your_password"), new_password_path(resource_name) %><br />
+  <%= link_to t(".forgot_your_password"), new_password_path(resource_name) %><br>
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to t('.didn_t_receive_confirmation_instructions'), new_confirmation_path(resource_name) %><br />
+  <%= link_to t(".didn_t_receive_confirmation_instructions"), new_confirmation_path(resource_name) %><br>
 <% end %>
 
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-  <%= link_to t('.didn_t_receive_unlock_instructions'), new_unlock_path(resource_name) %><br />
+  <%= link_to t(".didn_t_receive_unlock_instructions"), new_unlock_path(resource_name) %><br>
 <% end %>
 
 <%- if devise_mapping.omniauthable? %>
   <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= link_to t('.sign_in_with_provider', provider: OmniAuth::Utils.camelize(provider)), omniauth_authorize_path(resource_name, provider) %><br />
+    <%= link_to(t(".sign_in_with_provider", provider: OmniAuth::Utils.camelize(provider)),
+                omniauth_authorize_path(resource_name, provider)) %>
+    <br>
   <% end %>
 <% end %>

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -1,15 +1,15 @@
-<h2><%= t('.resend_unlock_instructions') %></h2>
+<h2><%= t(".resend_unlock_instructions") %></h2>
 
 <%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">
-    <%= f.label :email %><br />
+    <%= f.label :email %><br>
     <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
   </div>
 
   <div class="actions">
-    <%= f.submit t('.resend_unlock_instructions') %>
+    <%= f.submit t(".resend_unlock_instructions") %>
   </div>
 <% end %>
 

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -5,8 +5,8 @@
   </small>
   <nav>
     <ul>
-      <li><%= link_to "About",   '#' %></li>
-      <li><%= link_to "Contact", '#' %></li>
+      <li><%= link_to "About", "#" %></li>
+      <li><%= link_to "Contact", "#" %></li>
     </ul>
   </nav>
 </footer>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,22 +5,22 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
-    <%= javascript_pack_tag 'application' %>
-    <%= stylesheet_pack_tag 'application' %>
+    <%= javascript_pack_tag "application" %>
+    <%= stylesheet_pack_tag "application" %>
 
-    <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
-    <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <%= stylesheet_link_tag "application", media: "all", 'data-turbolinks-track': "reload" %>
+    <%= javascript_pack_tag "application", 'data-turbolinks-track': "reload" %>
   </head>
 
   <body>
-    <%= render 'layouts/header' %>
+    <%= render "layouts/header" %>
     <div class="container">
       <% flash.each do |message_type, message| %>
         <% next if message_type == "timedout" %>
         <div class="alert alert-<%= message_type %>"><%= message %></div>
       <% end %>
       <%= yield %>
-      <%= render 'layouts/footer' %>
+      <%= render "layouts/footer" %>
       <%= debug(params) if Rails.env.development? %>
     </div>
   </body>

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <style>
       /* Email styles need to be inline */
     </style>

--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -22,7 +22,7 @@
   </div>
 
   <div class="form-group row">
-    <%= form.label :kura, { class: "col-4"} %>
+    <%= form.label :kura, { class: "col-4" } %>
     <%= form.text_field :kura, { class: "form-control col-8" } %>
   </div>
 
@@ -39,8 +39,9 @@
   <div class="form-group row">
     <%= form.label :tokutei_meisho, { class: "col-4" } %>
     <%= form.select(:tokutei_meisho,
-                    Sake.tokutei_meishos_i18n.keys.map{
-                      |k| [ I18n.t("enums.sake.tokutei_meisho.#{k}"), k ] },
+                    Sake.tokutei_meishos_i18n.keys.map do |k|
+                      [I18n.t("enums.sake.tokutei_meisho.#{k}"), k]
+                    end,
                     {},
                     { class: "form-control col-8" }) %>
   </div>
@@ -100,8 +101,9 @@
   <div class="form-group row">
     <%= form.label :moto, { class: "col-4" } %>
     <%= form.select(:moto,
-                    Sake.motos_i18n.keys.map{
-                      |k| [ I18n.t("enums.sake.moto.#{k}"), k ] },
+                    Sake.motos_i18n.keys.map do |k|
+                      [I18n.t("enums.sake.moto.#{k}"), k]
+                    end,
                     {},
                     { class: "form-control col-8" }) %>
   </div>
@@ -119,8 +121,9 @@
   <div class="form-group row">
     <%= form.label :hiire, { class: "col-4" } %>
     <%= form.select(:hiire,
-                    Sake.hiires_i18n.keys.map{
-                      |k| [ I18n.t("enums.sake.hiire.#{k}"), k ] },
+                    Sake.hiires_i18n.keys.map do |k|
+                      [I18n.t("enums.sake.hiire.#{k}"), k]
+                    end,
                     {},
                     { class: "form-control col-8", title: "test" }) %>
   </div>
@@ -133,7 +136,7 @@
   <div class="form-group row">
     <%= form.label :nihonshudo, { class: "col-4" } %>
     <%= form.number_field :nihonshudo,
-        { class: "form-control col-8" } %>
+                          { class: "form-control col-8" } %>
   </div>
 
   <div class="form-group row">
@@ -151,8 +154,9 @@
   <div class="form-group row">
     <%= form.label :warimizu, { class: "col-4" } %>
     <%= form.select(:warimizu,
-                    Sake.warimizus_i18n.keys.map{
-                      |k| [ I18n.t("enums.sake.warimizu.#{k}"), k ] },
+                    Sake.warimizus_i18n.keys.map do |k|
+                      [I18n.t("enums.sake.warimizu.#{k}"), k]
+                    end,
                     {},
                     { class: "form-control col-8" }) %>
   </div>
@@ -161,8 +165,9 @@
   <div class="form-group row">
     <%= form.label :bottle_level, { class: "col-4" } %>
     <%= form.select(:bottle_level,
-                    Sake.bottle_levels_i18n.keys.map{
-                      |k| [ I18n.t("enums.sake.bottle_level.#{k}"), k ] },
+                    Sake.bottle_levels_i18n.keys.map do |k|
+                      [I18n.t("enums.sake.bottle_level.#{k}"), k]
+                    end,
                     {},
                     { class: "form-control col-8" }) %>
   </div>
@@ -221,4 +226,4 @@
 
 <% end %>
 
-<%= javascript_pack_tag 'taste_graph' %>
+<%= javascript_pack_tag "taste_graph" %>

--- a/app/views/sakes/edit.html.erb
+++ b/app/views/sakes/edit.html.erb
@@ -1,2 +1,2 @@
 <h1>編集</h1>
-<%= render 'form', sake: @sake %>
+<%= render "form", sake: @sake %>

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -40,4 +40,4 @@
               { class: "btn btn-outline-primary" }) %>
 </div>
 
-<%= javascript_pack_tag 'clickable_sakeindex' %>
+<%= javascript_pack_tag "clickable_sakeindex" %>

--- a/app/views/sakes/new.html.erb
+++ b/app/views/sakes/new.html.erb
@@ -1,2 +1,2 @@
 <h1>新規登録</h1>
-<%= render 'form', sake: @sake %>
+<%= render "form", sake: @sake %>

--- a/app/views/sakes/show.html.erb
+++ b/app/views/sakes/show.html.erb
@@ -176,7 +176,7 @@
   <%= link_to(t("helpers.submit.delete"),
               @sake,
               method: :delete,
-              data: { confirm: t("message.delete") } ,
+              data: { confirm: t("message.delete") },
               class: "btn btn-outline-danger") %>
 
 </div>


### PR DESCRIPTION
# 追加元

- https://github.com/Shopify/erb-lint

# 方針

- ERB Lint
    - 古いオリジナルがあるが更新されていない
    - これはShopifyがforkしたプロジェクトで、Shopifyでも使われなくなってきているらしい
    - ときどき更新遅れで、Rubocopのアップデートで動かなくなる
- とりあえず最新のRubocopで動くので、動く間はLintすることにする
- 動かなくなったら、取り除くことも考える

# 更新内容

- ERB Lintを追加
    - 設定は全Linterをオンにしている
        - erb自体のチェックと、erbに埋め込まれたRubyコードをチェックする
        - 一部、埋め込みRubyと相性が悪いRubocopルールがあり、それをオフにしている
    - 横幅は120文字とした
- ERB LintのGitHub Actionsを追加
- ERB Lintに従い既存のerbファイルを修正した
    - 120文字で頑張る、できれば80文字が好き
    - 各種Rubyのいい感じ書き方にした
        - ダブルクオート！
        - `map { |k| ... }`は駄目で、`map do |k| ... end`がいいらしい
    - `<br />`のような`/>`閉じはXHTMLの作法で、HTML5では使わない