### PR TITLE
アップロードするファイルを選ぶとき、画像ファイル以外は選べないようにした

### DIFF
--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -58,7 +58,9 @@
             </div>
           <% end %>
         <% end %>
-        <%= form.file_field :photos, { multiple: true, class: "form-control-file col-12" } %>
+        <%= form.file_field :photos, { multiple: true,
+                                       class: "form-control-file col-12",
+                                       accept: "image/*" } %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
### やったこと

- アップロードするファイルを選ぶとき、画像ファイル以外は選べないようにした。

画像ファイル以外が選べない様子↓
![image](https://user-images.githubusercontent.com/6294782/108813559-9eb40500-75f4-11eb-85dc-9b6b44aea8cf.png)

### やってないこと

- _form.html.erbで括弧が省略されている箇所の修正
  - 変更が混ざるのが嫌なのでプルリク分けます