### PR TITLE
Elasticsearchその1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,11 @@ gem "kaminari"
 # Bootstrap icons
 gem "bootstrap-icons-helper"
 
+# ElasticSearch
+gem "bonsai-elasticsearch-rails"
+gem "elasticsearch-model"
+gem "elasticsearch-rails"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger
   # console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,9 @@ GEM
     bindex (0.8.1)
     binding_of_caller (1.0.0)
       debug_inspector (>= 0.0.1)
+    bonsai-elasticsearch-rails (7.0.1)
+      elasticsearch-model (< 8)
+      elasticsearch-rails (< 8)
     bootsnap (1.7.1)
       msgpack (~> 1.0)
     bootstrap-icons (1.0.7)
@@ -132,6 +135,19 @@ GEM
     dotenv-rails (2.7.6)
       dotenv (= 2.7.6)
       railties (>= 3.2)
+    elasticsearch (7.10.1)
+      elasticsearch-api (= 7.10.1)
+      elasticsearch-transport (= 7.10.1)
+    elasticsearch-api (7.10.1)
+      multi_json
+    elasticsearch-model (7.1.1)
+      activesupport (> 3)
+      elasticsearch (> 1)
+      hashie
+    elasticsearch-rails (7.1.1)
+    elasticsearch-transport (7.10.1)
+      faraday (~> 1)
+      multi_json
     enum_help (0.0.17)
       activesupport (>= 3.0.0)
     erb_lint (0.0.37)
@@ -148,9 +164,15 @@ GEM
     factory_bot_rails (6.1.0)
       factory_bot (~> 6.1.0)
       railties (>= 5.0.0)
+    faraday (1.3.0)
+      faraday-net_http (~> 1.0)
+      multipart-post (>= 1.2, < 3)
+      ruby2_keywords
+    faraday-net_http (1.0.1)
     ffi (1.14.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    hashie (4.1.0)
     html_tokenizer (0.0.7)
     http-accept (1.7.0)
     http-cookie (1.0.3)
@@ -204,6 +226,8 @@ GEM
     mini_portile2 (2.5.0)
     minitest (5.14.3)
     msgpack (1.4.2)
+    multi_json (1.15.0)
+    multipart-post (2.1.1)
     netrc (0.11.0)
     nio4r (2.5.4)
     nokogiri (1.11.1)
@@ -320,6 +344,7 @@ GEM
     ruby-progressbar (1.11.0)
     ruby-vips (2.0.17)
       ffi (~> 1.9)
+    ruby2_keywords (0.0.4)
     rubyzip (2.3.0)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -400,6 +425,7 @@ DEPENDENCIES
   bcrypt
   better_errors
   binding_of_caller
+  bonsai-elasticsearch-rails
   bootsnap (>= 1.4.2)
   bootstrap-icons-helper
   byebug
@@ -409,6 +435,8 @@ DEPENDENCIES
   devise
   devise-i18n
   dotenv-rails
+  elasticsearch-model
+  elasticsearch-rails
   enum_help
   erb_lint
   factory_bot_rails

--- a/README.md
+++ b/README.md
@@ -121,12 +121,21 @@ $ docker-compose run --rm web bundle exec rails db:migrate
 $ docker-compose run --rm web bundle exec rails db:seed
 ...
 $ docker-compose run --rm es elasticsearch-plugin install analysis-icu
-...
+Creating sakazuki_es_run ... done
+-> Installing analysis-icu
+-> Downloading analysis-icu from elastic
+[=================================================] 100%??
+-> Installed analysis-icu
 $ docker-compose run --rm es elasticsearch-plugin install analysis-kuromoji
-...
+Creating sakazuki_es_run ... done
+-> Installing analysis-kuromoji
+-> Downloading analysis-kuromoji from elastic
+[=================================================] 100%??
+-> Installed analysis-kuromoji
 $ docker-compose run --rm web bundle exec rake environment \
   elasticsearch:import:model CLASS='Sake' FORCE=y
-...
+Creating sakazuki_web_run ... done
+[IMPORT] Done
 ```
 
 - Dockerイメージの起動

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@
 - Yarn🐈 >= 1.22.4
 - Node.js >= 12.20.1
 - PostgreSQL >= 12.0
+- ElasticSearch >= 7.10.2
+  - Japanese (kuromoji) Analysis Plugin
+  - ICU Analysis Plugin
 
 ## How to use
 
@@ -108,7 +111,7 @@ $ docker-compose build
 ...
 ```
 
-- PostgreSQLコンテナの初期設定
+- PostgreSQLコンテナ、ElasticSearchコンテナの初期設定
 
 ```console
 $ docker-compose run --rm web bundle exec rails db:create
@@ -116,6 +119,13 @@ $ docker-compose run --rm web bundle exec rails db:create
 $ docker-compose run --rm web bundle exec rails db:migrate
 ...
 $ docker-compose run --rm web bundle exec rails db:seed
+...
+$ docker-compose run --rm es elasticsearch-plugin install analysis-icu
+...
+$ docker-compose run --rm es elasticsearch-plugin install analysis-kuromoji
+...
+$ docker-compose run --rm web bundle exec rake environment \
+  elasticsearch:import:model CLASS='Sake' FORCE=y
 ...
 ```
 

--- a/app/controllers/sakes_controller.rb
+++ b/app/controllers/sakes_controller.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics/ClassLength
 class SakesController < ApplicationController
   before_action :set_sake, only: %i[show edit update destroy]
   before_action :signed_in_user, only: %i[new create edit update destroy]
@@ -90,6 +91,14 @@ class SakesController < ApplicationController
     end
   end
 
+  # GET /sakes/elasticsearch
+  def elasticsearch
+    @sakes = Sake.simple_search(params.dig(:elasticsearch, :word)).records
+    # HACK: indexビュー表示にエラーが出ないようにするため、ransack用のインスタンス変数をセット
+    @searched = Sake.ransack(nil)
+    render :index
+  end
+
   private
 
   def to_multi_search!(query)
@@ -148,3 +157,4 @@ class SakesController < ApplicationController
     end
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -1,0 +1,67 @@
+module Searchable
+  extend ActiveSupport::Concern
+
+  # rubocop:disable Metrics/BlockLength
+  included do
+    include Elasticsearch::Model
+    include Elasticsearch::Model::Callbacks
+
+    index_name [Rails.application.engine_name, Rails.env].join("_")
+    sake_settings = YAML.load_file(Rails.root.join("config/elasticsearch.yml"))
+
+    settings sake_settings do
+      mapping do
+        indexes :aroma_impression, analyzer: "ja"
+        indexes :awa, analyzer: "ja"
+        indexes :color, analyzer: "ja"
+        indexes :genryomai, analyzer: "ja"
+        indexes :kakemai, analyzer: "ja"
+        indexes :kobo, analyzer: "ja"
+        indexes :kura, analyzer: "ja"
+        indexes :name, analyzer: "ja"
+        indexes :nigori, analyzer: "ja"
+        indexes :note, analyzer: "ja"
+        indexes :roka, analyzer: "ja"
+        indexes :season, analyzer: "ja"
+        indexes :shibori, analyzer: "ja"
+        indexes :taste_impression, analyzer: "ja"
+        indexes :todofuken, analyzer: "ja"
+      end
+    end
+
+    # rubocop:disable Metrics/MethodLength
+    def as_indexed_json(_options = {})
+      {
+        aroma_impression: aroma_impression,
+        awa: awa,
+        color: color,
+        genryomai: genryomai,
+        kakemai: kakemai,
+        kobo: kobo,
+        kura: kura,
+        name: name,
+        nigori: nigori,
+        note: note,
+        roka: roka,
+        season: season,
+        shibori: shibori,
+        taste_impression: taste_impression,
+        todofuken: todofuken,
+      }.as_json
+    end
+    # rubocop:enable Metrics/MethodLength
+
+    def self.simple_search(keyword)
+      __elasticsearch__.search(
+        query: {
+          multi_match: {
+            query: keyword,
+            fields: ["*"],
+            operator: "and",
+          },
+        },
+      )
+    end
+  end
+  # rubocop:enable Metrics/BlockLength
+end

--- a/app/models/sake.rb
+++ b/app/models/sake.rb
@@ -37,6 +37,9 @@
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
 #
+
+require "elasticsearch/model"
+
 class Sake < ApplicationRecord
   has_many :photos, dependent: :destroy
   enum bottle_level: {
@@ -120,4 +123,5 @@ class Sake < ApplicationRecord
   # rubocop:disable Layout/LineLength
   ransack_alias :all_text, :aroma_impression_or_awa_or_color_or_genryomai_or_kakemai_or_kobo_or_kura_or_name_or_nigori_or_note_or_roka_or_season_or_shibori_or_taste_impression_or_todofuken
   # rubocop:enable Layout/LineLength
+  include Searchable
 end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -4,6 +4,18 @@
     <div class="container-fluid-with-maxwidth">
       <%= link_to "Sakazuki", root_path, class: "navbar-brand" %>
 
+      <%= form_with({ scope: :elasticsearch,
+                      url: elasticsearch_sakes_path,
+                      method: :get,
+                      local: true,
+                      class: "form-inline my-1" }) do |f| %>
+        <%= f.label "search", class: "sr-only" %>
+        <%= f.text_field(:word,
+                         { placeholder: "Search",
+                           value: params.dig(:elasticsearch, :word),
+                           class: "form-control mr-sm-2" }) %>
+        <%= f.submit("Elastic Search", { class: "btn btn-secondary" }) %>
+      <% end %>
       <% if user_signed_in? %>
         <button class="navbar-toggler" type="button" data-toggle="collapse"
                 data-target="#navbarNav" aria-controls="navbarNav"

--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -1,0 +1,41 @@
+index:
+  analysis:
+    filter:
+      katakana_stemmer:
+        type: kuromoji_stemmer
+        minimum_length: 4
+      kana_converter:
+        type: icu_transform
+        id: Hiragana-Katakana
+      custom_synonym:
+        type: synonym
+        synonyms:
+          - 純米吟醸,純吟
+          - 大吟醸,大吟
+          - 純米大吟醸,純米大吟
+    tokenizer:
+      ja_tokenizer:
+        type: kuromoji_tokenizer
+        mode: search
+        user_dictionary_rules:
+          - 大吟醸,大吟醸,ダイギンジョウ,カスタム名詞
+          - 純米吟醸,純米吟醸,ジュンマイギンジョウ,カスタム名詞
+          - 純米大吟醸,純米大吟醸,ジュンマイダイギンジョウ,カスタム名詞
+          - 特別本醸造,特別本醸造,トクベツホンジョウゾウ,カスタム名詞
+          - 特別純米,特別純米,トクベツジュンマイ,カスタム名詞
+    analyzer:
+      # 今回使うanalyzer
+      ja:
+        type: custom
+        # kuromojiでトークナイズ(単語分割)
+        tokenizer: ja_tokenizer
+        # 文字単位のフィルター。トークナイズ前に適用される。
+        char_filter:
+          - icu_normalizer
+          - kuromoji_iteration_mark
+        # トークン単位のフィルター。トークナイズ後に実行される。
+        filter:
+          - katakana_stemmer # コンピューター -> コンピュータ 変換
+          - kuromoji_part_of_speech # 助詞等を除外
+          - kana_converter # ひらがな -> カタカナ 変換
+          - custom_synonym

--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -1,0 +1,5 @@
+config = {
+  host: ENV["ELASTICSEARCH_HOST"] || "localhost",
+  port: ENV["ELASTICSEARCH_PORT"] || "9200",
+}
+Elasticsearch::Model.client = Elasticsearch::Client.new(config)

--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -1,5 +1,5 @@
 config = {
-  host: ENV["ELASTICSEARCH_HOST"] || "localhost",
+  host: ENV["ELASTICSEARCH_HOSTNAME"] || "localhost",
   port: ENV["ELASTICSEARCH_PORT"] || "9200",
 }
 Elasticsearch::Model.client = Elasticsearch::Client.new(config)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   }
   root "sakes#index"
   resources :sakes do
-    get :filter, on: :collection
+    get :elasticsearch, on: :collection
   end
   get "sakes/:id/show_photo" => "sakes#show_photo", as: "show_photo"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,10 @@ version: "3.9"
 volumes:
   db_storage:
     driver: local
+  es_data:
+    driver: local
+  es_plugins:
+    driver: local
 services:
   db:
     image: postgres:13
@@ -23,11 +27,36 @@ services:
       POSTGRES_USERNAME: postgres
       POSTGRES_PASSWORD: password
       POSTGRES_HOSTNAME: db
-    env_file:
-      - .env
+      ELASTICSEARCH_HOST: es
+      ELASTICSEARCH_PORT: 9200
     build: .
     command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
     ports:
       - "3000:3000"
     depends_on:
       - db
+      - es
+  es:
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2
+    environment:
+      - discovery.type=single-node
+      - cluster.name=es-docker-cluster
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - es_data:/usr/share/elasticsearch/data
+      - es_plugins:/usr/share/elasticsearch/plugins
+    ports:
+      - 9200:9200
+  kibana:
+    image: docker.elastic.co/kibana/kibana-oss:7.10.2
+    ports:
+      - 5601:5601
+    environment:
+      - ELASTICSEARCH_HOSTS=http://es:9200
+    depends_on:
+      - es

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,10 +39,10 @@ services:
   es:
     image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2
     environment:
-      - discovery.type=single-node
-      - cluster.name=es-docker-cluster
-      - bootstrap.memory_lock=true
-      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      discovery.type: single-node
+      cluster.name: es-docker-cluster
+      bootstrap.memory_lock: "true"
+      ES_JAVA_OPTS: "-Xms512m -Xmx512m"
     ulimits:
       memlock:
         soft: -1
@@ -51,12 +51,12 @@ services:
       - es_data:/usr/share/elasticsearch/data
       - es_plugins:/usr/share/elasticsearch/plugins
     ports:
-      - 9200:9200
+      - "9200:9200"
   kibana:
     image: docker.elastic.co/kibana/kibana-oss:7.10.2
     ports:
-      - 5601:5601
+      - "5601:5601"
     environment:
-      - ELASTICSEARCH_HOSTS=http://es:9200
+      ELASTICSEARCH_HOSTS: http://es:9200
     depends_on:
       - es

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       POSTGRES_USERNAME: postgres
       POSTGRES_PASSWORD: password
       POSTGRES_HOSTNAME: db
-      ELASTICSEARCH_HOST: es
+      ELASTICSEARCH_HOSTNAME: es
       ELASTICSEARCH_PORT: 9200
     build: .
     command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"

--- a/dotenv.example
+++ b/dotenv.example
@@ -8,3 +8,9 @@ POSTGRES_HOSTNAME=localhost
 # User name and password to access PostgreSQL.
 POSTGRES_USERNAME=
 POSTGRES_PASSWORD=
+
+# Hostname of Elasticsearch. default is 'localhost'.
+ELASTICSEARCH_HOSTNAME=localhost
+
+# Port of Elasticsearch. default is '9200'.
+ELASTICSEARCH_PORT=9200

--- a/dotenv.example
+++ b/dotenv.example
@@ -9,6 +9,8 @@ POSTGRES_HOSTNAME=localhost
 POSTGRES_USERNAME=
 POSTGRES_PASSWORD=
 
+# Configurations of Elasticsearch.
+
 # Hostname of Elasticsearch. default is 'localhost'.
 ELASTICSEARCH_HOSTNAME=localhost
 

--- a/lib/tasks/elasticsearch.rake
+++ b/lib/tasks/elasticsearch.rake
@@ -1,0 +1,1 @@
+require "elasticsearch/rails/tasks/import"


### PR DESCRIPTION
### やったこと

- ElasticSearchでstring型とtext型のフィールドを対象に、日本語による全文検索をできるようにした
  - ElasticSearch用の検索BOXはheaderに仮置き
- DockerでElasticSearchを動かせるようにした 

### 今後やること

- enumのフィールド（特定名称や加水など）も文字列検索できるようにする
- DBの更新があったときにElasticSearchにデータを送る処理を非同期で行えるようにする
- ElasticSearchを実行し、検索結果を表示する専用のビューをつくる
- ElasticSearch用の検索BOXをどこか適切な場所に配置する（悩み中）
- 検索結果をハイライトする

### 非Docker環境での使い方

####  1. elasticsearchとプラグインの入手
  - elasticsearch
    - <https://www.elastic.co/jp/downloads/elasticsearch>
  - 日本語解析用のプラグイン
    - <https://www.elastic.co/guide/en/elasticsearch/plugins/current/analysis-kuromoji.html>
    - <https://www.elastic.co/guide/en/elasticsearch/plugins/current/analysis-icu.html>
 
#### 2. elasticsearchの起動
 ```sh
$ elasticsearch
```

#### 3. elasticsearchの起動確認のため、他のターミナルから下記コマンド実行
```sh
$ curl http://localhost:9200/
...
```
#### 4. ElasticSearchのインデックス作成

```sh
$ bundle exec rake environment elasticsearch:import:model CLASS='Sake' FORCE=y
...
```
