### PR TITLE
味・香りグラフを酒一覧に追加した

### DIFF
--- a/app/assets/stylesheets/sakes.scss
+++ b/app/assets/stylesheets/sakes.scss
@@ -2,10 +2,6 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: https://sass-lang.com/
 
-.clickable {
-  cursor: pointer;
-}
-
 #notice {
   color: green;
 }

--- a/app/assets/stylesheets/sakes_index.scss
+++ b/app/assets/stylesheets/sakes_index.scss
@@ -1,0 +1,10 @@
+.clickable {
+  cursor: pointer;
+}
+
+.table-image {
+  margin: auto;
+}
+
+.table-string {
+}

--- a/app/assets/stylesheets/sakes_index.scss
+++ b/app/assets/stylesheets/sakes_index.scss
@@ -5,6 +5,3 @@
 .table-image {
   margin: auto;
 }
-
-.table-string {
-}

--- a/app/javascript/packs/form_graph.ts
+++ b/app/javascript/packs/form_graph.ts
@@ -1,0 +1,39 @@
+import { TasteGraph, domZeroP } from './taste_graph'
+
+// DOMにデータがない場合はデータセットをする副作用がある
+function syncAndGetDomValue(): Chart.Point {
+  const tasteInput = document.getElementById(
+    'sake_taste_value'
+  ) as HTMLInputElement
+  const aromaInput = document.getElementById(
+    'sake_aroma_value'
+  ) as HTMLInputElement
+  if (tasteInput.value && aromaInput.value) {
+    const taste = parseInt(tasteInput.value)
+    const aroma = parseInt(aromaInput.value)
+    if (taste != NaN && aroma != NaN) return { x: taste, y: aroma }
+  }
+  // データがとれなかった場合はグラフの原点をセットする
+  updateDomValue(domZeroP)
+  return domZeroP
+}
+
+function updateDomValue(data: Chart.Point): void {
+  const tasteInput = document.getElementById(
+    'sake_taste_value'
+  ) as HTMLInputElement
+  const aromaInput = document.getElementById(
+    'sake_aroma_value'
+  ) as HTMLInputElement
+  tasteInput.setAttribute('value', data.x.toString())
+  aromaInput.setAttribute('value', data.y.toString())
+}
+
+// Main
+{
+  // get datas from DOM
+  const canvas = document.getElementById('taste_graph') as HTMLCanvasElement
+  const domData = syncAndGetDomValue() // dataは0~6の二次元データ
+  // make graph
+  new TasteGraph(canvas, domData, updateDomValue)
+}

--- a/app/javascript/packs/form_graph.ts
+++ b/app/javascript/packs/form_graph.ts
@@ -1,7 +1,20 @@
-import { TasteGraph, domZeroP } from './taste_graph'
+import { GraphP, TasteGraph, domZeroP } from './taste_graph'
+
+function updateDomValue(data: GraphP): void {
+  const x = data ? data.x.toString() : ''
+  const y = data ? data.y.toString() : ''
+  const tasteInput = document.getElementById(
+    'sake_taste_value'
+  ) as HTMLInputElement
+  const aromaInput = document.getElementById(
+    'sake_aroma_value'
+  ) as HTMLInputElement
+  tasteInput.setAttribute('value', x)
+  aromaInput.setAttribute('value', y)
+}
 
 // DOMにデータがない場合はデータセットをする副作用がある
-function syncAndGetDomValue(): Chart.Point {
+function syncAndGetDomValue(): GraphP {
   const tasteInput = document.getElementById(
     'sake_taste_value'
   ) as HTMLInputElement
@@ -13,27 +26,21 @@ function syncAndGetDomValue(): Chart.Point {
     const aroma = parseInt(aromaInput.value)
     if (taste != NaN && aroma != NaN) return { x: taste, y: aroma }
   }
-  // データがとれなかった場合はグラフの原点をセットする
-  updateDomValue(domZeroP)
-  return domZeroP
+  return null // データがない場合
 }
 
-function updateDomValue(data: Chart.Point): void {
-  const tasteInput = document.getElementById(
-    'sake_taste_value'
-  ) as HTMLInputElement
-  const aromaInput = document.getElementById(
-    'sake_aroma_value'
-  ) as HTMLInputElement
-  tasteInput.setAttribute('value', data.x.toString())
-  aromaInput.setAttribute('value', data.y.toString())
-}
-
-// Main
 {
-  // get datas from DOM
+  // DOMから味・香りの値を取る
   const canvas = document.getElementById('taste_graph') as HTMLCanvasElement
   const domData = syncAndGetDomValue() // dataは0~6の二次元データ
-  // make graph
-  new TasteGraph(canvas, domData, updateDomValue)
+
+  // グラフをセットする
+  const graph = new TasteGraph(canvas, domData, updateDomValue)
+
+  // グラフのリセットボタンをセットする
+  const button = document.getElementById('graph-reset') as HTMLDivElement
+  button.onclick = () => {
+    graph.update(null)
+    updateDomValue(null)
+  }
 }

--- a/app/javascript/packs/form_graph.ts
+++ b/app/javascript/packs/form_graph.ts
@@ -35,7 +35,7 @@ function syncAndGetDomValue(): GraphP {
   const domData = syncAndGetDomValue() // dataは0~6の二次元データ
 
   // グラフをセットする
-  const graph = new TasteGraph(canvas, domData, updateDomValue)
+  const graph = new TasteGraph(canvas, domData, true, updateDomValue)
 
   // グラフのリセットボタンをセットする
   const button = document.getElementById('graph-reset') as HTMLDivElement

--- a/app/javascript/packs/index_graph.ts
+++ b/app/javascript/packs/index_graph.ts
@@ -1,7 +1,7 @@
 import { Chart } from 'chart.js'
-import { TasteGraph, toGraphPoint } from './taste_graph'
+import { GraphP, TasteGraph, toGraphPoint } from './taste_graph'
 
-function getDomValueFromCanvas(canvas: HTMLCanvasElement): Chart.Point {
+function getDomValueFromCanvas(canvas: HTMLCanvasElement): GraphP {
   const tasteS = canvas.dataset.tasteValue
   const aromaS = canvas.dataset.aromaValue
   // not (undefined or empty string)
@@ -11,7 +11,7 @@ function getDomValueFromCanvas(canvas: HTMLCanvasElement): Chart.Point {
     if (taste != NaN && aroma != NaN) return { x: taste, y: aroma }
   }
   // データがないなら範囲外を描く
-  return toGraphPoint({ x: -1, y: -1 })
+  return null
 }
 
 const hasCanvasID = (elem: HTMLCanvasElement): boolean => {

--- a/app/javascript/packs/index_graph.ts
+++ b/app/javascript/packs/index_graph.ts
@@ -1,0 +1,30 @@
+import { Chart } from 'chart.js'
+import { TasteGraph, toGraphPoint } from './taste_graph'
+
+function getDomValueFromCanvas(canvas: HTMLCanvasElement): Chart.Point {
+  const tasteS = canvas.dataset.tasteValue
+  const aromaS = canvas.dataset.aromaValue
+  // not (undefined or empty string)
+  if (tasteS && aromaS) {
+    const taste = parseInt(tasteS)
+    const aroma = parseInt(aromaS)
+    if (taste != NaN && aroma != NaN) return { x: taste, y: aroma }
+  }
+  // データがないなら範囲外を描く
+  return toGraphPoint({ x: -1, y: -1 })
+}
+
+const hasCanvasID = (elem: HTMLCanvasElement): boolean => {
+  const id = elem.getAttribute('id')
+  return id != null
+}
+
+// Main
+{
+  const canvases = Array.from(document.getElementsByTagName('canvas'))
+  const graphs = canvases.filter(hasCanvasID)
+  graphs.forEach((canvas) => {
+    const p = getDomValueFromCanvas(canvas)
+    new TasteGraph(canvas, p)
+  })
+}

--- a/app/javascript/packs/index_graph.ts
+++ b/app/javascript/packs/index_graph.ts
@@ -1,4 +1,3 @@
-import { Chart } from 'chart.js'
 import { GraphP, TasteGraph, toGraphPoint } from './taste_graph'
 
 function getDomValueFromCanvas(canvas: HTMLCanvasElement): GraphP {

--- a/app/javascript/packs/index_graph.ts
+++ b/app/javascript/packs/index_graph.ts
@@ -9,7 +9,7 @@ function getDomValueFromCanvas(canvas: HTMLCanvasElement): GraphP {
     const aroma = parseInt(aromaS)
     if (taste != NaN && aroma != NaN) return { x: taste, y: aroma }
   }
-  // データがないなら範囲外を描く
+  // データがないなど、Domからデータが取れない場合
   return null
 }
 

--- a/app/javascript/packs/taste_graph.ts
+++ b/app/javascript/packs/taste_graph.ts
@@ -16,35 +16,22 @@ interface ClickableChart extends Chart {
  */
 const middle = 3
 
-function toGraphPoint(documentData: Chart.Point): Chart.Point {
+export function toGraphPoint(documentData: Chart.Point): Chart.Point {
   return { x: documentData.x - middle, y: documentData.y - middle }
 }
 
-function toDomPoint(graphData: Chart.Point): Chart.Point {
+export function toDomPoint(graphData: Chart.Point): Chart.Point {
   return { x: graphData.x + middle, y: graphData.y + middle }
 }
 
-const graphZeroP = { x: 0, y: 0 }
-const domZeroP = toDomPoint(graphZeroP)
+export const graphZeroP = { x: 0, y: 0 }
+export const domZeroP = toDomPoint(graphZeroP)
 
 interface InteractiveGraph {
   update(data: Chart.Point): void
 }
 
-function updateDomValue(data: Chart.Point): void {
-  const tasteInput = document.getElementById(
-    'sake_taste_value'
-  ) as HTMLInputElement
-  const aromaInput = document.getElementById(
-    'sake_aroma_value'
-  ) as HTMLInputElement
-  if (tasteInput != null && aromaInput != null) {
-    tasteInput.setAttribute('value', data.x.toString())
-    aromaInput.setAttribute('value', data.y.toString())
-  }
-}
-
-class TasteGraph implements InteractiveGraph {
+export class TasteGraph implements InteractiveGraph {
   public graph: Chart
 
   /*
@@ -71,8 +58,8 @@ class TasteGraph implements InteractiveGraph {
   public update(data: Chart.Point): void {
     this.popData()
     this.pushData(data)
-    updateDomValue(toDomPoint(data))
     this.graph.update()
+    this.callbackUpdate(toDomPoint(data))
   }
 
   private getClickedData(event: MouseEvent): Chart.Point {
@@ -158,38 +145,13 @@ class TasteGraph implements InteractiveGraph {
     return config
   }
 
-  constructor(canvas: HTMLCanvasElement, public data: Chart.Point) {
-    const cd = this.makeChartData(toGraphPoint(data))
-    const config = this.makeChartConfiguration(cd)
+  constructor(
+    canvas: HTMLCanvasElement,
+    data: Chart.Point,
+    private callbackUpdate: (data: Chart.Point) => void = (data) => {}
+  ) {
+    const p = this.makeChartData(toGraphPoint(data))
+    const config = this.makeChartConfiguration(p)
     this.graph = new Chart(canvas, config)
   }
-}
-
-// DOMにデータがない場合はデータセットをする副作用がある
-function syncAndGetDomValue(): Chart.Point {
-  const tasteInput = document.getElementById(
-    'sake_taste_value'
-  ) as HTMLInputElement
-  const aromaInput = document.getElementById(
-    'sake_aroma_value'
-  ) as HTMLInputElement
-  if (tasteInput != null && aromaInput != null) {
-    if (aromaInput.value != '' && tasteInput.value != '') {
-      const taste = parseInt(tasteInput.value)
-      const aroma = parseInt(aromaInput.value)
-      if (taste != NaN && aroma != NaN) return { x: taste, y: aroma }
-    }
-  }
-  // データがとれなかった場合はグラフの原点をセットする
-  updateDomValue(domZeroP)
-  return domZeroP
-}
-
-// Main
-{
-  // get datas from DOM
-  const canvas = document.getElementById('taste_graph') as HTMLCanvasElement
-  const domData = syncAndGetDomValue() // dataは0~6の二次元データ
-  // make graph
-  new TasteGraph(canvas, domData)
 }

--- a/app/javascript/packs/taste_graph.ts
+++ b/app/javascript/packs/taste_graph.ts
@@ -9,6 +9,8 @@ interface ClickableChart extends Chart {
   }
 }
 
+export type GraphP = Chart.Point | null
+
 /*
  * HACK:
  *   内部データが0〜6に対してグラフデータが-3〜3のため、
@@ -16,19 +18,23 @@ interface ClickableChart extends Chart {
  */
 const middle = 3
 
-export function toGraphPoint(documentData: Chart.Point): Chart.Point {
-  return { x: documentData.x - middle, y: documentData.y - middle }
+export function toGraphPoint(documentData: GraphP): GraphP {
+  return documentData != null
+    ? { x: documentData.x - middle, y: documentData.y - middle }
+    : null
 }
 
-export function toDomPoint(graphData: Chart.Point): Chart.Point {
-  return { x: graphData.x + middle, y: graphData.y + middle }
+export function toDomPoint(graphData: GraphP): GraphP {
+  return graphData != null
+    ? { x: graphData.x + middle, y: graphData.y + middle }
+    : null
 }
 
 export const graphZeroP = { x: 0, y: 0 }
 export const domZeroP = toDomPoint(graphZeroP)
 
 interface InteractiveGraph {
-  update(data: Chart.Point): void
+  update(data: GraphP): void
 }
 
 export class TasteGraph implements InteractiveGraph {
@@ -36,8 +42,8 @@ export class TasteGraph implements InteractiveGraph {
 
   /*
    * HACk:
-   *   graphは常に1点データしか持たないという制約をしている。
-   *   そのため、popを1回すれば全データが消える。
+   *   graphは常に0or1点データしか持たないという制約をしている。
+   *   そのため、1点データを持つグラフにpopを1回すれば全データが消える。
    */
   private popData(): void {
     this.graph.data.datasets?.forEach((dataset) => {
@@ -55,11 +61,12 @@ export class TasteGraph implements InteractiveGraph {
     }
   }
 
-  public update(data: Chart.Point): void {
-    this.popData()
-    this.pushData(data)
+  public update(newData: GraphP): void {
+    if (this.data != null) this.popData()
+    this.data = newData
+    if (newData != null) this.pushData(newData)
     this.graph.update()
-    this.callbackUpdate(toDomPoint(data))
+    this.callbackUpdate(toDomPoint(this.data))
   }
 
   private getClickedData(event: MouseEvent): Chart.Point {
@@ -81,8 +88,8 @@ export class TasteGraph implements InteractiveGraph {
     this.update(data)
   }
 
-  private makeChartData(data: Chart.Point): Chart.ChartData {
-    const points = [data]
+  private makeChartData(data: GraphP): Chart.ChartData {
+    const points = data != null ? [data] : []
     const datasets: Chart.ChartDataSets = {
       data: points,
       pointBackgroundColor: 'rgba(190, 20, 20, 0.7)',
@@ -147,8 +154,8 @@ export class TasteGraph implements InteractiveGraph {
 
   constructor(
     canvas: HTMLCanvasElement,
-    data: Chart.Point,
-    private callbackUpdate: (data: Chart.Point) => void = (data) => {}
+    private data: GraphP,
+    private callbackUpdate: (data: GraphP) => void = (data) => {}
   ) {
     const p = this.makeChartData(toGraphPoint(data))
     const config = this.makeChartConfiguration(p)

--- a/app/javascript/packs/taste_graph.ts
+++ b/app/javascript/packs/taste_graph.ts
@@ -63,10 +63,10 @@ export class TasteGraph implements InteractiveGraph {
 
   public update(newData: GraphP): void {
     if (this.data != null) this.popData()
-    this.data = newData
     if (newData != null) this.pushData(newData)
     this.graph.update()
-    this.callbackUpdate(toDomPoint(this.data))
+    this.callbackUpdate(toDomPoint(newData))
+    this.data = newData
   }
 
   private getClickedData(event: MouseEvent): GraphP {

--- a/app/javascript/packs/taste_graph.ts
+++ b/app/javascript/packs/taste_graph.ts
@@ -69,7 +69,7 @@ export class TasteGraph implements InteractiveGraph {
     this.callbackUpdate(toDomPoint(this.data))
   }
 
-  private getClickedData(event: MouseEvent): Chart.Point {
+  private getClickedData(event: MouseEvent): GraphP {
     // @types/chart.jsに型宣言がないので型を潰して独自宣言で上書きする
     const g = this.graph as ClickableChart
     let x = g.chart.scales['x-axis-1'].getValueForPixel(event.offsetX)
@@ -79,11 +79,11 @@ export class TasteGraph implements InteractiveGraph {
       x = Math.round(x)
       y = Math.round(y)
       return { x, y }
-    } else return graphZeroP
+    } else return null
   }
 
   // JSに渡すときにthis問題を防ぐため、アロー関数で書いておく
-  private onClickFn = (event: MouseEvent): void => {
+  private onClickUpdate = (event: MouseEvent): void => {
     const data = this.getClickedData(event)
     this.update(data)
   }
@@ -118,7 +118,7 @@ export class TasteGraph implements InteractiveGraph {
       zeroLineWidth: 7,
     }
     const options: Chart.ChartOptions = {
-      onClick: this.onClickFn,
+      onClick: this.clickable ? this.onClickUpdate : (event) => {},
       legend: { display: false },
       elements: { point: { radius: 10 } },
       scales: {
@@ -155,6 +155,7 @@ export class TasteGraph implements InteractiveGraph {
   constructor(
     canvas: HTMLCanvasElement,
     private data: GraphP,
+    private clickable: boolean = false,
     private callbackUpdate: (data: GraphP) => void = (data) => {}
   ) {
     const p = this.makeChartData(toGraphPoint(data))

--- a/app/models/sake.rb
+++ b/app/models/sake.rb
@@ -41,18 +41,16 @@ class Sake < ApplicationRecord
   # validates :brew_year,
   validates :todofuken, exclusion: { in: [nil] }
   validates :taste_value,
-            numericality:
-            {
+            numericality: {
               allow_nil: true,
               greater_than_or_equal_to: 0,
-              less_than_or_equal_to: 10,
+              less_than_or_equal_to: 6,
             }
   validates :aroma_value,
-            numericality:
-            {
+            numericality: {
               allow_nil: true,
               greater_than_or_equal_to: 0,
-              less_than_or_equal_to: 10,
+              less_than_or_equal_to: 6,
             }
   validates :nihonshudo, numericality: { allow_nil: true }
   validates :sando, numericality: { allow_nil: true }

--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -232,3 +232,4 @@
 <% end %>
 
 <%= javascript_pack_tag "taste_graph" %>
+<%= javascript_pack_tag "form_graph" %>

--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -189,8 +189,15 @@
   </div>
 
   <div class="form-group row">
-    <%= form.label("#{t('activerecord.attributes.sake.taste_value')}, #{t('activerecord.attributes.sake.aroma_value')}",
-                   { class: "col-3" }) %>
+    <div class="col-3">
+      <%= form.label(
+            "#{t('activerecord.attributes.sake.taste_value')}, #{t('activerecord.attributes.sake.aroma_value')}",
+            { class: "row" },
+          ) %>
+      <div class="row btn btn-secondary" id="graph-reset">
+        <%= t("helpers.button.reset") %>
+      </div>
+    </div>
     <div class="col">
       <canvas id="taste_graph"></canvas>
       <%= form.number_field(:taste_value,

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -9,30 +9,42 @@
   <% end %>
   <%= f.submit :filter %>
 <% end %>
-<table class="table table-sm table-hover">
-  <thead class="thead-light">
-    <tr>
-      <th><%= @sakes.human_attribute_name :name %></th>
-      <th><%= @sakes.human_attribute_name :kura %></th>
-      <th><%= @sakes.human_attribute_name :photo %></th>
-      <th><%= @sakes.human_attribute_name :taste_value %></th>
-      <th><%= @sakes.human_attribute_name :aroma_value %></th>
-      <th><%= @sakes.human_attribute_name :tokutei_meisho %></th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @sakes.each do |sake| %>
-      <tr class="clickable" data-sake-id="<%= sake.id.to_s %>" role="link">
-        <td><%= sake.name %></td>
-        <td><%= sake.kura %></td>
-        <td><%= sake.photo %></td>
-        <td><%= sake.taste_value %></td>
-        <td><%= sake.aroma_value %></td>
-        <td><%= sake.tokutei_meisho_i18n %></td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+
+<div class="table-responsive">
+  <table class="table table-hover" caption="Sake List">
+    <thead></thead>
+    <tbody>
+      <% @sakes.each do |sake| %>
+        <tr class="clickable" data-sake-id="<%= sake.id %>">
+          <td class="col-6">
+            <div class="row">
+              <div class="col table-string">
+                <%= sake.name %>
+              </div>
+            </div>
+            <div class="row">
+              <div class="col table-string">
+                <%= sake.tokutei_meisho_i18n %>
+              </div>
+              <div class="col table-string">
+                <%= sake.todofuken %>
+              </div>
+            </div>
+          </td>
+          <td class="col-3 table-image">
+            <canvas id="sake-<%= sake.id %>"
+                    data-taste-value="<%= sake.taste_value %>"
+                    data-aroma-value="<%= sake.aroma_value %>">
+            </canvas>
+          </td>
+          <td class="col-3 table-image">
+            <canvas></canvas>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>
 
 <div class="row justify-content-center">
   <%= link_to(t("helpers.submit.create"),
@@ -41,3 +53,5 @@
 </div>
 
 <%= javascript_pack_tag "clickable_sakeindex" %>
+<%= javascript_pack_tag "taste_graph" %>
+<%= javascript_pack_tag "index_graph" %>

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -18,15 +18,15 @@
         <tr class="clickable" data-sake-id="<%= sake.id %>">
           <td class="col-6">
             <div class="row">
-              <div class="col table-string">
+              <div class="col">
                 <%= sake.name %>
               </div>
             </div>
             <div class="row">
-              <div class="col table-string">
+              <div class="col">
                 <%= sake.tokutei_meisho_i18n %>
               </div>
-              <div class="col table-string">
+              <div class="col">
                 <%= sake.todofuken %>
               </div>
             </div>

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -11,6 +11,8 @@ ja:
       delete: 削除
     badge:
       presence: 必須
+    button:
+      reset: リセット
   activerecord:
     models:
       sake: 酒


### PR DESCRIPTION
Fix #2

# 概要

- なんと酒一覧がよりかっこよくなったよ！
- あとは酒の画像だけ

# 変更点

- 酒一覧にグラフ表示した
    - あんま重たくないのでグラフは当初の予定と違って画像化してない
    - 酒一覧のデザインを2段組にしたよ、今後タグとかより情報を足していきたいね
- 酒の新規・編集で味・香りを入力なしにできるようにした
    - リセットボタンが追加された
    - 味香りの値がない酒は空グラフが表示される
