### PR TITLE
味香りグラフのサイズを変更した

### DIFF
--- a/app/javascript/src/typescript/input_taste_graph.ts
+++ b/app/javascript/src/typescript/input_taste_graph.ts
@@ -35,7 +35,7 @@ function syncAndGetDomValue(): GraphP {
   const domData = syncAndGetDomValue() // dataは0~6の二次元データ
 
   // グラフをセットする
-  const graph = new TasteGraph(canvas, domData, true, updateDomValue)
+  const graph = new TasteGraph(canvas, domData, {}, true, updateDomValue)
 
   // グラフのリセットボタンをセットする
   const button = document.getElementById("graph-reset") as HTMLDivElement

--- a/app/javascript/src/typescript/show_taste_graph.ts
+++ b/app/javascript/src/typescript/show_taste_graph.ts
@@ -24,6 +24,6 @@ const hasCanvasID = (elem: HTMLCanvasElement): boolean => {
   const graphs = canvases.filter(hasCanvasID)
   graphs.forEach((canvas) => {
     const p = getDomValueFromCanvas(canvas)
-    new TasteGraph(canvas, p)
+    new TasteGraph(canvas, p, { pointRadius: 6, zeroLineWidth: 3 })
   })
 }

--- a/app/javascript/src/typescript/taste_graph.ts
+++ b/app/javascript/src/typescript/taste_graph.ts
@@ -102,8 +102,16 @@ export class TasteGraph implements InteractiveGraph {
   }
 
   private makeChartConfiguration(
-    dataset: Chart.ChartData
+    dataset: Chart.ChartData,
+    config: {
+      pointRadius?: number
+      zeroLineWidth?: number
+    }
   ): Chart.ChartConfiguration {
+    const defaultedConfig = {
+      ...{ pointRadius: 10, zeroLineWidth: 7 },
+      ...config,
+    }
     const margin = 0.2
     const ticks: Chart.TickOptions = {
       display: false,
@@ -115,12 +123,12 @@ export class TasteGraph implements InteractiveGraph {
       drawBorder: true,
       drawTicks: false,
       drawOnChartArea: true,
-      zeroLineWidth: 7,
+      zeroLineWidth: defaultedConfig.zeroLineWidth,
     }
     const options: Chart.ChartOptions = {
       onClick: this.clickable ? this.onClickUpdate : (_event) => {},
       legend: { display: false },
-      elements: { point: { radius: 10 } },
+      elements: { point: { radius: defaultedConfig.pointRadius } },
       scales: {
         xAxes: [
           {
@@ -144,22 +152,23 @@ export class TasteGraph implements InteractiveGraph {
         ],
       },
     }
-    const config: Chart.ChartConfiguration = {
+    const chartConfig: Chart.ChartConfiguration = {
       type: "scatter",
       data: dataset,
       options: options,
     }
-    return config
+    return chartConfig
   }
 
   constructor(
     canvas: HTMLCanvasElement,
     private data: GraphP,
+    config: { pointRadius?: number; zeroLineWidth?: number },
     private clickable: boolean = false,
     private callbackUpdate: (data: GraphP) => void = (_data) => {}
   ) {
     const p = this.makeChartData(toGraphPoint(data))
-    const config = this.makeChartConfiguration(p)
-    this.graph = new Chart(canvas, config)
+    const chartConfig = this.makeChartConfiguration(p, config)
+    this.graph = new Chart(canvas, chartConfig)
   }
 }

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -66,14 +66,13 @@
             </div>
           </div>
         </td>
-        <%# BUG: col-12だと、md未満のとき画面サイズを変えてもグラフが縮まなくなる --%>
-        <td class="col-lg-3 col-md-6 col-11">
+        <td class="col-lg-3 col-6">
           <canvas id="sake-<%= sake.id %>"
                   data-taste-value="<%= sake.taste_value %>"
                   data-aroma-value="<%= sake.aroma_value %>">
           </canvas>
         </td>
-        <td class="col-lg-3 col-md-6 col-12" style="text-align: center">
+        <td class="col-lg-3 col-6" style="text-align: center">
           <%# HACK: セルの縦横比が約2:1、サムネイル画像の縦横比が1:1である。 %>
           <%#       そこで、セルの50%幅を指定することでセルが縦長になるのを防ぐ %>
           <% if sake.photos.any? %>


### PR DESCRIPTION
Issue #121 関係、場合によっては閉じる。

### やったこと

- 酒indexの味香りグラフ・画像をモバイル表示で2段組にした
- 味香りグラフのドットサイズを調整した
  - index/showは小さく、formはそのままに

### やってないこと

- 酒showの味香りグラフのドットを小さくしたが、大きくしたままが大変で諦めた。