### PR TITLE
酒一覧をより見やすくする機能強化

### DIFF
--- a/app/controllers/sakes_controller.rb
+++ b/app/controllers/sakes_controller.rb
@@ -5,7 +5,7 @@ class SakesController < ApplicationController
   # GET /sakes
   # GET /sakes.json
   def index
-    @sakes = Sake.all
+    @sakes = all_bottles(params[:all_bottles]).order(id: :desc)
   end
 
   # GET /sakes/1
@@ -70,6 +70,11 @@ class SakesController < ApplicationController
   end
 
   private
+
+  # flagがないときは、空瓶を除外したSakeモデルを取得して返す
+  def all_bottles(flag)
+    flag.blank? ? Sake.where.not(bottle_level: :empty) : Sake.all
+  end
 
   # Use callbacks to share common setup or constraints between actions.
   def set_sake

--- a/app/controllers/sakes_controller.rb
+++ b/app/controllers/sakes_controller.rb
@@ -2,10 +2,14 @@ class SakesController < ApplicationController
   before_action :set_sake, only: %i[show edit update destroy]
   before_action :signed_in_user, only: %i[new create edit update destroy]
 
+  include SakesHelper
+
   # GET /sakes
   # GET /sakes.json
   def index
-    @sakes = all_bottles(params[:all_bottles]).order(id: :desc)
+    sort_key = empty_to_default(params[:sort], "id").intern
+    sort_order = params[:order] == "asc" ? :asc : :desc
+    @sakes = all_bottles(params[:all_bottles]).order(sort_key => sort_order)
   end
 
   # GET /sakes/1

--- a/app/helpers/sakes_helper.rb
+++ b/app/helpers/sakes_helper.rb
@@ -1,6 +1,6 @@
 module SakesHelper
-  # HACK: 整数値と文字列値のどちらでも使えるようにnil/blankで判定している
-  def empty_to_default(value, default = "-")
+  def empty_to_default(value, default)
+    # HACK: IntegerとStringのどちらでも使えるようにnil/blankで判定している
     value.nil? || value.blank? ? default : value
   end
 end

--- a/app/models/search/base.rb
+++ b/app/models/search/base.rb
@@ -8,16 +8,6 @@ module Search
       data.where("#{column}::text LIKE ?", "%#{value}%")
     end
 
-    def exclude(data, column, value)
-      return data if data.count.zero?
-
-      data.where.not("#{column}::text LIKE ?", "%#{value}%")
-    end
-
-    def value_to_boolean(value)
-      ActiveRecord::Type::Boolean.new.cast(value)
-    end
-
     private
 
     def data_class(data)

--- a/app/models/search/sake.rb
+++ b/app/models/search/sake.rb
@@ -5,7 +5,6 @@ module Search
     def filter
       results = ::Sake.all
       results = word_filter(results) if word.present?
-      results = exclude(results, "bottle_level", "2") if only_in_stock?
       results
     end
 
@@ -16,10 +15,6 @@ module Search
       result2 = contain(data, "kura", word)
       result3 = contain(data, "tokutei_meisho", word)
       result1.or(result2).or(result3)
-    end
-
-    def only_in_stock?
-      value_to_boolean(only_in_stock)
     end
   end
 end

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -23,7 +23,7 @@
   </div>
 
   <div class="row justify-content-center">
-    <%= f.submit t(".change_my_password"), class: "btn btn-outline-primary" %>
+    <%= f.submit t(".change_my_password"), class: "btn btn-primary" %>
   </div>
 <% end %>
 

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -11,7 +11,7 @@
   </div>
 
   <div class="row justify-content-center">
-    <%= f.submit t(".send_me_reset_password_instructions"), class: "btn btn-outline-primary" %>
+    <%= f.submit t(".send_me_reset_password_instructions"), class: "btn btn-primary" %>
   </div>
 <% end %>
 

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -45,7 +45,7 @@
   </div>
 
   <div class="row justify-content-center">
-    <%= f.submit t(".update"), class: "btn btn-outline-primary mx-3" %>
+    <%= f.submit t(".update"), class: "btn btn-primary mx-3" %>
   </div>
 <% end %>
 
@@ -56,5 +56,5 @@
                 registration_path(resource_name),
                 data: { confirm: t(".are_you_sure") },
                 method: :delete,
-                class: "btn btn-outline-danger mx-3" %>
+                class: "btn btn-danger mx-3" %>
 </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -24,7 +24,7 @@
   <% end %>
 
   <div class="row justify-content-center">
-    <%= f.submit t(".sign_in"), class: "btn btn-outline-primary" %>
+    <%= f.submit t(".sign_in"), class: "btn btn-primary" %>
   </div>
 <% end %>
 

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -11,7 +11,7 @@
   </div>
 
   <div class="row justify-content-center">
-    <%= f.submit t(".resend_unlock_instructions"), class: "btn btn-outline-primary" %>
+    <%= f.submit t(".resend_unlock_instructions"), class: "btn btn-primary" %>
   </div>
 <% end %>
 

--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -322,7 +322,7 @@
   </div>
 
   <div class="row justify-content-center">
-    <%= form.submit nil, { class: "btn btn-outline-primary mx-3" } %>
+    <%= form.submit nil, { class: "btn btn-primary mx-3" } %>
   </div>
 
 <% end %>

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -1,12 +1,24 @@
 <h2><%= t(".title") %></h2>
 
-<%= form_with scope: :filter, url: filter_sakes_path, method: :get, local: true, class: "form-inline" do |f| %>
+<%= form_with scope: :filter, url: filter_sakes_path, method: :get, local: true, class: "form-inline my-1" do |f| %>
   <%= f.label "search", class: "sr-only" %>
-  <%= f.text_field :word, placeholder: "Search", class: "form-control mb-2 mr-sm-2" %>
-  <%= f.submit t("index.filter"), class: "btn btn-secondary mb-2" %>
+  <%= f.text_field :word, placeholder: "Search", class: "form-control mr-sm-2" %>
+  <%= f.submit t(".filter"), class: "btn btn-secondary" %>
 <% end %>
 
-<%= link_to(t("index.all_bottles"), sakes_path({all_bottles: "yes"}), { class: "btn btn-outline-secondary mb-2" }) %>
+<div>
+  <div class="btn-group my-1" role="group" aria-label="Sort">
+    <%= link_to(t("activerecord.attributes.sake.tokutei_meisho"),
+                sakes_path({ sort: "tokutei_meisho" }),
+                { class: "btn btn-info" }) %>
+    <%= link_to(t("activerecord.attributes.sake.todofuken"),
+                sakes_path({ sort: "todofuken" }),
+                { class: "btn btn-info" }) %>
+    <%= link_to(t("activerecord.attributes.sake.bottle_level"),
+                sakes_path({ sort: "bottle_level" }),
+                { class: "btn btn-info" }) %>
+  </div>
+</div>
 
 <table class="table table-hover table-bordered" caption="Sake List">
   <thead></thead>
@@ -51,7 +63,10 @@
 <div class="row justify-content-center">
   <%= link_to(t("helpers.submit.create"),
               new_sake_path,
-              { class: "btn btn-primary" }) %>
+              { class: "btn btn-primary mx-3" }) %>
+  <%= link_to(t(".all_bottles"),
+              sakes_path({ all_bottles: "yes" }),
+              { class: "btn btn-outline-secondary mx-3" }) %>
 </div>
 
 <%= javascript_pack_tag "sakes_index" %>

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -3,7 +3,7 @@
 <%= form_with scope: :filter, url: filter_sakes_path, method: :get, local: true, class: "form-inline" do |f| %>
   <%= f.label "search", class: "sr-only" %>
   <%= f.text_field :word, placeholder: "Search", class: "form-control mb-2 mr-sm-2" %>
-  <%= f.submit t("index.filter"), class: "btn btn-outline-secondary mb-2" %>
+  <%= f.submit t("index.filter"), class: "btn btn-secondary mb-2" %>
 <% end %>
 
 <table class="table table-hover table-bordered" caption="Sake List">
@@ -49,7 +49,7 @@
 <div class="row justify-content-center">
   <%= link_to(t("helpers.submit.create"),
               new_sake_path,
-              { class: "btn btn-outline-primary" }) %>
+              { class: "btn btn-primary" }) %>
 </div>
 
 <%= javascript_pack_tag "sakes_index" %>

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -6,6 +6,8 @@
   <%= f.submit t("index.filter"), class: "btn btn-secondary mb-2" %>
 <% end %>
 
+<%= link_to(t("index.all_bottles"), sakes_path({all_bottles: "yes"}), { class: "btn btn-outline-secondary mb-2" }) %>
+
 <table class="table table-hover table-bordered" caption="Sake List">
   <thead></thead>
   <tbody>

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -3,12 +3,6 @@
 <%= form_with scope: :filter, url: filter_sakes_path, method: :get, local: true, class: "form-inline" do |f| %>
   <%= f.label "search", class: "sr-only" %>
   <%= f.text_field :word, placeholder: "Search", class: "form-control mb-2 mr-sm-2" %>
-
-  <div class="form-check mb-2 mr-sm-2">
-    <%= f.check_box :only_in_stock, class: "form-check-input" %>
-    <%= f.label t("index.stocked"), class: "form-check-label" %>
-  </div>
-
   <%= f.submit t("index.filter"), class: "btn btn-outline-secondary mb-2" %>
 <% end %>
 

--- a/app/views/sakes/show.html.erb
+++ b/app/views/sakes/show.html.erb
@@ -240,12 +240,12 @@
 <div class="row justify-content-center">
   <%= link_to(t("helpers.submit.edit"),
               edit_sake_path(@sake),
-              { class: "btn btn-outline-primary mx-2" }) %>
+              { class: "btn btn-primary mx-2" }) %>
   <%= link_to(t("helpers.submit.delete"),
               @sake,
               method: :delete,
               data: { confirm: t("message.delete") },
-              class: "btn btn-outline-danger mx-2") %>
+              class: "btn btn-danger mx-2") %>
 </div>
 
 <%= javascript_pack_tag "sakes_show" %>

--- a/app/views/sakes/show.html.erb
+++ b/app/views/sakes/show.html.erb
@@ -19,14 +19,14 @@
     <b><%= Sake.human_attribute_name :kura %></b>
   </div>
   <div class="show-body">
-    <%= empty_to_default @sake.kura %>
+    <%= empty_to_default(@sake.kura, "-") %>
   </div>
 
   <div class="show-label">
     <b><%= Sake.human_attribute_name :todofuken %></b>
   </div>
   <div class="show-body">
-    <%= empty_to_default @sake.todofuken %>
+    <%= empty_to_default(@sake.todofuken, "-") %>
   </div>
 
   <div class="show-label">
@@ -49,7 +49,7 @@
     <b><%= Sake.human_attribute_name :seimai_buai %></b>
   </div>
   <div class="show-body">
-    <%= empty_to_default @sake.seimai_buai %> %
+    <%= empty_to_default(@sake.seimai_buai, "-") %> %
   </div>
 
   <div class="show-label">
@@ -70,14 +70,14 @@
     <b><%= Sake.human_attribute_name :size %></b>
   </div>
   <div class="show-body">
-    <%= empty_to_default @sake.size %> ml
+    <%= empty_to_default(@sake.size, "-") %> ml
   </div>
 
   <div class="show-label">
     <b><%= Sake.human_attribute_name :alcohol %></b>
   </div>
   <div class="show-body">
-    <%= empty_to_default @sake.alcohol %>
+    <%= empty_to_default(@sake.alcohol, "-") %>
   </div>
 
   <div class="show-label">
@@ -92,21 +92,21 @@
     <b><%= Sake.human_attribute_name :genryomai %></b>
   </div>
   <div class="show-body">
-    <%= empty_to_default @sake.genryomai %>
+    <%= empty_to_default(@sake.genryomai, "-") %>
   </div>
 
   <div class="show-label">
     <b><%= Sake.human_attribute_name :kakemai %></b>
   </div>
   <div class="show-body">
-    <%= empty_to_default @sake.kakemai %>
+    <%= empty_to_default(@sake.kakemai, "-") %>
   </div>
 
   <div class="show-label">
     <b><%= Sake.human_attribute_name :kobo %></b>
   </div>
   <div class="show-body">
-    <%= empty_to_default @sake.kobo %>
+    <%= empty_to_default(@sake.kobo, "-") %>
   </div>
 
   <div class="show-label">
@@ -120,14 +120,14 @@
     <b><%= Sake.human_attribute_name :roka %></b>
   </div>
   <div class="show-body">
-    <%= empty_to_default @sake.roka %>
+    <%= empty_to_default(@sake.roka, "-") %>
   </div>
 
   <div class="show-label">
     <b><%= Sake.human_attribute_name :shibori %></b>
   </div>
   <div class="show-body">
-    <%= empty_to_default @sake.shibori %>
+    <%= empty_to_default(@sake.shibori, "-") %>
   </div>
 
   <div class="show-label">
@@ -141,28 +141,28 @@
     <b><%= Sake.human_attribute_name :season %></b>
   </div>
   <div class="show-body">
-    <%= empty_to_default @sake.season %>
+    <%= empty_to_default(@sake.season, "-") %>
   </div>
 
   <div class="show-label">
     <b><%= Sake.human_attribute_name :nihonshudo %></b>
   </div>
   <div class="show-body">
-    <%= empty_to_default @sake.nihonshudo %>
+    <%= empty_to_default(@sake.nihonshudo, "-") %>
   </div>
 
   <div class="show-label">
     <b><%= Sake.human_attribute_name :sando %></b>
   </div>
   <div class="show-body">
-    <%= empty_to_default @sake.sando %>
+    <%= empty_to_default(@sake.sando, "-") %>
   </div>
 
   <div class="show-label">
     <b><%= Sake.human_attribute_name :aminosando %></b>
   </div>
   <div class="show-body">
-    <%= empty_to_default @sake.aminosando %>
+    <%= empty_to_default(@sake.aminosando, "-") %>
   </div>
 
   <div class="show-label">
@@ -188,14 +188,14 @@
     <b><%= Sake.human_attribute_name :color %></b>
   </div>
   <div class="show-body">
-    <%= empty_to_default @sake.color %>
+    <%= empty_to_default(@sake.color, "-") %>
   </div>
 
   <div class="show-label">
     <b><%= Sake.human_attribute_name :nigori %></b>
   </div>
   <div class="show-body">
-    <%= empty_to_default @sake.nigori %>
+    <%= empty_to_default(@sake.nigori, "-") %>
   </div>
 
   <div class="show-label">
@@ -212,30 +212,29 @@
     <b><%= Sake.human_attribute_name :aroma_impression %></b>
   </div>
   <div class="show-body">
-    <%= empty_to_default @sake.aroma_impression %>
+    <%= empty_to_default(@sake.aroma_impression, "-") %>
   </div>
 
   <div class="show-label">
     <b><%= Sake.human_attribute_name :taste_impression %></b>
   </div>
   <div class="show-body">
-    <%= empty_to_default @sake.taste_impression %>
+    <%= empty_to_default(@sake.taste_impression, "-") %>
   </div>
 
   <div class="show-label">
     <b><%= Sake.human_attribute_name :awa %></b>
   </div>
   <div class="show-body">
-    <%= empty_to_default @sake.awa %>
+    <%= empty_to_default(@sake.awa, "-") %>
   </div>
 
   <div class="show-label">
     <b><%= Sake.human_attribute_name :note %></b>
   </div>
   <div class="show-body">
-    <%= empty_to_default @sake.note %>
+    <%= empty_to_default(@sake.note, "-") %>
   </div>
-
 </div>
 
 <div class="row justify-content-center">
@@ -247,7 +246,6 @@
               method: :delete,
               data: { confirm: t("message.delete") },
               class: "btn btn-outline-danger mx-2") %>
-
 </div>
 
 <%= javascript_pack_tag "sakes_show" %>

--- a/app/views/sakes/show_photo.html.erb
+++ b/app/views/sakes/show_photo.html.erb
@@ -2,5 +2,5 @@
   <%= cl_image_tag @photo.image.url, { class: "img-fluid" } %>
 </div>
 <div class="row justify-content-center">
-  <%= link_to t("helpers.submit.back"), sake_path, class: "btn btn-outline-secondary mx-3" %>
+  <%= link_to t("helpers.submit.back"), sake_path, class: "btn btn-secondary mx-3" %>
 </div>

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -1,5 +1,6 @@
 ja:
   index:
+    all_bottles: 空瓶を表示
     filter: 検索
   message:
     delete: 本当に削除しますか？

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -1,6 +1,5 @@
 ja:
   index:
-    stocked: 在庫あり
     filter: 検索
   message:
     delete: 本当に削除しますか？

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -1,7 +1,4 @@
 ja:
-  index:
-    all_bottles: 空瓶を表示
-    filter: 検索
   message:
     delete: 本当に削除しますか？
   helpers:
@@ -23,6 +20,8 @@ ja:
   sakes:
     index:
       title: 日本酒リスト
+      filter: 検索
+      all_bottles: 空瓶を表示
     new:
       title: 新規登録
     edit:


### PR DESCRIPTION
Fix #80

### 行ったこと

- 空き瓶をデフォルトでは非表示にした
    - 古い機能の在庫表示は削除した
- 酒のデフォルト表示を新しい順にした
    - idによる降順でソートされる
- 酒のソート機能を追加した
    - 特定名称、都道府県、開封状態の昇順でソートできる

### まだできていないこと

- テーブルヘッダーで昇順降順の変更
    - 現状の酒一覧のテーブルがレスポンシブデザインかつ構造が複雑なテーブルになっている
    - そのためうまくテーブルにヘッダーがつけられない
- モデルへのインデックスの付加
    - 昇順降順を頻繁かつ大量のモデルに使うなら、モデルへインデックスを付加して高速化する必要がある
    - https://techracho.bpsinc.jp/hachi8833/2018_01_11/50793