### PR TITLE
開発用Dockerイメージをコンパクトに仕上げた

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,0 @@
-.git
-
-node_modules
-public/packs

--- a/README.md
+++ b/README.md
@@ -93,18 +93,9 @@ cloudinary:
   - `heroku config:set RAILS_MASTER_KEY=`cat config/credentials/production.key`
     - ※production.keyファイルはメーラとCloudinaryの設定をしたときに作られる。
 
-## How to build Docker image
+## How to develop with Docker
 
 レポジトリをDocker Bindするため、レポジトリをWSLファイルシステムに置くと動きません。
-
-- ローカルな環境変数の設定ファイル（.env）を作成
-
-```shell
-# .env
-POSTGRES_USERNAME=postgres
-POSTGRES_PASSWORD=password
-POSTGRES_HOSTNAME=db
-```
 
 - Dockerイメージのビルド
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ cloudinary:
 
 ## How to build Docker image
 
+レポジトリをDocker Bindするため、レポジトリをWSLファイルシステムに置くと動きません。
+
 - ローカルな環境変数の設定ファイル（.env）を作成
 
 ```shell
@@ -128,6 +130,8 @@ $ docker-compose run --rm web bundle exec rails db:seed
 $ docker-compose up
 ...
 ```
+
+- Gem/Node Packageの更新があった場合は、`docker-compose build`でイメージを更新する
 
 ## How to Contribute
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,22 +4,24 @@ volumes:
     driver: local
 services:
   db:
-    env_file:
-      - .env
     image: postgres:13
     volumes:
       - db_storage:/var/lib/postgresql/data
     environment:
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_PASSWORD: password
     ports:
       - "5432:5432"
-    hostname: ${POSTGRES_HOSTNAME}
+    hostname: db
   web:
     volumes:
       - .:/sakazuki:cached
       - /sakazuki/node_modules
       - /sakazuki/log
       - /sakazuki/tmp
+    environment:
+      POSTGRES_USERNAME: postgres
+      POSTGRES_PASSWORD: password
+      POSTGRES_HOSTNAME: db
     env_file:
       - .env
     build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,12 @@
 version: "3.9"
 volumes:
   db_storage:
-    driver:
-      local
+    driver: local
 services:
   db:
     env_file:
       - .env
-    image: postgres:11
+    image: postgres:13
     volumes:
       - db_storage:/var/lib/postgresql/data
     environment:
@@ -16,6 +15,11 @@ services:
       - "5432:5432"
     hostname: ${POSTGRES_HOSTNAME}
   web:
+    volumes:
+      - .:/sakazuki:cached
+      - /sakazuki/node_modules
+      - /sakazuki/log
+      - /sakazuki/tmp
     env_file:
       - .env
     build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - "5432:5432"
     hostname: db
   web:
+    image: sakazuki
     volumes:
       - .:/sakazuki:cached
       - /sakazuki/node_modules


### PR DESCRIPTION
### やったこと

- slimイメージを使い開発用Dockerイメージをコンパクトにした
- 中途半端なDockerイメージを、Macでの開発用に仕上げた
    - おそらくMacでの開発に使えるはず

### メモ

- https://evilmartians.com/chronicles/ruby-on-whales-docker-for-ruby-rails-development
- https://iriya-ufo.net/blog/2019/08/14/rails-dev-env-on-docker/
