### PR TITLE
PostgreSQL移行による検索機能のバグ修正

### DIFF
--- a/app/models/search/base.rb
+++ b/app/models/search/base.rb
@@ -5,13 +5,13 @@ module Search
     def contain(data, column, value)
       return data if data.count.zero?
 
-      data.where("#{column} LIKE ?", "%#{value}%")
+      data.where("#{column}::text LIKE ?", "%#{value}%")
     end
 
     def exclude(data, column, value)
       return data if data.count.zero?
 
-      data.where.not("#{column} LIKE ?", "%#{value}%")
+      data.where.not("#{column}::text LIKE ?", "%#{value}%")
     end
 
     def value_to_boolean(value)


### PR DESCRIPTION
- PostgreSQL移行後、検索ができなくなった問題を修正した
- 原因
  - PostgreSQLでは"WHERE LIKE"をtext型のデータ検索にしか使えないため(SQLiteでは、"WHERE LIKE"でtext型もinteger型も検索できる)
  - 現在検索対象のカラムのうち、integer型であるbottle_levelとtokutei_meishoがエラーとなる
- 対策
  - 検索するときにカラムのデータをtext型にキャストする
- 備考
  - text型にキャストすることで検索速度の低下のおそれがある。
  - 将来的に全文検索に対応する。そのときに検索機能は一新する予定なので、現時点では検索速度を考慮しない。