### PR TITLE
Ransackを使って空き瓶表示機能を作成した

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -11,10 +11,6 @@ linters:
     rubocop_config:
       inherit_from:
         - .rubocop.yml
-      # ERBでは120文字を採用する
-      Layout/LineLength:
-        Enabled: true
-        Max: 120
       # ERBでは<% %>が分離するため誤検知が多い
       # 以下、公式おすすめのオフ設定を持ってきた
       Layout/InitialIndentation:

--- a/app/controllers/sakes_controller.rb
+++ b/app/controllers/sakes_controller.rb
@@ -12,7 +12,7 @@ class SakesController < ApplicationController
     params[:q] = {} unless params[:q]
 
     # default, not empty bottle
-    params[:q].merge!({ bottle_level_not_eq: 2 }) unless params.dig(:q, :bottle_level_not_eq)
+    params[:q].merge!({ bottle_level_not_eq: Sake.bottle_levels["empty"] }) unless params.dig(:q, :bottle_level_not_eq)
 
     # default, sort by id
     params[:q].merge!({ s: "id desc" }) unless params.dig(:q, :s)

--- a/app/controllers/sakes_controller.rb
+++ b/app/controllers/sakes_controller.rb
@@ -8,13 +8,10 @@ class SakesController < ApplicationController
   # GET /sakes
   # GET /sakes.json
   def index
-    # default sort
-    @sakes = all_bottles(params[:all_bottles]).order({ id: :desc })
-
     # search
     query = params[:q].deep_dup
     to_multi_search!(query) if exist_search?(query)
-    @searched = @sakes.ransack(query)
+    @searched = Sake.ransack(query)
     @sakes = @searched.result(distinct: true)
   end
 
@@ -84,11 +81,6 @@ class SakesController < ApplicationController
   end
 
   private
-
-  # flagがないときは、空瓶を除外したSakeモデルを取得して返す
-  def all_bottles(flag)
-    flag.blank? ? Sake.where.not(bottle_level: :empty) : Sake.all
-  end
 
   # query[search_query]が存在すればtrueを返す。
   # queryがnil、または、query[search_query]がnilならばfalseを返す。

--- a/app/controllers/sakes_controller.rb
+++ b/app/controllers/sakes_controller.rb
@@ -19,7 +19,7 @@ class SakesController < ApplicationController
 
     # search
     query = params[:q].deep_dup
-    to_multi_search!(query) if query[search_query]
+    to_multi_search!(query) if query[:all_text_cont]
     @searched = Sake.ransack(query)
     @sakes = @searched.result(distinct: true)
   end
@@ -93,14 +93,14 @@ class SakesController < ApplicationController
   private
 
   def to_multi_search!(query)
-    words = query.delete(search_query)
+    words = query.delete(:all_text_cont)
     query[:groupings] = separate_words(words)
   end
 
   def separate_words(words)
     # 全角空白または半角空白で区切ることを許可
     # { :name_cont => "" }があり得るがransackがSQL変換で削除するのでOK
-    words.split(/[ 　]/).map { |word| { search_query => word } }
+    words.split(/[ 　]/).map { |word| { all_text_cont: word } }
   end
 
   # DBの蔵名に（県名）をつけて_formの描画でつかう形にする

--- a/app/helpers/sakes_helper.rb
+++ b/app/helpers/sakes_helper.rb
@@ -12,4 +12,9 @@ module SakesHelper
     # BYは年のみ、使わない月日はBY始まりの7/1とする
     Date.new(by_year, 7)
   end
+
+  # どの瓶状態（bottle_level）にもマッチしない値
+  def bottom_bottle
+    -1
+  end
 end

--- a/app/helpers/sakes_helper.rb
+++ b/app/helpers/sakes_helper.rb
@@ -1,10 +1,4 @@
 module SakesHelper
-  def search_query
-    # rubocop:disable Layout/LineLength
-    :aroma_impression_or_awa_or_color_or_genryomai_or_kakemai_or_kobo_or_kura_or_name_or_nigori_or_note_or_roka_or_season_or_shibori_or_taste_impression_or_todofuken_cont
-    # rubocop:enable Layout/LineLength
-  end
-
   def empty_to_default(value, default)
     value.presence || default
   end

--- a/app/models/sake.rb
+++ b/app/models/sake.rb
@@ -116,4 +116,8 @@ class Sake < ApplicationRecord
   validates :hiire, presence: true
   validates :price, numericality: { allow_nil: true }
   validates :size, numericality: true
+
+  # rubocop:disable Layout/LineLength
+  ransack_alias :all_text, :aroma_impression_or_awa_or_color_or_genryomai_or_kakemai_or_kobo_or_kura_or_name_or_nigori_or_note_or_roka_or_season_or_shibori_or_taste_impression_or_todofuken
+  # rubocop:enable Layout/LineLength
 end

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -73,9 +73,6 @@
   <%= link_to(t("helpers.submit.create"),
               new_sake_path,
               { class: "btn btn-primary mx-3" }) %>
-  <%= link_to(t(".all_bottles"),
-              sakes_path({ all_bottles: "yes" }),
-              { class: "btn btn-outline-secondary mx-3" }) %>
 </div>
 
 <%= javascript_pack_tag "sakes_index" %>

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -3,9 +3,9 @@
 <div class="row my-1">
   <div class="col">
     <%= search_form_for(@searched, { class: "form-inline" }) do |f| %>
-      <%= f.search_field(search_query,
+      <%= f.search_field(:all_text_cont,
                          { class: "form-control mr-sm-2",
-                           value: params.dig(:q, search_query) }) %>
+                           value: params.dig(:q, :all_text_cont) }) %>
 
       <div class="custom-control custom-switch ml-sm-2 mr-2">
         <%= f.check_box(:bottle_level_not_eq,

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -10,7 +10,9 @@
       <div class="custom-control custom-switch ml-sm-2 mr-2">
         <%= f.check_box(:bottle_level_not_eq,
                         { class: "custom-control-input",
-                          id: "all_bottle_level" }, "-1", Sake.bottle_levels["empty"]) %>
+                          id: "all_bottle_level" },
+                        bottom_bottle,
+                        Sake.bottle_levels["empty"]) %>
         <%= f.label(t(".all_bottles"),
                     { class: "custom-control-label",
                       for: "all_bottle_level" }) %>

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -6,9 +6,20 @@
       <%= f.search_field(search_query,
                          { class: "form-control mr-sm-2",
                            value: params.dig(:q, search_query) }) %>
-      <%= f.submit({ class: "btn btn-secondary" }) %>
+
+      <div class="custom-control custom-switch ml-sm-2 mr-2">
+        <%= f.check_box(:bottle_level_not_eq,
+                        { class: "custom-control-input",
+                          id: "all_bottle_level" }, "-1", "2") %>
+        <%= f.label(t(".all_bottles"),
+                    { class: "custom-control-label",
+                      for: "all_bottle_level" }) %>
+      </div>
+
+      <%= f.submit({ class: "btn btn-secondary mx-2" }) %>
     <% end %>
   </div>
+
   <div class="col-md-6 col-12">
     <div class="btn-group float-md-right" role="group" aria-label="Sort">
       <%= sort_link(@searched,

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -10,7 +10,7 @@
       <div class="custom-control custom-switch ml-sm-2 mr-2">
         <%= f.check_box(:bottle_level_not_eq,
                         { class: "custom-control-input",
-                          id: "all_bottle_level" }, "-1", "2") %>
+                          id: "all_bottle_level" }, "-1", Sake.bottle_levels["empty"]) %>
         <%= f.label(t(".all_bottles"),
                     { class: "custom-control-label",
                       for: "all_bottle_level" }) %>

--- a/config/initializers/ransack.rb
+++ b/config/initializers/ransack.rb
@@ -1,0 +1,5 @@
+Ransack.configure do |c|
+  # Raise errors if a query contains an unknown predicate or attribute.
+  # Default is true (do not raise error on unknown conditions).
+  c.ignore_unknown_conditions = false
+end


### PR DESCRIPTION
### 使い方

- 空き瓶にチェックを入れる
- 検索すると、空き瓶も表示される
    - 空き瓶は普段使わないので、「チェックを入れる」→「検索する」、の2段階でアクセスさせる形式にした
- その後、検索や空き瓶表示の状態を引き継いでソートもできる

### やったこと

- 古い空き瓶リンクを削除
- Ransackでデフォルトのidソートと空き瓶表示機能を実現
- Ransackのリファクタ
    - 検索クエリにわかりやすい別名をつけた
    - Ransackの検索クエリに間違いがあると実行時エラーになるようにした
- 必要なかったERBLintの設定を消した