### PR TITLE
Elasticsearch導入その2

### DIFF
--- a/app/controllers/elasticsearch_controller.rb
+++ b/app/controllers/elasticsearch_controller.rb
@@ -1,0 +1,7 @@
+class ElasticsearchController < ApplicationController
+  def index
+    @sakes = Sake.simple_search(params.dig(:elasticsearch, :word))
+                 .page(params[:page])
+                 .results
+  end
+end

--- a/app/controllers/sakes_controller.rb
+++ b/app/controllers/sakes_controller.rb
@@ -89,14 +89,6 @@ class SakesController < ApplicationController
     end
   end
 
-  # GET /sakes/elasticsearch
-  def elasticsearch
-    @sakes = Sake.simple_search(params.dig(:elasticsearch, :word)).records
-    # HACK: indexビュー表示にエラーが出ないようにするため、ransack用のインスタンス変数をセット
-    @searched = Sake.ransack(nil)
-    render :index
-  end
-
   private
 
   def to_multi_search!(query)

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -51,17 +51,25 @@ module Searchable
     end
     # rubocop:enable Metrics/MethodLength
 
+    # rubocop:disable Metrics/MethodLength
     def self.simple_search(keyword)
-      __elasticsearch__.search(
-        query: {
-          multi_match: {
-            query: keyword,
-            fields: ["*"],
-            operator: "and",
+      if keyword.blank?
+        __elasticsearch__.search(
+          query: { match_all: {} },
+        )
+      else
+        __elasticsearch__.search(
+          query: {
+            multi_match: {
+              query: keyword,
+              fields: ["*"],
+              operator: "and",
+            },
           },
-        },
-      )
+        )
+      end
     end
+    # rubocop:enable Metrics/MethodLength
   end
   # rubocop:enable Metrics/BlockLength
 end

--- a/app/views/elasticsearch/index.html.erb
+++ b/app/views/elasticsearch/index.html.erb
@@ -23,18 +23,18 @@
   </div>
   <div class="row mb-2">
     <div class="col-12">
-      <%= sake.season %>
-      <%= sake.shibori %>
-      <%= sake.awa %>
-      <%= sake.color %>
-      <%= "#{Sake.human_attribute_name :genryomai}: #{sake.genryomai}" if sake.genryomai.present? %>
-      <%= "#{Sake.human_attribute_name :kakemai}: #{sake.kakemai}" if sake.kakemai.present? %>
-      <%= sake.kobo %>
-      <%= sake.nigori %>
-      <%= sake.roka %>
-      <%= sake.aroma_impression %>
-      <%= sake.taste_impression %>
-      <%= sake.note %>
+      <span><%= sake.season %></span>
+      <span><%= sake.shibori %></span>
+      <span><%= sake.awa %></span>
+      <span><%= sake.color %></span>
+      <span><%= sake.genryomai %></span>
+      <span><%= sake.kakemai %></span>
+      <span><%= sake.kobo %></span>
+      <span><%= sake.nigori %></span>
+      <span><%= sake.roka %></span>
+      <span><%= sake.aroma_impression %></span>
+      <span><%= sake.taste_impression %></span>
+      <span><%= sake.note %></span>
     </div>
   </div>
 <% end %>

--- a/app/views/elasticsearch/index.html.erb
+++ b/app/views/elasticsearch/index.html.erb
@@ -1,0 +1,42 @@
+<h2><%= link_to(t("views.elasticsearch.title"), elasticsearch_path, { class: "text-dark" }) %></h2>
+
+<%= form_with({ scope: :elasticsearch,
+                url: elasticsearch_path,
+                method: :get,
+                local: true,
+                class: "form-inline my-1" }) do |f| %>
+  <%= f.label "search", class: "sr-only" %>
+  <%= f.text_field(:word,
+                   { placeholder: "Keyword",
+                     value: params.dig(:elasticsearch, :word),
+                     class: "form-control mr-sm-2" }) %>
+  <%= button_tag(type: :submit, class: "btn btn-secondary") do %>
+    <%= bootstrap_icon("search") %>
+  <% end %>
+<% end %>
+
+<% @sakes.each do |sake| %>
+  <div class="row">
+    <div class="col-12">
+      <%= link_to("#{sake.name} #{sake.todofuken} #{sake.kura}", sake_path(sake.id)) %>
+    </div>
+  </div>
+  <div class="row mb-2">
+    <div class="col-12">
+      <%= sake.season %>
+      <%= sake.shibori %>
+      <%= sake.awa %>
+      <%= sake.color %>
+      <%= sake.genryomai %>
+      <%= sake.kakemai %>
+      <%= sake.kobo %>
+      <%= sake.nigori %>
+      <%= sake.roka %>
+      <%= sake.aroma_impression %>
+      <%= sake.taste_impression %>
+      <%= sake.note %>
+    </div>
+  </div>
+<% end %>
+
+<%= paginate(@sakes) %>

--- a/app/views/elasticsearch/index.html.erb
+++ b/app/views/elasticsearch/index.html.erb
@@ -27,8 +27,8 @@
       <%= sake.shibori %>
       <%= sake.awa %>
       <%= sake.color %>
-      <%= sake.genryomai %>
-      <%= sake.kakemai %>
+      <%= "#{Sake.human_attribute_name :genryomai}: #{sake.genryomai}" if sake.genryomai.present? %>
+      <%= "#{Sake.human_attribute_name :kakemai}: #{sake.kakemai}" if sake.kakemai.present? %>
       <%= sake.kobo %>
       <%= sake.nigori %>
       <%= sake.roka %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -4,18 +4,6 @@
     <div class="container-fluid-with-maxwidth">
       <%= link_to "Sakazuki", root_path, class: "navbar-brand" %>
 
-      <%= form_with({ scope: :elasticsearch,
-                      url: elasticsearch_sakes_path,
-                      method: :get,
-                      local: true,
-                      class: "form-inline my-1" }) do |f| %>
-        <%= f.label "search", class: "sr-only" %>
-        <%= f.text_field(:word,
-                         { placeholder: "Search",
-                           value: params.dig(:elasticsearch, :word),
-                           class: "form-control mr-sm-2" }) %>
-        <%= f.submit("Elastic Search", { class: "btn btn-secondary" }) %>
-      <% end %>
       <% if user_signed_in? %>
         <button class="navbar-toggler" type="button" data-toggle="collapse"
                 data-target="#navbarNav" aria-controls="navbarNav"

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,6 +1,6 @@
 <header>
   <!-- HACK: 画面サイズがlg以上のときだけのnavbarのタイトルがずれる対策にpx-lg-0をいれる -->
-  <nav class="navbar navbar-expand-lg navbar-dark bg-dark px-lg-0">
+  <nav class="navbar navbar-dark bg-dark px-lg-0">
     <div class="container-fluid-with-maxwidth">
       <%= link_to "Sakazuki", root_path, class: "navbar-brand" %>
       <button class="navbar-toggler" type="button" data-toggle="collapse"
@@ -8,7 +8,8 @@
               aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
-      <div class="collapse navbar-collapse d-lg-flex justify-content-end" id="navbarNav">
+
+      <div class="collapse navbar-collapse" id="navbarNav">
         <div class="navbar-nav">
           <% if user_signed_in? %>
             <%= link_to current_user.email, edit_user_registration_path, class: "nav-item nav-link" %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -3,21 +3,22 @@
   <nav class="navbar navbar-dark bg-dark px-lg-0">
     <div class="container-fluid-with-maxwidth">
       <%= link_to "Sakazuki", root_path, class: "navbar-brand" %>
+
       <button class="navbar-toggler" type="button" data-toggle="collapse"
               data-target="#navbarNav" aria-controls="navbarNav"
               aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
-
       <div class="collapse navbar-collapse" id="navbarNav">
         <div class="navbar-nav">
+          <%= link_to "Elasticsearch", elasticsearch_path, class: "nav-item nav-link" %>
+          <span class="border-bottom border-secondary"></span>
           <% if user_signed_in? %>
             <%= link_to current_user.email, edit_user_registration_path, class: "nav-item nav-link" %>
             <%= link_to "Sign out", destroy_user_session_path, method: :delete, class: "nav-item nav-link" %>
           <% else %>
             <%= link_to "Sign in", new_user_session_path, class: "nav-item nav-link" %>
           <% end %>
-          <%= link_to "Elasticsearch", elasticsearch_path, class: "nav-item nav-link" %>
         </div>
       </div>
     </div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -3,24 +3,21 @@
   <nav class="navbar navbar-expand-lg navbar-dark bg-dark px-lg-0">
     <div class="container-fluid-with-maxwidth">
       <%= link_to "Sakazuki", root_path, class: "navbar-brand" %>
-
-      <% if user_signed_in? %>
-        <button class="navbar-toggler" type="button" data-toggle="collapse"
-                data-target="#navbarNav" aria-controls="navbarNav"
-                aria-expanded="false" aria-label="Toggle navigation">
+      <button class="navbar-toggler" type="button" data-toggle="collapse"
+              data-target="#navbarNav" aria-controls="navbarNav"
+              aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
-        </button>
-        <div class="collapse navbar-collapse d-lg-flex justify-content-end" id="navbarNav">
-          <div class="navbar-nav">
+      </button>
+      <div class="collapse navbar-collapse d-lg-flex justify-content-end" id="navbarNav">
+        <div class="navbar-nav">
+          <% if user_signed_in? %>
             <%= link_to current_user.email, edit_user_registration_path, class: "nav-item nav-link" %>
             <%= link_to "Sign out", destroy_user_session_path, method: :delete, class: "nav-item nav-link" %>
-          </div>
+          <% else %>
+            <%= link_to "Sign in", new_user_session_path, class: "nav-item nav-link" %>
+          <% end %>
         </div>
-      <% else %>
-        <div class="navbar-nav">
-          <%= link_to "Sign in", new_user_session_path, class: "nav-item nav-link" %>
-        </div>
-      <% end %>
+      </div>
     </div>
   </nav>
 </header>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -17,6 +17,7 @@
           <% else %>
             <%= link_to "Sign in", new_user_session_path, class: "nav-item nav-link" %>
           <% end %>
+          <%= link_to "Elasticsearch", elasticsearch_path, class: "nav-item nav-link" %>
         </div>
       </div>
     </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -4,3 +4,5 @@ ja:
       previous: "< 前へ"
       next: "次へ >"
       truncate: "..."
+    elasticsearch:
+      title: "Elastic Search"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
     get :elasticsearch, on: :collection
   end
   get "sakes/:id/show_photo" => "sakes#show_photo", as: "show_photo"
+  get "/elasticsearch" => "elasticsearch#index", as: "elasticsearch"
 
   mount LetterOpenerWeb::Engine, at: "/letter_opener" unless Rails.env.production?
 end


### PR DESCRIPTION
#150 のつづき

### やったこと

- ElasticSearchを実行し、検索結果を表示する専用のページをつくった(<http://localhost:3000/elasticsearch>)
- 画面サイズやサインイン状態によらず、ヘッダーに常時ハンバーガーメニューを表示するようにした
- ElasticSearch用の検索BOXをヘッダーのハンバーガーメニューに入れた

### 今後やること

enumのフィールド（特定名称や加水など）も文字列検索できるようにする
DBの更新があったときにElasticSearchにデータを送る処理を非同期で行えるようにする
検索結果のハイライト表示
テストの追加