### PR TITLE
Email認証

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ User.create!(
   email: "<your emacs address>",      # この2行を
   password: "your account password>", # 編集する
   admin: true,
+  confirmed_at: Time.current,
 )
 ```
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,9 @@
 #
 #  id                     :bigint           not null, primary key
 #  admin                  :boolean          default(FALSE)
+#  confirmation_sent_at   :datetime
+#  confirmation_token     :string
+#  confirmed_at           :datetime
 #  current_sign_in_at     :datetime
 #  current_sign_in_ip     :string
 #  email                  :string           default(""), not null
@@ -16,6 +19,7 @@
 #  reset_password_sent_at :datetime
 #  reset_password_token   :string
 #  sign_in_count          :integer          default(0), not null
+#  unconfirmed_email      :string
 #  unlock_token           :string
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
@@ -31,5 +35,5 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
-         :lockable, :timeoutable, :trackable
+         :lockable, :timeoutable, :trackable, :confirmable
 end

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,0 +1,24 @@
+<h2><%= t(".resend_confirmation_instructions") %></h2>
+
+<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+
+  <div class="row form-group">
+    <%= f.label :email, class: "sakazuki-label" %>
+      <div class="col">
+        <%= f.email_field(
+              :email,
+              autofocus: true,
+              autocomplete: "email",
+              class: "form-control",
+              value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email),
+            ) %>
+      </div>
+  </div>
+
+  <div class="row justify-content-center">
+    <%= f.submit t(".resend_confirmation_instructions"), class: "btn btn-primary" %>
+  </div>
+<% end %>
+
+<%= render "devise/shared/links" %>

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,23 +1,27 @@
 <h2><%= t(".resend_confirmation_instructions") %></h2>
 
-<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
+<%= form_for(resource,
+             as: resource_name,
+             url: confirmation_path(resource_name),
+             html: { method: :post }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="row form-group">
-    <%= f.label :email, class: "sakazuki-label" %>
+    <%= f.label(:email, { class: "sakazuki-label" }) %>
       <div class="col">
         <%= f.email_field(
               :email,
               autofocus: true,
               autocomplete: "email",
               class: "form-control",
-              value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email),
+              value:
+                (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email),
             ) %>
       </div>
   </div>
 
   <div class="row justify-content-center">
-    <%= f.submit t(".resend_confirmation_instructions"), class: "btn btn-primary" %>
+    <%= f.submit(t(".resend_confirmation_instructions"), { class: "btn btn-primary" }) %>
   </div>
 <% end %>
 

--- a/db/migrate/20210126072328_add_column_to_users.rb
+++ b/db/migrate/20210126072328_add_column_to_users.rb
@@ -1,0 +1,9 @@
+class AddColumnToUsers < ActiveRecord::Migration[6.0]
+  def change
+      ## Confirmable
+      add_column :users, :confirmation_token, :string
+      add_column :users, :confirmed_at, :datetime
+      add_column :users, :confirmation_sent_at, :datetime
+      add_column :users, :unconfirmed_email,:string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_31_112225) do
+ActiveRecord::Schema.define(version: 2021_01_26_072328) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -75,6 +75,10 @@ ActiveRecord::Schema.define(version: 2020_12_31_112225) do
     t.boolean "admin", default: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string "unconfirmed_email"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,4 +13,6 @@ User.create!(
   email: "example@example.com",
   password: "rootroot",
   admin: true,
+  # HACK: confirmed_atカラムに値が入っていれば、deviseが認証済みと判断する
+  confirmed_at: Time.current,
 )

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -4,6 +4,9 @@
 #
 #  id                     :bigint           not null, primary key
 #  admin                  :boolean          default(FALSE)
+#  confirmation_sent_at   :datetime
+#  confirmation_token     :string
+#  confirmed_at           :datetime
 #  current_sign_in_at     :datetime
 #  current_sign_in_ip     :string
 #  email                  :string           default(""), not null
@@ -16,6 +19,7 @@
 #  reset_password_sent_at :datetime
 #  reset_password_token   :string
 #  sign_in_count          :integer          default(0), not null
+#  unconfirmed_email      :string
 #  unlock_token           :string
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -4,6 +4,9 @@
 #
 #  id                     :bigint           not null, primary key
 #  admin                  :boolean          default(FALSE)
+#  confirmation_sent_at   :datetime
+#  confirmation_token     :string
+#  confirmed_at           :datetime
 #  current_sign_in_at     :datetime
 #  current_sign_in_ip     :string
 #  email                  :string           default(""), not null
@@ -16,6 +19,7 @@
 #  reset_password_sent_at :datetime
 #  reset_password_token   :string
 #  sign_in_count          :integer          default(0), not null
+#  unconfirmed_email      :string
 #  unlock_token           :string
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null


### PR DESCRIPTION
### やったこと

メールアドレスの認証機能をつけた
![image](https://user-images.githubusercontent.com/6294782/105815932-f57aee80-5ff6-11eb-8704-33f05ac2b249.png)
※devlopment環境では、メールは  http://localhost:3000/letter_opener で確認できます。

### 覚書

このプルリクをmasterに反映すると、 https://sakazuki.herokuapp.com/ にログインしようとしたとき１回だけ下記のメッセージが出る。
「アカウント確認のメールを受け取っていませんか？」をクリックし、アカウント確認メールを再送すること。
![image](https://user-images.githubusercontent.com/6294782/105816502-bb5e1c80-5ff7-11eb-9570-e8659d41e178.png)
