### PR TITLE
酒画像削除時の選択状態をボーダー色とアイコンで強調

### DIFF
--- a/app/javascript/src/stylesheet/application.scss
+++ b/app/javascript/src/stylesheet/application.scss
@@ -87,9 +87,11 @@
 label.sakazuki-label + div input[type="checkbox"] {
   display: none;
 }
+
 label.sakazuki-label + div input:checked[type="checkbox"] + label img {
   border: 10px solid #f66;
 }
+
 label.sakazuki-label + div input:checked[type="checkbox"] + label::after {
   content: "❌";
   font-size: 40px;

--- a/app/javascript/src/stylesheet/application.scss
+++ b/app/javascript/src/stylesheet/application.scss
@@ -84,6 +84,20 @@
   @extend .col-6;
 }
 
+label.sakazuki-label + div input[type="checkbox"] {
+  display: none;
+}
+label.sakazuki-label + div input:checked[type="checkbox"] + label img {
+  border: 10px solid #f66;
+}
+label.sakazuki-label + div input:checked[type="checkbox"] + label::after {
+  content: "❌";
+  font-size: 40px;
+  display: block;
+  margin-top: -40px;
+  margin-left: -10px;
+}
+
 //------ show ------
 
 .show-label {

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -29,7 +29,7 @@ ja:
       title: 編集
     form:
       reset: リセット
-      delete_photo: 削除する画像に☑
+      delete_photo: 削除する画像を選択してください
     show:
       title: 詳細
   activerecord:


### PR DESCRIPTION
Closes #94

こんなもんでどうでしょうか。
選択された画像は、赤いボーダーと ❌  アイコンで、削除されるっぽい見た目にしています。

チェックボックスは隠しました。
チェックボックスは、そこしかクリックできないような印象が出てしまいますが、
実際は画像全体が label で囲まれていてクリック可能領域です。

![image](https://user-images.githubusercontent.com/127635/120891332-01c92500-c643-11eb-8258-f0fa7e27a30c.png)
![image](https://user-images.githubusercontent.com/127635/120891341-0b528d00-c643-11eb-9562-04e54ddaa0ff.png)
