### PR TITLE
Tweetボタンを追加した

### DIFF
--- a/app/helpers/tweet_helper.rb
+++ b/app/helpers/tweet_helper.rb
@@ -7,24 +7,22 @@ module TweetHelper
           data: { text: tweet_text, hashtags: "Sakazuki", show_count: false }
   end
 
-  def add_postfix(text, postfix, period = "")
-    postfix.empty? ? text : "#{postfix}#{period}#{text}"
+  def add_period(text, period = t("helpers.tweet.punctuation"))
+    if text.empty? || text.end_with?(period) then text
+    else "#{text}#{period}" end
   end
 
-  # 酒の香りなどに「。」があったりなかったりする可能性があるため、
-  # PREFIXEにPERIODがない場合は自動で付加する。
-  def add_prefix(text, prefix, period = "")
-    if prefix.empty? then text
-    elsif prefix.end_with? period then "#{text}#{prefix}"
-    else "#{text}#{prefix}#{period}" end
+  def to_kakkokabu(text)
+    text.gsub("株式会社", "㈱").to_s
   end
 
   # 酒の名前のみがnon nilのため、他パラメータは空の場合を考慮する。
   def make_text(name, kura, color, aroma, taste)
-    text = "#{name}#{t('helpers.tweet.punctuation')}"
-    text = add_postfix(text, kura.gsub("株式会社", "㈱").to_s, t("helpers.tweet.honorific_title"))
-    text = add_prefix(text, color, t("helpers.tweet.punctuation"))
-    text = add_prefix(text, aroma, t("helpers.tweet.punctuation"))
-    add_prefix(text, taste, t("helpers.tweet.punctuation"))
+    kura = add_period(to_kakkokabu(kura), t("helpers.tweet.honorific_title"))
+    name = add_period(name)
+    color = add_period(color)
+    aroma = add_period(aroma)
+    taste = add_period(taste)
+    "#{kura}#{name}#{color}#{aroma}#{taste}"
   end
 end

--- a/app/helpers/tweet_helper.rb
+++ b/app/helpers/tweet_helper.rb
@@ -12,13 +12,21 @@ module TweetHelper
     else "#{text}#{period}" end
   end
 
-  def to_kakkokabu(text)
-    text.gsub("株式会社", "㈱").to_s
+  # 囲み文字
+  # https://0g0.org/
+  # 法人等略語一覧表
+  # https://hiramatu-hifuka.com/onyak/kotoba-1/hojin.html
+  def to_enclosed(text)
+    text = text.gsub("株式会社", "㈱")
+    text = text.gsub("有限会社", "㈲")
+    text = text.gsub("合名会社", "㈴")
+    text = text.gsub("合資会社", "㈾")
+    text.gsub("合同会社", "(同)")
   end
 
   # 酒の名前のみがnon nilのため、他パラメータは空の場合を考慮する。
   def make_text(name, kura, color, aroma, taste)
-    kura = add_period(to_kakkokabu(kura), t("helpers.tweet.honorific_title"))
+    kura = add_period(to_enclosed(kura), t("helpers.tweet.honorific_title"))
     name = add_period(name)
     color = add_period(color)
     aroma = add_period(aroma)

--- a/app/helpers/tweet_helper.rb
+++ b/app/helpers/tweet_helper.rb
@@ -1,0 +1,30 @@
+module TweetHelper
+  def tweet_button(tweet_text)
+    hashed_twitter = "https://twitter.com/intent/tweet?button_hashtag=Sakazuki&ref_src=twsrc%5Etfw"
+    tag.a "Tweet",
+          href: hashed_twitter,
+          class: "twitter-hashtag-button",
+          data: { text: tweet_text, show_count: false }
+  end
+
+  def add_postfix(text, postfix, period = "")
+    postfix.empty? ? text : "#{postfix}#{period}#{text}"
+  end
+
+  # 酒の香りなどに「。」があったりなかったりする可能性があるため、
+  # PREFIXEにPERIODがない場合は自動で付加する。
+  def add_prefix(text, prefix, period = "")
+    if prefix.empty? then text
+    elsif prefix.end_with? period then "#{text}#{prefix}"
+    else "#{text}#{prefix}#{period}" end
+  end
+
+  # 酒の名前のみがnon nilのため、他パラメータは空の場合を考慮する。
+  def make_text(name, kura, color, aroma, taste)
+    text = "#{name}#{t('helpers.tweet.punctuation')}"
+    text = add_postfix(text, kura.gsub("株式会社", "㈱").to_s, t("helpers.tweet.honorific_title"))
+    text = add_prefix(text, color, t("helpers.tweet.punctuation"))
+    text = add_prefix(text, aroma, t("helpers.tweet.punctuation"))
+    add_prefix(text, taste, t("helpers.tweet.punctuation"))
+  end
+end

--- a/app/helpers/tweet_helper.rb
+++ b/app/helpers/tweet_helper.rb
@@ -1,10 +1,10 @@
 module TweetHelper
   def tweet_button(tweet_text)
-    hashed_twitter = "https://twitter.com/intent/tweet?button_hashtag=Sakazuki&ref_src=twsrc%5Etfw"
+    share_twitter = "https://twitter.com/share?ref_src=twsrc%5Etfw"
     tag.a "Tweet",
-          href: hashed_twitter,
-          class: "twitter-hashtag-button",
-          data: { text: tweet_text, show_count: false }
+          href: share_twitter,
+          class: "twitter-share-button",
+          data: { text: tweet_text, hashtags: "Sakazuki", show_count: false }
   end
 
   def add_postfix(text, postfix, period = "")

--- a/app/views/sakes/show.html.erb
+++ b/app/views/sakes/show.html.erb
@@ -1,5 +1,9 @@
 <h2><%= t ".title" %></h2>
 
+<!-- ツイートボタン -->
+<%= tweet_button make_text(@sake.name, @sake.kura, @sake.color, @sake.aroma_impression, @sake.taste_impression) %>
+<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+
 <!-- 表示義務ありのラベル情報 -->
 <h3 class="my-2"><%= t "helpers.subtitle.labelinfo" %></h3>
 

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -18,6 +18,9 @@ ja:
     subtitle:
       labelinfo: ラベル
       tasteinfo: 味わい
+    tweet:
+      punctuation: 。
+      honorific_title: さんの
   sakes:
     index:
       title: 日本酒リスト


### PR DESCRIPTION
close #34

![image](https://user-images.githubusercontent.com/849256/102899006-adbfef00-44ad-11eb-8dc3-ccbcc8444405.png)

![image](https://user-images.githubusercontent.com/849256/102899048-b7e1ed80-44ad-11eb-921f-dfc690f423f7.png)


### やったこと

- 酒のshowにTweetボタンを追加した
    - Tweetボタンを押すツイッターの投稿画面に飛ぶ
    - Tweet内容には酒の名前、蔵の名前、色、香り、味が入る。
        - 末尾の「。」のありなしでいい感じに「。」を入れたり入れなかったりする。
    - Tweet内容には`#Sakazuki`のハッシュタグが入る
    - Twitterの仕様から、末尾にいらない#が入る

### やってないこと

- gemのtweet-buttonは使わなかった
    - tweet-buttonはLink Shareのみ対応しており、ハッシュタグShareに対応していない
    - tweet-buttonは使うと巨大な<html>を生成するため、かなり巨大なタグが生成される
- ja.ymlを使って記述しているが、日本語のみに対応している。
    - "萩野酒造さんの萩の鶴"と"Haginotsuru of Hagino Shuzo"のように、英語だと文章の順番が変わるため面倒。




