### PR TITLE
酒の画像サイズを大きく＆レスポンシブにする

### DIFF
--- a/app/javascript/src/stylesheet/application.scss
+++ b/app/javascript/src/stylesheet/application.scss
@@ -46,6 +46,10 @@
   @extend .col-12;
 }
 
+.show_image {
+  @extend .col-3;
+}
+
 // Ruby on Railsが生成するエラー用スタイルなので、アンダーバーのままにする
 .field_with_errors {
   display: contents;

--- a/app/javascript/src/stylesheet/application.scss
+++ b/app/javascript/src/stylesheet/application.scss
@@ -50,6 +50,11 @@
   @extend .col-3;
 }
 
+.thumb_image {
+  @extend .img-fluid;
+  max-height: 200px;
+}
+
 // Ruby on Railsが生成するエラー用スタイルなので、アンダーバーのままにする
 .field_with_errors {
   display: contents;

--- a/app/javascript/src/stylesheet/application.scss
+++ b/app/javascript/src/stylesheet/application.scss
@@ -50,11 +50,6 @@
   @extend .col-3;
 }
 
-.thumb_image {
-  @extend .img-fluid;
-  max-height: 200px;
-}
-
 // Ruby on Railsが生成するエラー用スタイルなので、アンダーバーのままにする
 .field_with_errors {
   display: contents;

--- a/app/javascript/src/stylesheet/application.scss
+++ b/app/javascript/src/stylesheet/application.scss
@@ -46,10 +46,6 @@
   @extend .col-12;
 }
 
-.show_image {
-  @extend .col-3;
-}
-
 // Ruby on Railsが生成するエラー用スタイルなので、アンダーバーのままにする
 .field_with_errors {
   display: contents;

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -6,10 +6,6 @@ class ImageUploader < CarrierWave::Uploader::Base
     storage :file
   end
 
-  version :thumb do
-    process resize_to_fit: [100, 100]
-  end
-
   def store_dir
     "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
   end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -7,7 +7,8 @@ class ImageUploader < CarrierWave::Uploader::Base
   end
 
   version :thumb do
-    process resize_to_fit: [100, 100]
+    # HACK: 1:1でスマホで２つ並んでも潰れないサイズ
+    process resize_to_fill: [600, 600]
   end
 
   def store_dir

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -6,6 +6,10 @@ class ImageUploader < CarrierWave::Uploader::Base
     storage :file
   end
 
+  version :thumb do
+    process resize_to_fit: [100, 100]
+  end
+
   def store_dir
     "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
   end

--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -48,7 +48,7 @@
         <% @sake.photos.each do |photo| %>
           <div class="form-check">
             <%= check_box_tag photo.chackbox_name, "delete", nil, { class: "form-check-input" } %>
-            <%= cl_image_tag(photo.image.thumb.url) %>
+            <%= cl_image_tag(photo.image.url, { class: "show_image" }) %>
           </div>
         <% end %>
       <% end %>

--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -48,7 +48,7 @@
         <% @sake.photos.each do |photo| %>
           <div class="form-check">
             <%= check_box_tag photo.chackbox_name, "delete", nil, { class: "form-check-input" } %>
-            <%= cl_image_tag(photo.image.url, { class: "show_image" }) %>
+            <%= cl_image_tag(photo.image.thumb.url) %>
           </div>
         <% end %>
       <% end %>

--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -44,17 +44,19 @@
     <%= form.label :photos, { class: "sakazuki-label" } %>
     <div class="col">
       <% if @sake.photos.any? %>
-        <%= t(".delete_photo") %>
+        <p id="photoHelp" class="form-text"><%= t(".delete_photo") %></p>
         <% @sake.photos.each do |photo| %>
-          <div class="form-check">
-            <%= check_box_tag photo.chackbox_name, "delete", nil, { class: "form-check-input" } %>
-            <%= cl_image_tag(photo.image.thumb.url) %>
+          <div class="form-check form-check-inline col-5">
+            <%# Hack: min-widthを設定することで、スマホ表示のときチェックボックスが小さくなりすぎるのを防ぐ %>
+            <%= check_box_tag photo.chackbox_name, "delete", nil, { class: "form-check-input", style: "min-width:32px" } %>
+            <label class="form-check-label" for="<%= photo.chackbox_name %>">
+              <%= cl_image_tag(photo.image.thumb.url, { class: "img-thumbnail" }) %>
+            </label>
           </div>
         <% end %>
       <% end %>
       <%= form.file_field :photos, { multiple: true, class: "form-control-file" } %>
     </div>
-
   </div>
 
   <div class="form-group row">

--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -43,19 +43,29 @@
   <div class="form-group row">
     <%= form.label :photos, { class: "sakazuki-label" } %>
     <div class="col">
-      <% if @sake.photos.any? %>
-        <p id="photoHelp" class="form-text"><%= t(".delete_photo") %></p>
-        <% @sake.photos.each do |photo| %>
-          <div class="form-check form-check-inline col-5">
-            <%# Hack: min-widthを設定することで、スマホ表示のときチェックボックスが小さくなりすぎるのを防ぐ %>
-            <%= check_box_tag photo.chackbox_name, "delete", nil, { class: "form-check-input", style: "min-width:32px" } %>
-            <label class="form-check-label" for="<%= photo.chackbox_name %>">
-              <%= cl_image_tag(photo.image.thumb.url, { class: "img-thumbnail" }) %>
-            </label>
-          </div>
+      <div class="row">
+        <% if @sake.photos.any? %>
+          <p id="photoHelp" class="form-text col-12">
+            <%= t(".delete_photo") %>
+          </p>
+          <% @sake.photos.each do |photo| %>
+            <div class="col-lg-4 col-6">
+              <div class="form-check form-check-inline">
+                <%# Hack: min-widthを設定することで、 %>
+                <%#       スマホ表示のときチェックボックスが小さくなりすぎるのを防ぐ %>
+                <%= check_box_tag(photo.chackbox_name,
+                                  "delete",
+                                  nil,
+                                  { class: "form-check-input", style: "min-width:32px" }) %>
+                <label class="form-check-label" for="<%= photo.chackbox_name %>">
+                  <%= cl_image_tag(photo.image.thumb.url, { class: "img-thumbnail" }) %>
+                </label>
+              </div>
+            </div>
+          <% end %>
         <% end %>
-      <% end %>
-      <%= form.file_field :photos, { multiple: true, class: "form-control-file" } %>
+        <%= form.file_field :photos, { multiple: true, class: "form-control-file col-12" } %>
+      </div>
     </div>
   </div>
 

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -45,7 +45,8 @@
           </canvas>
         </td>
         <td class="col-lg-3 col-md-6 col-11" style="text-align: center">
-        <%# Hack: 画像を置くセルの縦横比がだいたい2:1、画像自体の縦横比が1:1なので、画像の横幅を50%にすることで行が縦長になるのを防ぐ %>
+          <%# Hack: セルの縦横比が約2:1、サムネイル画像の縦横比が1:1である。 %>
+          <%#       そこで、セルの50%幅を指定することでセルが縦長になるのを防ぐ %>
           <%= if sake.photos.any?
                 cl_image_tag(sake.photos.first.image.thumb.url, { class: "img-fulid", style: "width: 50%" })
               end %>

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -44,8 +44,11 @@
                     data-aroma-value="<%= sake.aroma_value %>">
           </canvas>
         </td>
-        <td class="col-lg-3 col-md-6 col-11">
-          <%= cl_image_tag(sake.photos.first.image.thumb.url) if sake.photos.any? %>
+        <td class="col-lg-3 col-md-6 col-11" style="text-align: center">
+        <%# Hack: 画像を置くセルの縦横比がだいたい2:1、画像自体の縦横比が1:1なので、画像の横幅を50%にすることで行が縦長になるのを防ぐ %>
+          <%= if sake.photos.any?
+                cl_image_tag(sake.photos.first.image.thumb.url, { class: "img-fulid", style: "width: 50%" })
+              end %>
         </td>
       </tr>
     <% end %>

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -45,7 +45,7 @@
           </canvas>
         </td>
         <td class="col-lg-3 col-md-6 col-11">
-          <%= cl_image_tag(sake.photos.first.image.thumb.url) if sake.photos.any? %>
+          <%= cl_image_tag(sake.photos.first.image.url, { class: "thumb_image" }) if sake.photos.any? %>
         </td>
       </tr>
     <% end %>

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -45,7 +45,7 @@
           </canvas>
         </td>
         <td class="col-lg-3 col-md-6 col-11">
-          <%= cl_image_tag(sake.photos.first.image.url, { class: "thumb_image" }) if sake.photos.any? %>
+          <%= cl_image_tag(sake.photos.first.image.thumb.url) if sake.photos.any? %>
         </td>
       </tr>
     <% end %>

--- a/app/views/sakes/show.html.erb
+++ b/app/views/sakes/show.html.erb
@@ -33,9 +33,14 @@
     <b><%= Sake.human_attribute_name :photos %></b>
   </div>
   <div class="show-body">
-    <% @sake.photos.each do |photo| %>
-      <%= link_to cl_image_tag(photo.image.thumb.url), show_photo_path(photo_id: photo) %>
-    <% end %>
+    <div class="row">
+      <% @sake.photos.each do |photo| %>
+          <div class="col-lg-4 col-6">
+            <%= link_to cl_image_tag(photo.image.thumb.url, { class: "img-thumbnail" }),
+                        show_photo_path(photo_id: photo) %>
+            </div>
+      <% end %>
+    </div>
   </div>
 
   <div class="show-label">

--- a/app/views/sakes/show.html.erb
+++ b/app/views/sakes/show.html.erb
@@ -34,7 +34,7 @@
   </div>
   <div class="show-body">
     <% @sake.photos.each do |photo| %>
-      <%= link_to cl_image_tag(photo.image.url, { class: "show_image" }), show_photo_path(photo_id: photo) %>
+      <%= link_to cl_image_tag(photo.image.thumb.url), show_photo_path(photo_id: photo) %>
     <% end %>
   </div>
 

--- a/app/views/sakes/show.html.erb
+++ b/app/views/sakes/show.html.erb
@@ -34,7 +34,7 @@
   </div>
   <div class="show-body">
     <% @sake.photos.each do |photo| %>
-      <%= link_to cl_image_tag(photo.image.thumb.url), show_photo_path(photo_id: photo) %>
+      <%= link_to cl_image_tag(photo.image.url, { class: "show_image" }), show_photo_path(photo_id: photo) %>
     <% end %>
   </div>
 


### PR DESCRIPTION
### やったこと

- 酒の画像サイズをいままでより大きくした
- 酒の画像を閲覧端末に応じて適切なサイズで表示できるようにした。
 - IndexやShowビューに表示するサムネイル画像は縦横比1:1でトリミングして、並べた時に綺麗に整列するようにした
 
### できてないこと

- 画像アップロード時のサイズ制限or圧縮