### PR TITLE
Dockerfileが複数存在するときにgithub actionsでチェックできるようにした

### DIFF
--- a/cli-scripts/run-all-checks.sh
+++ b/cli-scripts/run-all-checks.sh
@@ -42,15 +42,17 @@ bundle exec erblint --lint-all
 # docker
 
 message "##### Run Hadolint"
-files=$(git ls-files | grep 'Dockerfile')
 if type hadolint > /dev/null 2>&1; then
-    hadolint_command='hadolint'
+    HADOLINT="hadolint"
 elif type docker > /dev/null 2>&1; then
-    hadolint_command='docker run --rm -i hadolint/hadolint <'
+    HADOLINT="docker run --rm -i hadolint/hadolint <"
+fi
+
+if [ -n "${HADOLINT}" ]; then
+    files=$(git ls-files | grep "Dockerfile")
+    for file in ${files}; do
+        eval "${HADOLINT} ${file}"
+    done
 else
     warning "[SKIP] hadolint is not installed."
 fi
-
-for file in ${files}; do
-    eval "${hadolint_command} ${file}"
-done

--- a/cli-scripts/run-all-checks.sh
+++ b/cli-scripts/run-all-checks.sh
@@ -42,10 +42,15 @@ bundle exec erblint --lint-all
 # docker
 
 message "##### Run Hadolint"
+files=$(git ls-files | grep 'Dockerfile')
 if type hadolint > /dev/null 2>&1; then
-    hadolint Dockerfile
+    hadolint_command='hadolint'
 elif type docker > /dev/null 2>&1; then
-    docker run --rm -i hadolint/hadolint < Dockerfile
+    hadolint_command='docker run --rm -i hadolint/hadolint <'
 else
     warning "[SKIP] hadolint is not installed."
 fi
+
+for file in ${files}; do
+    eval "${hadolint_command} ${file}"
+done


### PR DESCRIPTION
### 背景

ElasticSearch導入にあたり、Dockerfileが複数になる予定である。
現状のDockerfileのチェックは、プロジェクトのトップディレクトリにDockerfileが一つだけ存在する前提でチェックをしている。このため、Dockerfileが複数になったときにチェックを行えない。

### やったこと

下記のいずれの場合でも、Dockerfileをgithub actionsでチェックできるようにした

- Dockerfileが一つの場合
- Dockerfileが拡張子違い（dev.Dockerfile など）で複数存在する場合
- 異なるディレクトリにDockerfileが複数存在する場合