### PR TITLE
Add: 酒を評価するボタンを追加した

### DIFF
--- a/app/helpers/sakes_helper.rb
+++ b/app/helpers/sakes_helper.rb
@@ -17,25 +17,4 @@ module SakesHelper
   def bottom_bottle
     -1
   end
-
-  # 酒が未開封か
-  # @param [Sake] 酒
-  # @return [Boolean] 酒が未開封ならture、さもなくばfalse
-  def sealed?(sake)
-    sake.bottle_level == "sealed"
-  end
-
-  # 酒が開封されてまだ残っているか
-  # @param [Sake] 酒
-  # @return [Boolean] 酒が開封済みで中身が残っていたらture、未開封や空ならfalse
-  def opened?(sake)
-    sake.bottle_level == "opened"
-  end
-
-  # 酒が未評価か
-  # @param [Sake] 酒
-  # @return [Boolean] 酒の味・香りが評価されていないとtrue、評価済みならfalse
-  def unimpressed?(sake)
-    sake.taste_value.nil? && sake.aroma_value.nil?
-  end
 end

--- a/app/helpers/sakes_helper.rb
+++ b/app/helpers/sakes_helper.rb
@@ -17,4 +17,25 @@ module SakesHelper
   def bottom_bottle
     -1
   end
+
+  # 酒が未開封か
+  # @param [Sake] 酒
+  # @return [Boolean] 酒が未開封ならture、さもなくばfalse
+  def sealed?(sake)
+    sake.bottle_level == "sealed"
+  end
+
+  # 酒が開封されてまだ残っているか
+  # @param [Sake] 酒
+  # @return [Boolean] 酒が開封済みで中身が残っていたらture、未開封や空ならfalse
+  def opened?(sake)
+    sake.bottle_level == "opened"
+  end
+
+  # 酒が未評価か
+  # @param [Sake] 酒
+  # @return [Boolean] 酒の味・香りが評価されていないとtrue、評価済みならfalse
+  def unimpressed?(sake)
+    sake.taste_value.nil? && sake.aroma_value.nil?
+  end
 end

--- a/app/models/sake.rb
+++ b/app/models/sake.rb
@@ -120,4 +120,22 @@ class Sake < ApplicationRecord
   # rubocop:disable Layout/LineLength
   ransack_alias :all_text, :aroma_impression_or_awa_or_color_or_genryomai_or_kakemai_or_kobo_or_kura_or_name_or_nigori_or_note_or_roka_or_season_or_shibori_or_taste_impression_or_todofuken
   # rubocop:enable Layout/LineLength
+
+  # 酒が未開封か
+  # @return [Boolean] 酒が未開封ならture、さもなくばfalse
+  def sealed?
+    self.bottle_level == "sealed"
+  end
+
+  # 酒が開封されてまだ残っているか
+  # @return [Boolean] 酒が開封済みで中身が残っていたらture、未開封や空ならfalse
+  def opened?
+    self.bottle_level == "opened"
+  end
+
+  # 酒が未評価か
+  # @return [Boolean] 酒の味・香りが評価されていないとtrue、評価済みならfalse
+  def unimpressed?
+    self.taste_value.nil? && self.aroma_value.nil?
+  end
 end

--- a/app/views/sakes/_update-sake-bottle-button.html.erb
+++ b/app/views/sakes/_update-sake-bottle-button.html.erb
@@ -1,0 +1,26 @@
+<% if sealed?(sake) %>
+  <%= link_to(html_escape(t("sakes.index.open")) + bootstrap_icon("droplet-half", { width: "1em", height: "1em" }),
+              sake_path(sake, params: { sake: { bottle_level: "opened" } }),
+              { method: :patch,
+                data: { confirm: t("message.open") },
+                id: "open-#{sake.id}",
+                class: "badge badge-pill badge-primary ml-2" }) %>
+  <%= link_to(html_escape(t("sakes.index.impress")) + bootstrap_icon("cup-fill", { width: "1em", height: "1em" }),
+              edit_sake_path(sake, params: { sake: { bottle_level: "opened" } }),
+              { id: "open-and-impress-#{sake.id}",
+                class: "badge badge-pill badge-secondary ml-2" }) %>
+<% end %>
+<% if opened?(sake) && unimpressed?(sake) %>
+  <%= link_to(html_escape(t("sakes.index.impress")) + bootstrap_icon("cup-fill", { width: "1em", height: "1em" }),
+              edit_sake_path(sake),
+              { id: "open-and-impress-#{sake.id}",
+                class: "badge badge-pill badge-secondary ml-2" }) %>
+<% end %>
+<% if opened?(sake) %>
+  <%= link_to(html_escape(t("sakes.index.empty")) + bootstrap_icon("droplet", { width: "1em", height: "1em" }),
+              sake_path(sake, params: { sake: { bottle_level: "empty" } }),
+              { method: :patch,
+                data: { confirm: t("message.empty") },
+                id: "empty-#{sake.id}",
+                class: "badge badge-pill badge-light ml-2" }) %>
+<% end %>

--- a/app/views/sakes/_update-sake-bottle-button.html.erb
+++ b/app/views/sakes/_update-sake-bottle-button.html.erb
@@ -4,17 +4,17 @@
               { method: :patch,
                 data: { confirm: t("message.open") },
                 class: "badge badge-pill badge-primary ml-2",
-                "data-testid": "open-button-#{sake.id}" }) %>
+                "data-testid": "open-button-#{sake.id}", }) %>
   <%= link_to(html_escape(t("sakes.index.impress")) + bootstrap_icon("cup-fill", { width: "1em", height: "1em" }),
               edit_sake_path(sake, params: { sake: { bottle_level: "opened" } }),
               { class: "badge badge-pill badge-secondary ml-2",
-                "data-testid": "open-and-impress-button-#{sake.id}" }) %>
+                "data-testid": "open-and-impress-button-#{sake.id}", }) %>
 <% end %>
 <% if opened?(sake) && unimpressed?(sake) %>
   <%= link_to(html_escape(t("sakes.index.impress")) + bootstrap_icon("cup-fill", { width: "1em", height: "1em" }),
               edit_sake_path(sake),
               { class: "badge badge-pill badge-secondary ml-2",
-                "data-testid": "impress-button-#{sake.id}" }) %>
+                "data-testid": "impress-button-#{sake.id}", }) %>
 <% end %>
 <% if opened?(sake) %>
   <%= link_to(html_escape(t("sakes.index.empty")) + bootstrap_icon("droplet", { width: "1em", height: "1em" }),
@@ -22,5 +22,5 @@
               { method: :patch,
                 data: { confirm: t("message.empty") },
                 class: "badge badge-pill badge-light ml-2",
-                "data-testid": "empty-button-#{sake.id}"}) %>
+                "data-testid": "empty-button-#{sake.id}", }) %>
 <% end %>

--- a/app/views/sakes/_update-sake-bottle-button.html.erb
+++ b/app/views/sakes/_update-sake-bottle-button.html.erb
@@ -1,4 +1,4 @@
-<% if sealed?(sake) %>
+<% if sake.sealed? %>
   <%= link_to(html_escape(t("sakes.index.open")) + bootstrap_icon("droplet-half", { width: "1em", height: "1em" }),
               sake_path(sake, params: { sake: { bottle_level: "opened" } }),
               { method: :patch,
@@ -10,13 +10,13 @@
               { class: "badge badge-pill badge-secondary ml-2",
                 "data-testid": "open-and-impress-button-#{sake.id}", }) %>
 <% end %>
-<% if opened?(sake) && unimpressed?(sake) %>
+<% if sake.opened? && sake.unimpressed? %>
   <%= link_to(html_escape(t("sakes.index.impress")) + bootstrap_icon("cup-fill", { width: "1em", height: "1em" }),
               edit_sake_path(sake),
               { class: "badge badge-pill badge-secondary ml-2",
                 "data-testid": "impress-button-#{sake.id}", }) %>
 <% end %>
-<% if opened?(sake) %>
+<% if sake.opened? %>
   <%= link_to(html_escape(t("sakes.index.empty")) + bootstrap_icon("droplet", { width: "1em", height: "1em" }),
               sake_path(sake, params: { sake: { bottle_level: "empty" } }),
               { method: :patch,

--- a/app/views/sakes/_update-sake-bottle-button.html.erb
+++ b/app/views/sakes/_update-sake-bottle-button.html.erb
@@ -3,24 +3,24 @@
               sake_path(sake, params: { sake: { bottle_level: "opened" } }),
               { method: :patch,
                 data: { confirm: t("message.open") },
-                id: "open-#{sake.id}",
-                class: "badge badge-pill badge-primary ml-2" }) %>
+                class: "badge badge-pill badge-primary ml-2",
+                "data-testid": "open-button-#{sake.id}" }) %>
   <%= link_to(html_escape(t("sakes.index.impress")) + bootstrap_icon("cup-fill", { width: "1em", height: "1em" }),
               edit_sake_path(sake, params: { sake: { bottle_level: "opened" } }),
-              { id: "open-and-impress-#{sake.id}",
-                class: "badge badge-pill badge-secondary ml-2" }) %>
+              { class: "badge badge-pill badge-secondary ml-2",
+                "data-testid": "open-and-impress-button-#{sake.id}" }) %>
 <% end %>
 <% if opened?(sake) && unimpressed?(sake) %>
   <%= link_to(html_escape(t("sakes.index.impress")) + bootstrap_icon("cup-fill", { width: "1em", height: "1em" }),
               edit_sake_path(sake),
-              { id: "open-and-impress-#{sake.id}",
-                class: "badge badge-pill badge-secondary ml-2" }) %>
+              { class: "badge badge-pill badge-secondary ml-2",
+                "data-testid": "impress-button-#{sake.id}" }) %>
 <% end %>
 <% if opened?(sake) %>
   <%= link_to(html_escape(t("sakes.index.empty")) + bootstrap_icon("droplet", { width: "1em", height: "1em" }),
               sake_path(sake, params: { sake: { bottle_level: "empty" } }),
               { method: :patch,
                 data: { confirm: t("message.empty") },
-                id: "empty-#{sake.id}",
-                class: "badge badge-pill badge-light ml-2" }) %>
+                class: "badge badge-pill badge-light ml-2",
+                "data-testid": "empty-button-#{sake.id}"}) %>
 <% end %>

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -61,19 +61,7 @@
           <div class="row m-0 mt-2">
             <div calss="col p-0">
               <%= sake.bottle_level_i18n %>
-              <% if sake.bottle_level == "sealed" %>
-                <%= link_to(html_escape(t(".open")) + bootstrap_icon("droplet-half", { width: "1em", height: "1em" }),
-                            edit_sake_path(sake, params: { sake: { bottle_level: "opened" } }),
-                            { id: "open-#{sake.id}",
-                              class: "badge badge-pill badge-primary ml-2", }) %>
-              <% elsif sake.bottle_level == "opened" %>
-                <%= link_to(html_escape(t(".empty")) + bootstrap_icon("droplet", { width: "1em", height: "1em" }),
-                            sake_path(sake, params: { sake: { bottle_level: "empty" } }),
-                            { method: :patch,
-                              data: { confirm: t("message.empty") },
-                              id: "empty-#{sake.id}",
-                              class: "badge badge-pill badge-light ml-2", }) %>
-              <% end %>
+              <%= render "update-sake-bottle-button", sake: sake %>
             </div>
           </div>
         </td>

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -12,7 +12,8 @@
       <div class="custom-control custom-switch ml-sm-2 mr-2">
         <%= f.check_box(:bottle_level_not_eq,
                         { class: "custom-control-input",
-                          id: "all_bottle_level", },
+                          id: "all_bottle_level",
+                          "data-testid": "check_empty_bottle", },
                         bottom_bottle,
                         Sake.bottle_levels["empty"]) %>
         <%= f.label(t(".all_bottles"),
@@ -20,7 +21,7 @@
                       for: "all_bottle_level", }) %>
       </div>
 
-      <%= f.submit({ class: "btn btn-secondary mx-2" }) %>
+      <%= f.submit({ class: "btn btn-secondary mx-2", "data-testid": "submit_search" }) %>
     <% end %>
   </div>
 

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -59,7 +59,7 @@
             </div>
           </div>
           <div class="row m-0 mt-2">
-            <div calss="col p-0">
+            <div calss="col p-0" data-testid="bottle-level-<%= sake.id %>">
               <%= sake.bottle_level_i18n %>
               <%= render "update-sake-bottle-button", sake: sake %>
             </div>

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -22,6 +22,7 @@ ja:
       title: 日本酒リスト
       all_bottles: 空瓶を表示
       open: 開封する
+      impress: 評価する
       empty: 空にする
     new:
       title: 新規登録

--- a/spec/models/sake_spec.rb
+++ b/spec/models/sake_spec.rb
@@ -55,4 +55,35 @@ RSpec.describe Sake, type: :model do
       it { is_expected.to be_falsy }
     end
   end
+
+  let(:sealed_sake) { FactoryBot.create(:sake, bottle_level: "sealed") }
+  let(:opened_sake) { FactoryBot.create(:sake, bottle_level: "opened") }
+  let(:impressed_sake) { FactoryBot.create(:sake, bottle_level: "opened", aroma_value: 1, taste_value: 2) }
+
+  describe "check sealed" do
+    it "returns true" do
+      expect(sealed_sake.sealed?).to be_truthy
+    end
+    it "returns false" do
+      expect(opened_sake.sealed?).to be_falsy
+    end
+  end
+
+  describe "check opened" do
+    it "returns true" do
+      expect(opened_sake.opened?).to be_truthy
+    end
+    it "returns false" do
+      expect(sealed_sake.opened?).to be_falsy
+    end
+  end
+
+  describe "check unimpressed" do
+    it "returns true" do
+      expect(opened_sake.unimpressed?).to be_truthy
+    end
+    it "returns false" do
+      expect(impressed_sake.unimpressed?).to be_falsy
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require "simplecov"
+require "capybara"
 
 SimpleCov.start("rails")
 
@@ -95,4 +96,17 @@ RSpec.configure do |config|
   #   # test failures related to randomization by passing the same `--seed` value
   #   # as the one that triggered the failure.
   #   Kernel.srand config.seed
+end
+
+# Capybara configuration
+Capybara.configure do |config|
+  # "data-testid"をCapybaraのclick_linkなどで使えるように、Optional attributeに登録する
+  config.test_id = "data-testid"
+end
+
+# Capybaraのカスタムセレクタ
+# find(:test_id, "email")でfind("[data-testid='email']")と同じく、data-testidが指定値のタグを取得できる
+# 参考: https://speakerdeck.com/yasaichi/tokyurubykaigi12
+Capybara.add_selector(:test_id) do
+  css { |val| %([data-testid="#{val}"]) }
 end

--- a/spec/system/drink_buttons_spec.rb
+++ b/spec/system/drink_buttons_spec.rb
@@ -132,11 +132,11 @@ RSpec.describe "DrinkButtons", type: :system do
 
     describe "clicking open button of sealed bottle" do
       it "updates sake to opened" do
-        expect do
+        expect {
           click_link "open-button-#{sealed_sake.id}"
           wait_for_page
           sealed_sake.reload
-        end.to change(sealed_sake, :bottle_level).from("sealed").to("opened")
+        }.to change(sealed_sake, :bottle_level).from("sealed").to("opened")
       end
     end
 
@@ -183,10 +183,10 @@ RSpec.describe "DrinkButtons", type: :system do
       end
 
       it "updates sake to empty" do
-        expect do
+        expect {
           wait_for_page
           impressed_sake.reload
-        end.to change(impressed_sake, :bottle_level).from("opened").to("empty")
+        }.to change(impressed_sake, :bottle_level).from("opened").to("empty")
       end
     end
   end

--- a/spec/system/drink_buttons_spec.rb
+++ b/spec/system/drink_buttons_spec.rb
@@ -5,29 +5,73 @@ RSpec.describe "DrinkButtons", type: :system do
     driven_by(:rack_test)
   end
 
-  let!(:sake_sealed) { FactoryBot.create(:sake, bottle_level: "sealed") }
-  let!(:sake_opened) { FactoryBot.create(:sake, bottle_level: "opened") }
+  let!(:sealed_sake) { FactoryBot.create(:sake, bottle_level: "sealed") }
+  let!(:opened_sake) { FactoryBot.create(:sake, bottle_level: "opened") }
+  let!(:impressed_sake) { FactoryBot.create(:sake, bottle_level: "opened", taste_value: 1, aroma_value: 2) }
+  # let!(:empty_sake) { FactoryBot.create(:sake, bottle_level: "empty", taste_value: 1, aroma_value: 2) }
 
-  describe "sake column" do
+  describe "sake column in index page" do
     before do
       visit sakes_path
     end
 
-    describe "sealed bottle column" do
-      it "has button to open bottle" do
-        state = I18n.t("enums.sake.bottle_level.sealed")
-        link = I18n.t("sakes.index.open")
-        expect(find("td", text: state, match: :first)).to have_link(link)
+    open_text = I18n.t("sakes.index.open")
+    impress_text = I18n.t("sakes.index.impress")
+    empty_text = I18n.t("sakes.index.empty")
+
+    describe "sealed bottle" do
+      it "has open button with i18n text" do
+        id = "bottle-level-#{sealed_sake.id}"
+        expect(find(:test_id, id)).to have_text(open_text)
+      end
+
+      it "has impress button with i18n text" do
+        id = "bottle-level-#{sealed_sake.id}"
+        expect(find(:test_id, id)).to have_text(impress_text)
+      end
+
+      it "does not have empty button with i18n text" do
+        id = "bottle-level-#{sealed_sake.id}"
+        expect(find(:test_id, id)).to have_no_text(empty_text)
       end
     end
 
-    describe "opened bottle column" do
-      it "has button to make bottle empty" do
-        state = I18n.t("enums.sake.bottle_level.opened")
-        link = I18n.t("sakes.index.empty")
-        expect(find("td", text: state, match: :first)).to have_link(link)
+    describe "opened and unimpressed bottle" do
+      it "does not have open button with i18n text" do
+        id = "bottle-level-#{opened_sake.id}"
+        expect(find(:test_id, id)).to have_no_text(open_text)
+      end
+
+      it "has impress button with i18n text" do
+        id = "bottle-level-#{opened_sake.id}"
+        expect(find(:test_id, id)).to have_text(impress_text)
+      end
+
+      it "has empty button with i18n text" do
+        id = "bottle-level-#{opened_sake.id}"
+        expect(find(:test_id, id)).to have_text(empty_text)
       end
     end
+
+    describe "opened and impressed bottle" do
+      it "does not have open button with i18n text" do
+        id = "bottle-level-#{impressed_sake.id}"
+        expect(find(:test_id, id)).to have_no_text(open_text)
+      end
+
+      it "does not have impress button with i18n text" do
+        id = "bottle-level-#{impressed_sake.id}"
+        expect(find(:test_id, id)).to have_no_text(impress_text)
+      end
+
+      it "has empty button with i18n text" do
+        id = "bottle-level-#{impressed_sake.id}"
+        expect(find(:test_id, id)).to have_text(empty_text)
+      end
+    end
+
+    # TODO: 空ボトルのボタンテスト、vistにうまくparamを渡す方法がわからない
+    # describe "empty bottle column" do end
   end
 
   context "without login" do
@@ -35,16 +79,26 @@ RSpec.describe "DrinkButtons", type: :system do
       visit sakes_path
     end
 
-    describe "clicking button to open bottle" do
+    describe "clicking open button in sealed bottle" do
       it "redirects to user login page" do
-        click_link "open-#{sake_sealed.id}"
+        id = "open-button-#{sealed_sake.id}"
+        click_link id
         expect(page).to have_current_path new_user_session_path
       end
     end
 
-    describe "clicking button to make bottle empty" do
+    describe "clicking impress button in opened bottle" do
       it "redirects to user login page" do
-        click_link "empty-#{sake_opened.id}"
+        id = "impress-button-#{opened_sake.id}"
+        click_link id
+        expect(page).to have_current_path new_user_session_path
+      end
+    end
+
+    describe "clicking empty button in impressed bottle" do
+      it "redirects to user login page" do
+        id = "empty-button-#{impressed_sake.id}"
+        click_link id
         expect(page).to have_current_path new_user_session_path
       end
     end
@@ -54,45 +108,85 @@ RSpec.describe "DrinkButtons", type: :system do
     before do
       user = FactoryBot.create(:user)
       sign_in(user)
+      visit sakes_path
     end
 
-    describe "clicking button to open bottle" do
+    describe "clicking impress button of sealed bottle" do
       before do
-        visit sakes_path
-        click_link "open-#{sake_sealed.id}"
+        id = "open-and-impress-button-#{sealed_sake.id}"
+        click_link id
       end
 
       it "redirects to sake edit page" do
-        expect(page).to have_current_path "/sakes/#{sake_sealed.id}/edit?sake[bottle_level]=opened"
+        path = edit_sake_path(sealed_sake.id)
+        # クエリ "?sake[bottle_level]=opened" 部を無視する
+        expect(page).to have_current_path(path, { ignore_query: true })
       end
 
-      it "moves to edit page and has 'opened' state at satate of sake" do
-        expect(page).to have_select("sake_bottle_level", selected: I18n.t("enums.sake.bottle_level.opened"))
+      it "moves to edit page and has 'opened' state" do
+        id = "sake_bottle_level"
+        text = I18n.t("enums.sake.bottle_level.opened")
+        expect(page).to have_select(id: id, selected: text)
       end
     end
 
-    describe "clicking button to make bottle empty" do
+    describe "clicking open button of sealed bottle" do
+      it "updates sake to opened" do
+        expect do
+          click_link "open-button-#{sealed_sake.id}"
+          wait_for_page
+          sealed_sake.reload
+        end.to change(sealed_sake, :bottle_level).from("sealed").to("opened")
+      end
+    end
+
+    describe "clicking impress button of opened bottle" do
       before do
-        Capybara.current_driver = :selenium_headless
-        visit sakes_path
+        id = "impress-button-#{opened_sake.id}"
+        click_link id
+      end
+
+      it "redirects to sake edit page" do
+        path = edit_sake_path(opened_sake)
+        expect(page).to have_current_path path
+      end
+
+      it "moves to edit page and keep 'opened' state" do
+        id = "sake_bottle_level"
+        text = I18n.t("enums.sake.bottle_level.opened")
+        expect(page).to have_select(id: id, selected: text)
+      end
+    end
+  end
+
+  context "with login by selenium driver" do
+    before do
+      Capybara.current_driver = :selenium_headless
+      user = FactoryBot.create(:user)
+      sign_in(user)
+      visit sakes_path
+    end
+
+    describe "clicking empty button of impressed bottle" do
+      before do
         accept_confirm do
-          click_link "empty-#{sake_opened.id}"
+          click_link "empty-button-#{impressed_sake.id}"
         end
       end
 
-      it "moves to sake edit page" do
-        expect(page).to have_current_path sake_path(sake_opened.id)
+      it "moves to sake show page" do
+        expect(page).to have_current_path sake_path(impressed_sake.id)
       end
 
-      it "moves to sake edit page, and has success flash message" do
+      it "has success flash message" do
         expect(page).to have_css(".alert-success")
       end
 
-      it "makes bottle empty" do
+      it "updates sake to empty" do
         expect do
           wait_for_page
-          sake_opened.reload
-        end.to change(sake_opened, :bottle_level).from("opened").to("empty")
+          impressed_sake.reload
+        end.to change(impressed_sake, :bottle_level).from("opened").to("empty")
       end
     end
   end

--- a/spec/system/drink_buttons_spec.rb
+++ b/spec/system/drink_buttons_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "DrinkButtons", type: :system do
   let!(:sealed_sake) { FactoryBot.create(:sake, bottle_level: "sealed") }
   let!(:opened_sake) { FactoryBot.create(:sake, bottle_level: "opened") }
   let!(:impressed_sake) { FactoryBot.create(:sake, bottle_level: "opened", taste_value: 1, aroma_value: 2) }
-  # let!(:empty_sake) { FactoryBot.create(:sake, bottle_level: "empty", taste_value: 1, aroma_value: 2) }
+  let!(:empty_sake) { FactoryBot.create(:sake, bottle_level: "empty", taste_value: 1, aroma_value: 2) }
 
   describe "sake column in index page" do
     before do
@@ -70,8 +70,28 @@ RSpec.describe "DrinkButtons", type: :system do
       end
     end
 
-    # TODO: 空ボトルのボタンテスト、vistにうまくparamを渡す方法がわからない
-    # describe "empty bottle column" do end
+    describe "empty bottle" do
+      before do
+        visit sakes_path
+        page.check("check_empty_bottle")
+        click_button("submit_search")
+      end
+
+      it "does not have open button with i18n text" do
+        id = "bottle-level-#{empty_sake.id}"
+        expect(find(:test_id, id)).to have_no_text(open_text)
+      end
+
+      it "does not have impress button with i18n text" do
+        id = "bottle-level-#{empty_sake.id}"
+        expect(find(:test_id, id)).to have_no_text(impress_text)
+      end
+
+      it "does not have empty button with i18n text" do
+        id = "bottle-level-#{empty_sake.id}"
+        expect(find(:test_id, id)).to have_no_text(empty_text)
+      end
+    end
   end
 
   context "without login" do


### PR DESCRIPTION
close #185 #162

### 今まで

酒を開けると、評価もしないといけなかった。

### これから

酒を開けるのと評価するのを分けた。
酒indexには酒を開けるボタンと、開けて評価するボタンを追加した。
また、開けているが未評価の酒には評価するボタンが表示される。
