### PR TITLE
Update: RSpecテストのページ遷移待ちを高速化した

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,4 +1,4 @@
-<h2><%= t(".sign_in") %></h2>
+<h2 data-testid="<%= new_user_session_path %>"><%= t(".sign_in") %></h2>
 
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
 

--- a/app/views/sakes/edit.html.erb
+++ b/app/views/sakes/edit.html.erb
@@ -1,3 +1,3 @@
-<h2><%= t(".title") %></h2>
+<h2 data-testid="<%= edit_sake_path(@sake) %>"><%= t(".title") %></h2>
 
 <%= render "form", sake: @sake %>

--- a/app/views/sakes/show.html.erb
+++ b/app/views/sakes/show.html.erb
@@ -1,4 +1,4 @@
-<h2><%= t ".title" %></h2>
+<h2 data-testid="<%= sake_path(@sake) %>"><%= t ".title" %></h2>
 
 <%= render "float-button" %>
 

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -25,10 +25,11 @@ end
 
 # ページ遷移を待つ
 #
-# Capybaraのfindはページロードを待つため、これを使えばもっと効率のよいwaitが実装できる。
-# しかし、findでページ遷移をwaitするには、遷移前と遷移後で変化する要素が必要となる
-# 任意のページ遷移で該当する要素が思いつかず、汎用関数にできていない。
-def wait_for_page
-  sleep(1)
-  nil
+# Capybaraでselenium driverなどを使うと、テスト処理にページ遷移が追いつかずテストが落ちることがある。
+# このメソッドでページ遷移を待つことができる。
+# 例えば酒indexなら、`wait_for_page(sakes_path)`と呼び出せばよい。
+#
+# @param [String] page_key ページのパス
+def wait_for_page(page_key)
+  find(:test_id, page_key, visible: false)
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -27,9 +27,12 @@ end
 #
 # Capybaraでselenium driverなどを使うと、テスト処理にページ遷移が追いつかずテストが落ちることがある。
 # このメソッドでページ遷移を待つことができる。
-# 例えば酒indexなら、`wait_for_page(sakes_path)`と呼び出せばよい。
+# 対象ページにはdata-testidに自身のパスを持つことを想定している。
 #
-# @param [String] page_key ページのパス
-def wait_for_page(page_key)
-  find(:test_id, page_key, visible: false)
+# @example index.htmlの場合
+#   wait_for_page(sakes_path)
+#
+# @param [String] page_path ページのパス
+def wait_for_page(page_path)
+  find(:test_id, page_path, visible: false)
 end

--- a/spec/system/drink_buttons_spec.rb
+++ b/spec/system/drink_buttons_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe "DrinkButtons", type: :system do
         accept_confirm do
           click_link id
         end
-        wait_for_page
+        wait_for_page new_user_session_path
         expect(page).to have_current_path new_user_session_path
       end
 
@@ -126,7 +126,7 @@ RSpec.describe "DrinkButtons", type: :system do
         accept_confirm do
           click_link id
         end
-        wait_for_page
+        wait_for_page new_user_session_path
         signin_process_on_signin_page(user)
         expect { sealed_sake.reload }.to_not change(sealed_sake, :bottle_level)
       end
@@ -138,7 +138,7 @@ RSpec.describe "DrinkButtons", type: :system do
         accept_confirm do
           click_link id
         end
-        wait_for_page
+        wait_for_page new_user_session_path
         expect(page).to have_current_path new_user_session_path
       end
 
@@ -147,7 +147,7 @@ RSpec.describe "DrinkButtons", type: :system do
         accept_confirm do
           click_link id
         end
-        wait_for_page
+        wait_for_page new_user_session_path
         signin_process_on_signin_page(user)
         expect { impressed_sake.reload }.to_not change(sealed_sake, :bottle_level)
       end
@@ -184,7 +184,7 @@ RSpec.describe "DrinkButtons", type: :system do
       it "updates sake to opened" do
         expect {
           click_link "open-button-#{sealed_sake.id}"
-          wait_for_page
+          wait_for_page sake_path(sealed_sake.id)
           sealed_sake.reload
         }.to change(sealed_sake, :bottle_level).from("sealed").to("opened")
       end
@@ -233,7 +233,7 @@ RSpec.describe "DrinkButtons", type: :system do
 
       it "updates sake to empty" do
         expect {
-          wait_for_page
+          wait_for_page sake_path(impressed_sake.id)
           impressed_sake.reload
         }.to change(impressed_sake, :bottle_level).from("opened").to("empty")
       end

--- a/spec/system/signin_redirect_integrating_drinkbutton_spec.rb
+++ b/spec/system/signin_redirect_integrating_drinkbutton_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Sign in redirect with drink buttons", type: :system do
       accept_confirm do
         click_link("open-button-#{id}")
       end
-      wait_for_page
+      wait_for_page new_user_session_path
       signin_process_on_signin_page(user)
       expect(page).to have_current_path(sakes_path)
     end
@@ -38,7 +38,7 @@ RSpec.describe "Sign in redirect with drink buttons", type: :system do
       accept_confirm do
         click_link("empty-button-#{id}")
       end
-      wait_for_page
+      wait_for_page new_user_session_path
       signin_process_on_signin_page(user)
       expect(page).to have_current_path(sakes_path)
     end


### PR DESCRIPTION
無条件にsleepしていたが、テストごとにどんどん遅くなるのでやめた。
ページタイトルに仕込んだtestidをfindで読み込むことでページ遷移を認識するようにした。

### 残された問題

- 以下のような無意味に見えるテストが残るが、書き直しておくべきかどうか。

```ruby
wait_for_page new_user_session_path
expect(page).to have_current_path new_user_session_path
```