### PR TITLE
酒作成でログインしたときインデクスに戻されないようにした

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,16 +10,24 @@ class ApplicationController < ActionController::Base
     redirect_to(new_user_session_path)
   end
 
-  # 以下の場合にユーザーが居たパスを保存する
+  # サインイン時にユーザーが元いたパスへ戻れるようにするため、
+  # deviseのstore_location_forを使ってユーザーが居たパスを保存する
+  def store_location
+    if storable_location?
+      store_location_for(:user, request.fullpath)
+    end
+  end
+
+  private
+
+  # 下記すべての条件を満たすとき、ユーザーが居たパスを保存してよいと判定する。
   # - リクエストがGETメソッドである。
   # - Ajaxリクエストではない。
   # - ユーザー認証ページへのパスではない。
   #   （リダイレクトループが発生するのを避けるため）
-  def store_location
-    if request.get? &&
-       !request.xhr? &&
-       !request.path.match?("\/users\/.*")
-      store_location_for(:user, request.fullpath)
-    end
+  # 参考: https://github.com/heartcombo/devise/wiki/How-To:-Redirect-back-to-current-page-after-sign-in,-sign-out,-sign-up,-update
+  # @return [Boolean] ユーザーが居たパスを保存していいときにtrueを返す。
+  def storable_location?
+    request.get? && !request.xhr? && !request.path.match?("\/users\/.*")
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,8 +1,25 @@
 class ApplicationController < ActionController::Base
+  after_action :store_location
+
   def signed_in_user
     return if user_signed_in?
 
+    # 未ログインユーザーが酒作成・編集しようとしたときにパスを保存する
+    store_location
     flash[:danger] = "Please sign in."
     redirect_to(new_user_session_path)
+  end
+
+  # 以下の場合にユーザーが居たパスを保存する
+  # - リクエストがGETメソッドである。
+  # - Ajaxリクエストではない。
+  # - ユーザー認証ページへのパスではない。
+  #   （リダイレクトループが発生するのを避けるため）
+  def store_location
+    if request.get? &&
+       !request.xhr? &&
+       !request.path.match?("\/users\/.*")
+      store_location_for(:user, request.fullpath)
+    end
   end
 end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -18,7 +18,7 @@
         </div>
       <% else %>
         <div class="navbar-nav">
-          <%= link_to "Sign in", new_user_session_path, class: "nav-item nav-link" %>
+          <%= link_to "Sign in", new_user_session_path, class: "nav-item nav-link", "data-testid": "sign-in" %>
         </div>
       <% end %>
     </div>

--- a/app/views/sakes/_sake-buttons.html.erb
+++ b/app/views/sakes/_sake-buttons.html.erb
@@ -3,11 +3,13 @@
     <% if params["action"] == "show" %>
       <%= link_to(bootstrap_icon("pencil-square", { width: "2em", height: "2em" }),
                   edit_sake_path(@sake),
-                  { class: "btn btn-info mx-1 click-nontransparent" }) %>
+                  { class: "btn btn-info mx-1 click-nontransparent",
+                    "data-testid": "edit-#{@sake.id}", }) %>
     <% end %>
 
     <%= link_to(bootstrap_icon("plus-square", { width: "2em", height: "2em" }),
                 new_sake_path,
-                { class: "btn btn-primary ml-1 click-nontransparent" }) %>
+                { class: "btn btn-primary ml-1 click-nontransparent",
+                  "data-testid": "new-sake", }) %>
   </div>
 </div>

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -65,5 +65,5 @@ RSpec.configure do |config|
   # Devise helper for integration tests
   config.include(Devise::Test::IntegrationHelpers, type: :request)
   config.include(Devise::Test::IntegrationHelpers, type: :system)
-  config.include(SignInModule)
+  config.include(SignInModule, type: :system)
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -65,4 +65,5 @@ RSpec.configure do |config|
   # Devise helper for integration tests
   config.include(Devise::Test::IntegrationHelpers, type: :request)
   config.include(Devise::Test::IntegrationHelpers, type: :system)
+  config.include(SignInModule)
 end

--- a/spec/support/sign_in_module.rb
+++ b/spec/support/sign_in_module.rb
@@ -1,0 +1,14 @@
+module SignInModule
+  # ヘッダーのSign inボタンをクリックし、サインインする
+  def sign_in_via_header_button(user)
+    find(:test_id, "sign-in").click
+    fill_sign_column(user)
+  end
+
+  # Sign inページにてemail、passwordを入力し、サインインする
+  def fill_sign_column(user)
+    fill_in("user_email", with: user.email)
+    fill_in("user_password", with: user.password)
+    click_button("commit")
+  end
+end

--- a/spec/support/sign_in_module.rb
+++ b/spec/support/sign_in_module.rb
@@ -2,11 +2,16 @@ module SignInModule
   # ヘッダーのSign inボタンをクリックし、サインインする
   def sign_in_via_header_button(user)
     find(:test_id, "sign-in").click
-    fill_sign_column(user)
+    signin_process_on_signin_page(user)
   end
 
-  # Sign inページにてemail、passwordを入力し、サインインする
-  def fill_sign_column(user)
+  # email、passwordを入力し、サインインボタンをクリックする
+  # @raise [RuntimeError] 現在のページがSign inページではない場合
+  def signin_process_on_signin_page(user)
+    if current_path != new_user_session_path
+      raise
+    end
+
     fill_in("user_email", with: user.email)
     fill_in("user_password", with: user.password)
     click_button("commit")

--- a/spec/system/sign_in_redirect_spec.rb
+++ b/spec/system/sign_in_redirect_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 
 RSpec.describe "Sign-in redirect", type: :system do
-  let!(:sakes) { FactoryBot.create_list(:sake, 3) }
+  let(:sakes) { FactoryBot.create_list(:sake, 3) }
   let(:id) { sakes[0].id }
-  let!(:user) { FactoryBot.create(:user) }
+  let(:user) { FactoryBot.create(:user) }
 
   before do
     driven_by(:rack_test)

--- a/spec/system/sign_in_redirect_spec.rb
+++ b/spec/system/sign_in_redirect_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe "Sign-in redirect", type: :system do
       sign_in_via_header_button(user)
     end
 
-    it "redirects user to root url (does not occur redirection loop)" do
+    it "redirects to root url (does not occur redirection loop)" do
       expect(page).to have_current_path root_path
     end
   end

--- a/spec/system/sign_in_redirect_spec.rb
+++ b/spec/system/sign_in_redirect_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Sign-in redirect", type: :system do
     end
 
     it "redirect to edit_sake_path after user sign-in" do
-      fill_sign_column(user)
+      signin_process_on_signin_page(user)
       expect(page).to have_current_path edit_sake_path(id)
     end
   end
@@ -37,7 +37,7 @@ RSpec.describe "Sign-in redirect", type: :system do
     end
 
     it "redirects user to new_sake_path after user sign-in" do
-      fill_sign_column(user)
+      signin_process_on_signin_page(user)
       expect(page).to have_current_path new_sake_path
     end
   end

--- a/spec/system/sign_in_redirect_spec.rb
+++ b/spec/system/sign_in_redirect_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+RSpec.describe "Sign-in redirect", type: :system do
+  let!(:sakes) { FactoryBot.create_list(:sake, 3) }
+  let(:id) { sakes[0].id }
+  let!(:user) { FactoryBot.create(:user) }
+
+  before do
+    driven_by(:rack_test)
+    sign_out(user)
+  end
+
+  context "when non-signed-in user tries to edit-sake" do
+    before do
+      visit sake_path(id)
+      find(:test_id, "edit-#{id}").click
+    end
+
+    it "redirects user to new_user_session_path" do
+      expect(page).to have_current_path new_user_session_path
+    end
+
+    it "redirect to edit_sake_path after user sign-in" do
+      fill_sign_column(user)
+      expect(page).to have_current_path edit_sake_path(id)
+    end
+  end
+
+  context "when non-signed-in user tries to new-sake" do
+    before do
+      visit sakes_path
+      find(:test_id, "new-sake").click
+    end
+
+    it "redirects user to new_user_session_path" do
+      expect(page).to have_current_path new_user_session_path
+    end
+
+    it "redirects user to new_sake_path after user sign-in" do
+      fill_sign_column(user)
+      expect(page).to have_current_path new_sake_path
+    end
+  end
+
+  context "when user presses sign-in button on sake show page" do
+    before do
+      visit sake_path(id)
+      sign_in_via_header_button(user)
+    end
+
+    it "redirects user to sake show page after user sign-in" do
+      expect(page).to have_current_path sake_path(id)
+    end
+  end
+
+  context "when user presses sign-in button on sign-in page" do
+    before do
+      visit new_user_session_path
+      sign_in_via_header_button(user)
+    end
+
+    it "redirects user to root_path after user sign-in" do
+      expect(page).to have_current_path root_path
+    end
+  end
+end

--- a/spec/system/sign_in_redirect_spec.rb
+++ b/spec/system/sign_in_redirect_spec.rb
@@ -10,56 +10,56 @@ RSpec.describe "Sign-in redirect", type: :system do
     sign_out(user)
   end
 
-  context "when non-signed-in user tries to edit-sake" do
+  context "when not signed user tries to edit sake" do
     before do
       visit sake_path(id)
       find(:test_id, "edit-#{id}").click
     end
 
-    it "redirects user to new_user_session_path" do
+    it "redirects to sign in page" do
       expect(page).to have_current_path new_user_session_path
     end
 
-    it "redirect to edit_sake_path after user sign-in" do
+    it "redirect to sake editing page after sign in" do
       signin_process_on_signin_page(user)
       expect(page).to have_current_path edit_sake_path(id)
     end
   end
 
-  context "when non-signed-in user tries to new-sake" do
+  context "when not signed user tries to create sake" do
     before do
       visit sakes_path
       find(:test_id, "new-sake").click
     end
 
-    it "redirects user to new_user_session_path" do
+    it "redirects to sign in page" do
       expect(page).to have_current_path new_user_session_path
     end
 
-    it "redirects user to new_sake_path after user sign-in" do
+    it "redirects to sake creation page after sign in" do
       signin_process_on_signin_page(user)
       expect(page).to have_current_path new_sake_path
     end
   end
 
-  context "when user presses sign-in button on sake show page" do
+  context "when user signs in from header button on sake show page" do
     before do
       visit sake_path(id)
       sign_in_via_header_button(user)
     end
 
-    it "redirects user to sake show page after user sign-in" do
+    it "redirects to sake show page" do
       expect(page).to have_current_path sake_path(id)
     end
   end
 
-  context "when user presses sign-in button on sign-in page" do
+  context "when user signs in from header button on sign in page" do
     before do
       visit new_user_session_path
       sign_in_via_header_button(user)
     end
 
-    it "redirects user to root_path after user sign-in" do
+    it "redirects user to root url (does not occur redirection loop)" do
       expect(page).to have_current_path root_path
     end
   end


### PR DESCRIPTION
fix #171

- ユーザーが酒作成ボタンからログインしたとき、酒作成ページに飛ばされるようにした。
- ユーザーが酒編集ボタンからログインしたとき、酒編集ページに飛ばされるようにした。
- ユーザーが任意のページからヘッダーのSign-inボタンを押してログインしたとき、ログインする前にいたページに戻されるようにした。
  - ただしSign-inページのヘッダーからSign-inボタンを押してログインしたときは、Sign-inページではなくインデクスに飛ばされる。

やってないこと
- indexの「評価する」ボタンや「開封する」ボタンなどからログインしたときの挙動の検討
- 現状はなりゆきで以下の挙動をします
  - 「評価する」ボタンクリック後にログインしたらeditページへ遷移
  - 「開封する」「空にする」ボタンクリック後にログインしたらindexページへ遷移し、bottle_levelは変更されない