### PR TITLE
製造年月日&BY に和暦を追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ gem "kaminari"
 gem "bootstrap-icons-helper"
 
 # Japanese Era
-gem "era_ja"
+gem 'era_ja'
 
 group :development, :test do
   gem "annotate"

--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,9 @@ gem "kaminari"
 # Bootstrap icons
 gem "bootstrap-icons-helper"
 
+# Japanese Era
+gem 'era_ja'
+
 group :development, :test do
   gem "annotate"
   # Call 'byebug' anywhere in the code to stop execution and get a debugger

--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ gem "kaminari"
 gem "bootstrap-icons-helper"
 
 # Japanese Era
-gem 'era_ja'
+gem "era_ja"
 
 group :development, :test do
   gem "annotate"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,6 +134,7 @@ GEM
       railties (>= 3.2)
     enum_help (0.0.17)
       activesupport (>= 3.0.0)
+    era_ja (1.2.2)
     erb_lint (0.0.37)
       activesupport
       better_html (~> 1.0.7)
@@ -408,6 +409,7 @@ DEPENDENCIES
   devise-i18n
   dotenv-rails
   enum_help
+  era_ja
   erb_lint
   factory_bot_rails
   jbuilder (~> 2.7)

--- a/app/controllers/sakes_controller.rb
+++ b/app/controllers/sakes_controller.rb
@@ -40,8 +40,6 @@ class SakesController < ApplicationController
   # GET /sakes/new
   def new
     @sake = Sake.new
-    # デフォルト値を設定する
-    @sake.brew_year = to_by(Time.zone.today)
     @sake.size = 720
   end
 

--- a/app/helpers/sakes_helper.rb
+++ b/app/helpers/sakes_helper.rb
@@ -17,7 +17,7 @@ module SakesHelper
 
   # @param [Date] date
   def with_japanese_era(date)
-    [date.year, " / ", date.to_era("%O%-E年")].join
+    "#{date.year} / #{date.to_era('%O%-E年')}"
   end
 
   # @param [String] id

--- a/app/helpers/sakes_helper.rb
+++ b/app/helpers/sakes_helper.rb
@@ -20,14 +20,17 @@ module SakesHelper
     "#{date.year} / #{date.to_era('%O%-E年')}"
   end
 
+  def year_range(begin_year)
+    (begin_year - start_year_limit)..begin_year
+  end
+
   # @param [String] id
   # @param [String] name
   # @param [Integer] begin_year
   # @param [Integer] selected_year
   def year_select_with_japanese_era(id, name, begin_year, selected_year = begin_year)
-    year_range = (begin_year - start_year_limit)..begin_year
-    options = year_range.map do |year|
-      [with_japanese_era(to_by(Date.new(year + 1))), year]
+    options = year_range(begin_year).map do |year|
+      [with_japanese_era(Date.new(year)), year]
     end
     select_tag(id, options_for_select(options, selected: selected_year), { class: "form-control", name: name })
   end

--- a/app/helpers/sakes_helper.rb
+++ b/app/helpers/sakes_helper.rb
@@ -1,4 +1,4 @@
-require 'era_ja/date'
+require "era_ja/date"
 
 module SakesHelper
   def empty_to_default(value, default)
@@ -17,7 +17,7 @@ module SakesHelper
 
   # @param [Date] date
   def with_japanese_era(date)
-    [date.year, " / ", date.to_era("%O%-E年")].join("")
+    [date.year, " / ", date.to_era("%O%-E年")].join
   end
 
   # @param [String] id

--- a/app/helpers/sakes_helper.rb
+++ b/app/helpers/sakes_helper.rb
@@ -25,11 +25,11 @@ module SakesHelper
   # @param [Integer] begin_year
   # @param [Integer] selected_year
   def year_select_with_japanese_era(id, name, begin_year, selected_year = begin_year)
-    year_range = begin_year - start_year_limit..begin_year
-    options = year_range.collect do |year|
+    year_range = (begin_year - start_year_limit)..begin_year
+    options = year_range.map do |year|
       [with_japanese_era(to_by(Date.new(year + 1))), year]
     end
-    select_tag(id, options_for_select(options, selected: selected_year), class: "form-control", name: name)
+    select_tag(id, options_for_select(options, selected: selected_year), { class: "form-control", name: name })
   end
 
   # どの瓶状態（bottle_level）にもマッチしない値

--- a/app/helpers/sakes_helper.rb
+++ b/app/helpers/sakes_helper.rb
@@ -29,7 +29,7 @@ module SakesHelper
     options = year_range.collect do |year|
       [with_japanese_era(to_by(Date.new(year + 1))), year]
     end
-    select_tag id, options_for_select(options, selected: selected_year), class: "form-control", name: name
+    select_tag(id, options_for_select(options, selected: selected_year), class: "form-control", name: name)
   end
 
   # どの瓶状態（bottle_level）にもマッチしない値

--- a/app/helpers/sakes_helper.rb
+++ b/app/helpers/sakes_helper.rb
@@ -20,17 +20,16 @@ module SakesHelper
     [date.year, " / ", date.to_era("%O%-E年")].join("")
   end
 
-  # @param [Symbol] raw_id
+  # @param [String] id
+  # @param [String] name
   # @param [Integer] begin_year
   # @param [Integer] selected_year
-  def year_select_with_japanese_era(raw_id, begin_year, selected_year=begin_year)
-    year_range = begin_year - start_year_limit .. begin_year
+  def year_select_with_japanese_era(id, name, begin_year, selected_year = begin_year)
+    year_range = begin_year - start_year_limit..begin_year
     options = year_range.collect do |year|
       [with_japanese_era(to_by(Date.new(year + 1))), year]
     end
-    id = ["sake_", raw_id, "_1i"].join
-    name = ["sake[", raw_id, "(1i)]"].join
-    select_tag id, options_for_select(options, selected: selected_year), class:"form-control", name: name
+    select_tag id, options_for_select(options, selected: selected_year), class: "form-control", name: name
   end
 
   # どの瓶状態（bottle_level）にもマッチしない値

--- a/app/helpers/sakes_helper.rb
+++ b/app/helpers/sakes_helper.rb
@@ -1,3 +1,5 @@
+require 'era_ja/date'
+
 module SakesHelper
   def empty_to_default(value, default)
     value.presence || default
@@ -11,6 +13,11 @@ module SakesHelper
     by_year = date.year - (date.month >= 7 ? 0 : 1)
     # BYは年のみ、使わない月日はBY始まりの7/1とする
     Date.new(by_year, 7)
+  end
+
+  # @param [Date] date
+  def with_japanese_era(date)
+    [date.year, " / ", date.to_era("%O%-E年")].join("")
   end
 
   # どの瓶状態（bottle_level）にもマッチしない値

--- a/app/helpers/sakes_helper.rb
+++ b/app/helpers/sakes_helper.rb
@@ -1,4 +1,4 @@
-require "era_ja/date"
+require 'era_ja/date'
 
 module SakesHelper
   def empty_to_default(value, default)

--- a/app/helpers/sakes_helper.rb
+++ b/app/helpers/sakes_helper.rb
@@ -32,18 +32,6 @@ module SakesHelper
     select_tag(id, options_for_select(options, selected: selected_year), class: "form-control", name: name)
   end
 
-  # @param [String] id
-  # @param [String] name
-  # @param [Integer] begin_year
-  # @param [Integer] selected_year
-  def year_select_with_japanese_era(id, name, begin_year, selected_year = begin_year)
-    year_range = begin_year - start_year_limit..begin_year
-    options = year_range.collect do |year|
-      [with_japanese_era(to_by(Date.new(year + 1))), year]
-    end
-    select_tag id, options_for_select(options, selected: selected_year), class: "form-control", name: name
-  end
-
   # どの瓶状態（bottle_level）にもマッチしない値
   def bottom_bottle
     -1

--- a/app/helpers/sakes_helper.rb
+++ b/app/helpers/sakes_helper.rb
@@ -20,6 +20,19 @@ module SakesHelper
     [date.year, " / ", date.to_era("%O%-E年")].join("")
   end
 
+  # @param [Symbol] raw_id
+  # @param [Integer] begin_year
+  # @param [Integer] selected_year
+  def year_select_with_japanese_era(raw_id, begin_year, selected_year=begin_year)
+    year_range = begin_year - start_year_limit .. begin_year
+    options = year_range.collect do |year|
+      [with_japanese_era(to_by(Date.new(year + 1))), year]
+    end
+    id = ["sake_", raw_id, "_1i"].join
+    name = ["sake[", raw_id, "(1i)]"].join
+    select_tag id, options_for_select(options, selected: selected_year), class:"form-control", name: name
+  end
+
   # どの瓶状態（bottle_level）にもマッチしない値
   def bottom_bottle
     -1

--- a/app/helpers/sakes_helper.rb
+++ b/app/helpers/sakes_helper.rb
@@ -32,6 +32,19 @@ module SakesHelper
     select_tag(id, options_for_select(options, selected: selected_year), class: "form-control", name: name)
   end
 
+  # @param [Symbol] raw_id
+  # @param [Integer] begin_year
+  # @param [Integer] selected_year
+  def year_select_with_japanese_era(raw_id, begin_year, selected_year=begin_year)
+    year_range = begin_year - start_year_limit .. begin_year
+    options = year_range.collect do |year|
+      [with_japanese_era(to_by(Date.new(year + 1))), year]
+    end
+    id = ["sake_", raw_id, "_1i"].join
+    name = ["sake[", raw_id, "(1i)]"].join
+    select_tag id, options_for_select(options, selected: selected_year), class:"form-control", name: name
+  end
+
   # どの瓶状態（bottle_level）にもマッチしない値
   def bottom_bottle
     -1

--- a/app/helpers/sakes_helper.rb
+++ b/app/helpers/sakes_helper.rb
@@ -1,4 +1,4 @@
-require 'era_ja/date'
+require "era_ja/date"
 
 module SakesHelper
   def empty_to_default(value, default)

--- a/app/helpers/sakes_helper.rb
+++ b/app/helpers/sakes_helper.rb
@@ -32,17 +32,16 @@ module SakesHelper
     select_tag(id, options_for_select(options, selected: selected_year), class: "form-control", name: name)
   end
 
-  # @param [Symbol] raw_id
+  # @param [String] id
+  # @param [String] name
   # @param [Integer] begin_year
   # @param [Integer] selected_year
-  def year_select_with_japanese_era(raw_id, begin_year, selected_year=begin_year)
-    year_range = begin_year - start_year_limit .. begin_year
+  def year_select_with_japanese_era(id, name, begin_year, selected_year = begin_year)
+    year_range = begin_year - start_year_limit..begin_year
     options = year_range.collect do |year|
       [with_japanese_era(to_by(Date.new(year + 1))), year]
     end
-    id = ["sake_", raw_id, "_1i"].join
-    name = ["sake[", raw_id, "(1i)]"].join
-    select_tag id, options_for_select(options, selected: selected_year), class:"form-control", name: name
+    select_tag id, options_for_select(options, selected: selected_year), class: "form-control", name: name
   end
 
   # どの瓶状態（bottle_level）にもマッチしない値

--- a/app/javascript/src/typescript/sync_bindume_date.ts
+++ b/app/javascript/src/typescript/sync_bindume_date.ts
@@ -8,7 +8,6 @@ function syncElement(srcId: string, dstId: string) {
 
 function setBindumeDateEvent() {
   syncElement('bindume_year', 'sake_bindume_date_1i')
-  syncElement('bindume_month', 'sake_bindume_date_2i')
 }
 
 // Main

--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -99,10 +99,15 @@
     <%#       Railsデフォルトでは年月が縦並びになってしまう。%>
     <%#       そのため、2つフォームを設置してTSで同期する。 %>
     <div class="sakazuki-half-forms">
-      <%= year_select_with_japanese_era(id = "bindume_year",
-                                        name = "sake[bindume_date(1i)]",
-                                        begin_year = Date.current.year,
-                                        selected_year = @sake.bindume_date&.year || Date.current.year) %>
+      <% current_year = Date.current.year %>
+      <select id="sake_<%= :bindume_date %>_1i" name="sake[<%= :bindume_date %>(1i)]" class="form-control">
+        <option value="" label=" "></option>
+        <% (current_year-start_year_limit .. current_year).each do |year| %>
+          <option value="<%= year %>" <%= "selected" if year == current_year %>>
+            <%= with_japanese_era(to_by(Date.new(year + 1 ))) %>
+          </option>
+        <% end %>
+      </select>
     </div>
     <div class="sakazuki-half-forms">
       <%= form.date_select(:bindume_date,
@@ -114,14 +119,18 @@
   <div class="form-group row">
     <%= form.label(:brew_year, { class: "sakazuki-label" }) %>
     <div class="sakazuki-half-forms">
-      <% default_by = to_by(Date.current).year %>
-      <%= year_select_with_japanese_era(id = "sake_brew_year_1i",
-                                        name = "sake[brew_year(1i)]",
-                                        begin_year = Date.current.year,
-                                        selected_year = @sake.brew_year&.year || default_by) %>
+      <% current_by = to_by(Date.current).year %>
+      <select id="sake_<%= :brew_year %>_1i" name="sake[<%= :brew_year %>(1i)]" class="form-control">
+        <option value="" label=" "></option>
+        <% (current_by-start_year_limit .. current_by).each do |year| %>
+        <option value="<%= year %>" <%= "selected" if year == current_by %>>
+          <%= with_japanese_era(to_by(Date.new(year + 1 ))) %>
+        </option>
+        <% end %>
+      </select>
       <%# 使わない月日はBY始まりの7/1とする. See to_by %>
-      <input type="hidden" id="sake_<%= :brew_year %>_2i" name="sake[<%= :brew_year %>(2i)]" value="7">
-      <input type="hidden" id="sake_<%= :brew_year %>_3i" name="sake[<%= :brew_year %>(3i)]" value="1">
+      <input type="hidden" id="sake_<%= :brew_year %>_2i" name="sake[<%= :brew_year %>(2i)]" value="7" />
+      <input type="hidden" id="sake_<%= :brew_year %>_3i" name="sake[<%= :brew_year %>(3i)]" value="1" />
     </div>
   </div>
 

--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -99,7 +99,9 @@
     <%#       Railsデフォルトでは年月が縦並びになってしまう。%>
     <%#       そのため、2つフォームを設置してTSで同期する。 %>
     <div class="sakazuki-half-forms">
-      <%= year_select_with_japanese_era(:bindume_date, Date.current.year) %>
+      <%= year_select_with_japanese_era(id="bindume_year",
+                                        name="sake[bindume_date(1i)]",
+                                        begin_year=Date.current.year) %>
     </div>
     <div class="sakazuki-half-forms">
       <%= form.date_select(:bindume_date,
@@ -112,7 +114,10 @@
     <%= form.label(:brew_year, { class: "sakazuki-label" }) %>
     <div class="sakazuki-half-forms">
       <% current_by = to_by(Date.current).year %>
-      <%= year_select_with_japanese_era(:brew_year, Date.current.year, current_by ) %>
+      <%= year_select_with_japanese_era(id="sake_brew_year_1i",
+                                        name="sake[brew_year(1i)]",
+                                        begin_year=Date.current.year,
+                                        selected_year=current_by ) %>
       <%# 使わない月日はBY始まりの7/1とする. See to_by %>
       <input type="hidden" id="sake_<%= :brew_year %>_2i" name="sake[<%= :brew_year %>(2i)]" value="7" />
       <input type="hidden" id="sake_<%= :brew_year %>_3i" name="sake[<%= :brew_year %>(3i)]" value="1" />

--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -97,7 +97,9 @@
     </div>
     <%# HACK: bootstrapで配置するために2つのdate_selectを設置しTSで同期する %>
     <div class="sakazuki-half-forms">
-      <%= year_select_with_japanese_era(:bindume_date, Date.current.year) %>
+      <%= year_select_with_japanese_era(id="bindume_year",
+                                        name="sake[bindume_date(1i)]",
+                                        begin_year=Date.current.year) %>
     </div>
     <div class="sakazuki-half-forms">
       <%= form.date_select(:bindume_date,
@@ -110,7 +112,10 @@
     <%= form.label(:brew_year, { class: "sakazuki-label" }) %>
     <div class="sakazuki-half-forms">
       <% current_by = to_by(Date.current).year %>
-      <%= year_select_with_japanese_era(:brew_year, Date.current.year, current_by ) %>
+      <%= year_select_with_japanese_era(id="sake_brew_year_1i",
+                                        name="sake[brew_year(1i)]",
+                                        begin_year=Date.current.year,
+                                        selected_year=current_by ) %>
       <%# 使わない月日はBY始まりの7/1とする. See to_by %>
       <input type="hidden" id="sake_<%= :brew_year %>_2i" name="sake[<%= :brew_year %>(2i)]" value="7" />
       <input type="hidden" id="sake_<%= :brew_year %>_3i" name="sake[<%= :brew_year %>(3i)]" value="1" />

--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -99,15 +99,7 @@
     <%#       Railsデフォルトでは年月が縦並びになってしまう。%>
     <%#       そのため、2つフォームを設置してTSで同期する。 %>
     <div class="sakazuki-half-forms">
-      <% current_year = Date.current.year %>
-      <select id="sake_<%= :bindume_date %>_1i" name="sake[<%= :bindume_date %>(1i)]" class="form-control">
-        <option value="" label=" "></option>
-        <% (current_year-start_year_limit .. current_year).each do |year| %>
-          <option value="<%= year %>" <%= "selected" if year == current_year %>>
-            <%= with_japanese_era(to_by(Date.new(year + 1 ))) %>
-          </option>
-        <% end %>
-      </select>
+      <%= year_select_with_japanese_era(:bindume_date, Date.current.year) %>
     </div>
     <div class="sakazuki-half-forms">
       <%= form.date_select(:bindume_date,
@@ -120,14 +112,7 @@
     <%= form.label(:brew_year, { class: "sakazuki-label" }) %>
     <div class="sakazuki-half-forms">
       <% current_by = to_by(Date.current).year %>
-      <select id="sake_<%= :brew_year %>_1i" name="sake[<%= :brew_year %>(1i)]" class="form-control">
-        <option value="" label=" "></option>
-        <% (current_by-start_year_limit .. current_by).each do |year| %>
-        <option value="<%= year %>" <%= "selected" if year == current_by %>>
-          <%= with_japanese_era(to_by(Date.new(year + 1 ))) %>
-        </option>
-        <% end %>
-      </select>
+      <%= year_select_with_japanese_era(:brew_year, Date.current.year, current_by ) %>
       <%# 使わない月日はBY始まりの7/1とする. See to_by %>
       <input type="hidden" id="sake_<%= :brew_year %>_2i" name="sake[<%= :brew_year %>(2i)]" value="7" />
       <input type="hidden" id="sake_<%= :brew_year %>_3i" name="sake[<%= :brew_year %>(3i)]" value="1" />

--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -114,11 +114,11 @@
   <div class="form-group row">
     <%= form.label(:brew_year, { class: "sakazuki-label" }) %>
     <div class="sakazuki-half-forms">
-      <% default_by = to_by(Date.current).year %>
+      <% current_by = to_by(Date.current).year %>
       <%= year_select_with_japanese_era(id = "sake_brew_year_1i",
                                         name = "sake[brew_year(1i)]",
-                                        begin_year = Date.current.year,
-                                        selected_year = @sake.brew_year&.year || default_by) %>
+                                        begin_year = current_by,
+                                        selected_year = @sake.brew_year&.year || current_by) %>
       <%# 使わない月日はBY始まりの7/1とする. See to_by %>
       <input type="hidden" id="sake_<%= :brew_year %>_2i" name="sake[<%= :brew_year %>(2i)]" value="7">
       <input type="hidden" id="sake_<%= :brew_year %>_3i" name="sake[<%= :brew_year %>(3i)]" value="1">

--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -99,7 +99,8 @@
     <div class="sakazuki-half-forms">
       <%= year_select_with_japanese_era(id = "bindume_year",
                                         name = "sake[bindume_date(1i)]",
-                                        begin_year = Date.current.year) %>
+                                        begin_year = Date.current.year,
+                                        selected_year = @sake.bindume_date&.year || Date.current.year) %>
     </div>
     <div class="sakazuki-half-forms">
       <%= form.date_select(:bindume_date,
@@ -111,11 +112,11 @@
   <div class="form-group row">
     <%= form.label(:brew_year, { class: "sakazuki-label" }) %>
     <div class="sakazuki-half-forms">
-      <% current_by = to_by(Date.current).year %>
+      <% default_by = to_by(Date.current).year %>
       <%= year_select_with_japanese_era(id = "sake_brew_year_1i",
                                         name = "sake[brew_year(1i)]",
                                         begin_year = Date.current.year,
-                                        selected_year = current_by) %>
+                                        selected_year = @sake.brew_year&.year || default_by) %>
       <%# 使わない月日はBY始まりの7/1とする. See to_by %>
       <input type="hidden" id="sake_<%= :brew_year %>_2i" name="sake[<%= :brew_year %>(2i)]" value="7">
       <input type="hidden" id="sake_<%= :brew_year %>_3i" name="sake[<%= :brew_year %>(3i)]" value="1">

--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -97,9 +97,9 @@
     </div>
     <%# HACK: bootstrapで配置するために2つのdate_selectを設置しTSで同期する %>
     <div class="sakazuki-half-forms">
-      <%= year_select_with_japanese_era(id="bindume_year",
-                                        name="sake[bindume_date(1i)]",
-                                        begin_year=Date.current.year) %>
+      <%= year_select_with_japanese_era(id = "bindume_year",
+                                        name = "sake[bindume_date(1i)]",
+                                        begin_year = Date.current.year) %>
     </div>
     <div class="sakazuki-half-forms">
       <%= form.date_select(:bindume_date,
@@ -112,13 +112,13 @@
     <%= form.label(:brew_year, { class: "sakazuki-label" }) %>
     <div class="sakazuki-half-forms">
       <% current_by = to_by(Date.current).year %>
-      <%= year_select_with_japanese_era(id="sake_brew_year_1i",
-                                        name="sake[brew_year(1i)]",
-                                        begin_year=Date.current.year,
-                                        selected_year=current_by ) %>
+      <%= year_select_with_japanese_era(id = "sake_brew_year_1i",
+                                        name = "sake[brew_year(1i)]",
+                                        begin_year = Date.current.year,
+                                        selected_year = current_by) %>
       <%# 使わない月日はBY始まりの7/1とする. See to_by %>
-      <input type="hidden" id="sake_<%= :brew_year %>_2i" name="sake[<%= :brew_year %>(2i)]" value="7" />
-      <input type="hidden" id="sake_<%= :brew_year %>_3i" name="sake[<%= :brew_year %>(3i)]" value="1" />
+      <input type="hidden" id="sake_<%= :brew_year %>_2i" name="sake[<%= :brew_year %>(2i)]" value="7">
+      <input type="hidden" id="sake_<%= :brew_year %>_3i" name="sake[<%= :brew_year %>(3i)]" value="1">
     </div>
   </div>
 

--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -95,7 +95,9 @@
     <div class="sakazuki-badge">
       <span class="badge badge-secondary"><%= t("helpers.badge.obligation") %></span>
     </div>
-    <%# HACK: bootstrapで配置するために2つのdate_selectを設置しTSで同期する %>
+    <%# HACK: 年と月の入力フォームを分けて横並びに配置する。 %>
+    <%#       Railsデフォルトでは年月が縦並びになってしまう。%>
+    <%#       そのため、2つフォームを設置してTSで同期する。 %>
     <div class="sakazuki-half-forms">
       <%= year_select_with_japanese_era(id = "bindume_year",
                                         name = "sake[bindume_date(1i)]",

--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -97,15 +97,7 @@
     </div>
     <%# HACK: bootstrapで配置するために2つのdate_selectを設置しTSで同期する %>
     <div class="sakazuki-half-forms">
-      <% current_year = Date.current.year %>
-      <select id="sake_<%= :bindume_date %>_1i" name="sake[<%= :bindume_date %>(1i)]" class="form-control">
-        <option value="" label=" "></option>
-        <% (current_year-start_year_limit .. current_year).each do |year| %>
-          <option value="<%= year %>" <%= "selected" if year == current_year %>>
-            <%= with_japanese_era(to_by(Date.new(year + 1 ))) %>
-          </option>
-        <% end %>
-      </select>
+      <%= year_select_with_japanese_era(:bindume_date, Date.current.year) %>
     </div>
     <div class="sakazuki-half-forms">
       <%= form.date_select(:bindume_date,
@@ -118,14 +110,7 @@
     <%= form.label(:brew_year, { class: "sakazuki-label" }) %>
     <div class="sakazuki-half-forms">
       <% current_by = to_by(Date.current).year %>
-      <select id="sake_<%= :brew_year %>_1i" name="sake[<%= :brew_year %>(1i)]" class="form-control">
-        <option value="" label=" "></option>
-        <% (current_by-start_year_limit .. current_by).each do |year| %>
-        <option value="<%= year %>" <%= "selected" if year == current_by %>>
-          <%= with_japanese_era(to_by(Date.new(year + 1 ))) %>
-        </option>
-        <% end %>
-      </select>
+      <%= year_select_with_japanese_era(:brew_year, Date.current.year, current_by ) %>
       <%# 使わない月日はBY始まりの7/1とする. See to_by %>
       <input type="hidden" id="sake_<%= :brew_year %>_2i" name="sake[<%= :brew_year %>(2i)]" value="7" />
       <input type="hidden" id="sake_<%= :brew_year %>_3i" name="sake[<%= :brew_year %>(3i)]" value="1" />

--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -99,9 +99,9 @@
     <%#       Railsデフォルトでは年月が縦並びになってしまう。%>
     <%#       そのため、2つフォームを設置してTSで同期する。 %>
     <div class="sakazuki-half-forms">
-      <%= year_select_with_japanese_era(id="bindume_year",
-                                        name="sake[bindume_date(1i)]",
-                                        begin_year=Date.current.year) %>
+      <%= year_select_with_japanese_era(id = "bindume_year",
+                                        name = "sake[bindume_date(1i)]",
+                                        begin_year = Date.current.year) %>
     </div>
     <div class="sakazuki-half-forms">
       <%= form.date_select(:bindume_date,
@@ -114,13 +114,13 @@
     <%= form.label(:brew_year, { class: "sakazuki-label" }) %>
     <div class="sakazuki-half-forms">
       <% current_by = to_by(Date.current).year %>
-      <%= year_select_with_japanese_era(id="sake_brew_year_1i",
-                                        name="sake[brew_year(1i)]",
-                                        begin_year=Date.current.year,
-                                        selected_year=current_by ) %>
+      <%= year_select_with_japanese_era(id = "sake_brew_year_1i",
+                                        name = "sake[brew_year(1i)]",
+                                        begin_year = Date.current.year,
+                                        selected_year = current_by) %>
       <%# 使わない月日はBY始まりの7/1とする. See to_by %>
-      <input type="hidden" id="sake_<%= :brew_year %>_2i" name="sake[<%= :brew_year %>(2i)]" value="7" />
-      <input type="hidden" id="sake_<%= :brew_year %>_3i" name="sake[<%= :brew_year %>(3i)]" value="1" />
+      <input type="hidden" id="sake_<%= :brew_year %>_2i" name="sake[<%= :brew_year %>(2i)]" value="7">
+      <input type="hidden" id="sake_<%= :brew_year %>_3i" name="sake[<%= :brew_year %>(3i)]" value="1">
     </div>
   </div>
 

--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -97,12 +97,15 @@
     </div>
     <%# HACK: bootstrapで配置するために2つのdate_selectを設置しTSで同期する %>
     <div class="sakazuki-half-forms">
-      <%= form.date_select(:bindume_date,
-                           { discard_day: true,
-                             discard_month: true,
-                             start_year: Date.current.year - start_year_limit,
-                             end_year: Date.current.year, },
-                           { class: "form-control", id: "bindume_year" }) %>
+      <% current_year = Date.current.year %>
+      <select id="sake_<%= :bindume_date %>_1i" name="sake[<%= :bindume_date %>(1i)]" class="form-control">
+        <option value="" label=" "></option>
+        <% (current_year-start_year_limit .. current_year).each do |year| %>
+          <option value="<%= year %>" <%= "selected" if year == current_year %>>
+            <%= with_japanese_era(to_by(Date.new(year + 1 ))) %>
+          </option>
+        <% end %>
+      </select>
     </div>
     <div class="sakazuki-half-forms">
       <%= form.date_select(:bindume_date,
@@ -115,13 +118,17 @@
     <%= form.label(:brew_year, { class: "sakazuki-label" }) %>
     <div class="sakazuki-half-forms">
       <% current_by = to_by(Date.current).year %>
-      <%= form.date_select(:brew_year,
-                           { discard_day: true,
-                             discard_month: true,
-                             include_blank: true,
-                             start_year: current_by - start_year_limit,
-                             end_year: current_by, },
-                           { class: "form-control" }) %>
+      <select id="sake_<%= :brew_year %>_1i" name="sake[<%= :brew_year %>(1i)]" class="form-control">
+        <option value="" label=" "></option>
+        <% (current_by-start_year_limit .. current_by).each do |year| %>
+        <option value="<%= year %>" <%= "selected" if year == current_by %>>
+          <%= with_japanese_era(to_by(Date.new(year + 1 ))) %>
+        </option>
+        <% end %>
+      </select>
+      <%# 使わない月日はBY始まりの7/1とする. See to_by %>
+      <input type="hidden" id="sake_<%= :brew_year %>_2i" name="sake[<%= :brew_year %>(2i)]" value="7" />
+      <input type="hidden" id="sake_<%= :brew_year %>_3i" name="sake[<%= :brew_year %>(3i)]" value="1" />
     </div>
   </div>
 

--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -101,7 +101,8 @@
     <div class="sakazuki-half-forms">
       <%= year_select_with_japanese_era(id = "bindume_year",
                                         name = "sake[bindume_date(1i)]",
-                                        begin_year = Date.current.year) %>
+                                        begin_year = Date.current.year,
+                                        selected_year = @sake.bindume_date&.year || Date.current.year) %>
     </div>
     <div class="sakazuki-half-forms">
       <%= form.date_select(:bindume_date,
@@ -113,11 +114,11 @@
   <div class="form-group row">
     <%= form.label(:brew_year, { class: "sakazuki-label" }) %>
     <div class="sakazuki-half-forms">
-      <% current_by = to_by(Date.current).year %>
+      <% default_by = to_by(Date.current).year %>
       <%= year_select_with_japanese_era(id = "sake_brew_year_1i",
                                         name = "sake[brew_year(1i)]",
                                         begin_year = Date.current.year,
-                                        selected_year = current_by) %>
+                                        selected_year = @sake.brew_year&.year || default_by) %>
       <%# 使わない月日はBY始まりの7/1とする. See to_by %>
       <input type="hidden" id="sake_<%= :brew_year %>_2i" name="sake[<%= :brew_year %>(2i)]" value="7">
       <input type="hidden" id="sake_<%= :brew_year %>_3i" name="sake[<%= :brew_year %>(3i)]" value="1">

--- a/spec/helpers/sakes_helper_spec.rb
+++ b/spec/helpers/sakes_helper_spec.rb
@@ -80,5 +80,4 @@ RSpec.describe SakesHelper, type: :helper do
       expect(bottom_bottle).to eq(-1)
     end
   end
-
 end

--- a/spec/helpers/sakes_helper_spec.rb
+++ b/spec/helpers/sakes_helper_spec.rb
@@ -38,6 +38,15 @@ RSpec.describe SakesHelper, type: :helper do
     end
   end
 
+  describe "year_range" do
+    it "must generate a range starting from 30 years ago to the given year" do
+      expect(year_range(2021).last).to eq(2021)
+      expect(year_range(2021).first).to eq(1991)
+      expect(year_range(2030).last).to eq(2030)
+      expect(year_range(2030).first).to eq(2000)
+    end
+  end
+
   describe "to_by" do
     let(:date) { Date.current }
 
@@ -71,4 +80,5 @@ RSpec.describe SakesHelper, type: :helper do
       expect(bottom_bottle).to eq(-1)
     end
   end
+
 end


### PR DESCRIPTION
Closes #170 

* `form.date_select` では、ラベルのフォーマットをカスタマイズできるようですが、和暦を埋め込むようなことはできなさそうでした。
  このため、`<select>` を組み立てるヘルパーメソッドを定義しました。
* 西暦→和暦変換には https://github.com/tomiacannondale/era_ja を使いました。

<details>
<summary>📸 スクリーンショット</summary>

### 登録ページ
![image](https://user-images.githubusercontent.com/127635/120887924-8eb6b300-c630-11eb-8142-b36bf074a9d1.png)
![image](https://user-images.githubusercontent.com/127635/120887931-95ddc100-c630-11eb-95d8-254ab5efb467.png)

### 詳細ページ（未修正）
修正したほうがわかりやすそう？
![image](https://user-images.githubusercontent.com/127635/120888008-097fce00-c631-11eb-84ac-cb13f564e229.png)
</details>