### PR TITLE
Add: dbからseed.rbにデータをダンプするgemを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,3 +68,6 @@ gem "bcrypt"
 gem "config"
 gem "devise"
 gem "devise-i18n"
+
+# Create seed data files from the existing data in database
+gem "seed_dump"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -256,6 +256,9 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    seed_dump (3.3.1)
+      activerecord (>= 4)
+      activesupport (>= 4)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -325,6 +328,7 @@ DEPENDENCIES
   rubocop
   rubocop-rails
   sass-rails (>= 6)
+  seed_dump
   selenium-webdriver
   spring
   spring-watcher-listen (~> 2.0.0)


### PR DESCRIPTION
ソース： https://github.com/rroblak/seed_dump
本番環境でも開発環境でもデータをダンプしたくなるかもしれないので、どちらの環境で使えるようにしておいた

使用例: dbから酒のデータをダンプしてseed.rbに追記するコマンド
```
bundle exec rails db:seed:dump MODELS=Sake APPEND=true
```
