### PR TITLE
アイコンを導入した

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem "jbuilder", "~> 2.7"
 
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", ">= 1.4.2", require: false
+
 # Use pg as the database for Active Record
 gem "pg"
 
@@ -48,6 +49,9 @@ gem "ransack"
 
 # Pagination
 gem "kaminari"
+
+# Bootstrap icons
+gem "bootstrap-icons-helper"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,11 @@ GEM
       debug_inspector (>= 0.0.1)
     bootsnap (1.7.1)
       msgpack (~> 1.0)
+    bootstrap-icons (1.0.7)
+      nokogiri (~> 1.6)
+    bootstrap-icons-helper (1.0.7)
+      bootstrap-icons (~> 1.0)
+      rails (~> 6.0)
     builder (3.2.4)
     byebug (11.1.3)
     capybara (3.35.3)
@@ -361,6 +366,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   bootsnap (>= 1.4.2)
+  bootstrap-icons-helper
   byebug
   capybara (>= 2.15)
   carrierwave

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,3 @@
 //= link_tree ../images
 //= link_directory ../stylesheets .css
+//= link_directory ../../../node_modules/bootstrap-icons .svg

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,10 +3,4 @@ module ApplicationHelper
     display_meta_tags(twitter: { card: "summary" },
                       og: { title: "Sakazuki" })
   end
-
-  def bi_icon(icon, options = {})
-    path = asset_path("bootstrap-icons/bootstrap-icons.svg")
-    options = { class: "bi", fill: "currentColor" }.merge(options) { |_, default, added| "#{default} #{added}" }
-    tag.svg(tag.use(nil, "xlink:href" => "#{path}##{icon}"), options)
-  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,4 +3,10 @@ module ApplicationHelper
     display_meta_tags(twitter: { card: "summary" },
                       og: { title: "Sakazuki" })
   end
+
+  def bi_icon(icon, options = {})
+    path = asset_path("bootstrap-icons/bootstrap-icons.svg")
+    options = { class: "bi", fill: "currentColor" }.merge(options) { |_, default, added| "#{default} #{added}" }
+    tag.svg(tag.use(nil, "xlink:href" => "#{path}##{icon}"), options)
+  end
 end

--- a/app/views/sakes/_sake-buttons.html.erb
+++ b/app/views/sakes/_sake-buttons.html.erb
@@ -1,0 +1,13 @@
+<div class="row fixed-bottom mr-2 mb-4">
+  <div class="col text-right">
+    <% if params["action"] == "show" %>
+      <%= link_to(bi_icon("pencil-square", { width: "2em", height: "2em" }),
+                  edit_sake_path(@sake),
+                  { class: "btn btn-info" }) %>
+    <% end %>
+
+    <%= link_to(bi_icon("plus-square", { width: "2em", height: "2em" }),
+                new_sake_path,
+                { class: "btn btn-primary" }) %>
+  </div>
+</div>

--- a/app/views/sakes/_sake-buttons.html.erb
+++ b/app/views/sakes/_sake-buttons.html.erb
@@ -3,11 +3,11 @@
     <% if params["action"] == "show" %>
       <%= link_to(bootstrap_icon("pencil-square", { width: "2em", height: "2em" }),
                   edit_sake_path(@sake),
-                  { class: "btn btn-info" }) %>
+                  { class: "btn btn-info mx-1" }) %>
     <% end %>
 
     <%= link_to(bootstrap_icon("plus-square", { width: "2em", height: "2em" }),
                 new_sake_path,
-                { class: "btn btn-primary" }) %>
+                { class: "btn btn-primary ml-1" }) %>
   </div>
 </div>

--- a/app/views/sakes/_sake-buttons.html.erb
+++ b/app/views/sakes/_sake-buttons.html.erb
@@ -1,12 +1,12 @@
 <div class="row fixed-bottom mr-2 mb-4">
   <div class="col text-right">
     <% if params["action"] == "show" %>
-      <%= link_to(bi_icon("pencil-square", { width: "2em", height: "2em" }),
+      <%= link_to(bootstrap_icon("pencil-square", { width: "2em", height: "2em" }),
                   edit_sake_path(@sake),
                   { class: "btn btn-info" }) %>
     <% end %>
 
-    <%= link_to(bi_icon("plus-square", { width: "2em", height: "2em" }),
+    <%= link_to(bootstrap_icon("plus-square", { width: "2em", height: "2em" }),
                 new_sake_path,
                 { class: "btn btn-primary" }) %>
   </div>

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -1,5 +1,7 @@
 <h2><%= t(".title") %></h2>
 
+<%= render "sake-buttons" %>
+
 <div class="row my-1">
   <div class="col">
     <%= search_form_for(@searched, { class: "form-inline" }) do |f| %>
@@ -81,12 +83,7 @@
     <% end %>
   </tbody>
 </table>
-<%= paginate(@sakes) %>
 
-<div class="row justify-content-center">
-  <%= link_to(t("helpers.submit.create"),
-              new_sake_path,
-              { class: "btn btn-primary mx-3" }) %>
-</div>
+<%= paginate(@sakes) %>
 
 <%= javascript_pack_tag "sakes_index" %>

--- a/app/views/sakes/show.html.erb
+++ b/app/views/sakes/show.html.erb
@@ -1,5 +1,7 @@
 <h2><%= t ".title" %></h2>
 
+<%= render "sake-buttons" %>
+
 <!-- ツイートボタン -->
 <%= tweet_button make_text(@sake.name, @sake.kura, @sake.color, @sake.aroma_impression, @sake.taste_impression) %>
 <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
@@ -243,9 +245,6 @@
 </div>
 
 <div class="row justify-content-center">
-  <%= link_to(t("helpers.submit.edit"),
-              edit_sake_path(@sake),
-              { class: "btn btn-primary mx-3" }) %>
   <%= link_to(t("helpers.submit.delete"),
               @sake,
               method: :delete,

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -4,8 +4,6 @@ ja:
   helpers:
     submit:
       create: 登録
-      update: 更新
-      edit: 編集
       delete: 削除
       back: 戻る
     badge:

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@rails/webpacker": "^4.3.0",
     "@types/chart.js": "^2.9.30",
     "bootstrap": "^4.6.0",
+    "bootstrap-icons": "^1.3.0",
     "chart.js": "^2.9.4",
     "jquery": "^3.5.1",
     "popper.js": "^1.16.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1976,6 +1976,11 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
+bootstrap-icons@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/bootstrap-icons/-/bootstrap-icons-1.3.0.tgz#fb9d704622fcb30a0329695d5033d97171947d04"
+  integrity sha512-w6zQ93p626zmPDqDtET7VdB9EkoDtfmCBV53hunjntoCke6X5LafXf6TxPAP+ImjRAhhxAyA/sjzQnHBY0uoiQ==
+
 bootstrap@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.6.0.tgz#97b9f29ac98f98dfa43bf7468262d84392552fd7"


### PR DESCRIPTION
今後、文字をどんどんなくしていきたい

close #120 

### やったこと

- Node Packageのbootstrap-iconsを導入した
     - bootstrapと統一感がありよい
     - 最大手のfontawsomeはAPI利用回数制限がついたため、OSSへの導入へ向いていない
     - iconを呼び出しやすいヘルパーを作成した
         - gemはまだないようだった
- アイコンを使って、ページ右下に固定で「登録」「更新」ボタンを配置した
    - 丸ボタンはbootstrap5から使えるらしいので、現状は四角ボタンにした
        - https://bootstrap-guide.com/components/buttons