### PR TITLE
酒項目の順番を変更

### DIFF
--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -71,6 +71,17 @@
   <% end %>
 
   <div class="sakes-form-row">
+    <%= form.label(:alcohol, { class: "sakes-form-badged-label" }) %>
+    <div class="sakes-form-badge">
+      <span class="badge bg-secondary"><%= t("helpers.badge.obligation") %></span>
+    </div>
+    <div class="sakes-form-short-form">
+      <%= form.number_field(:alcohol,
+                            { step: "any", class: "form-control" }) %>
+    </div>
+  </div>
+
+  <div class="sakes-form-row">
     <%= form.label(:tokutei_meisho, { class: "sakes-form-badged-label" }) %>
     <div class="sakes-form-badge">
       <span class="badge bg-secondary"><%= t("helpers.badge.obligation") %></span>
@@ -137,17 +148,6 @@
     </div>
     <div class="sakes-form-short-form">
       <%= form.number_field(:size, { class: "form-control" }) %>
-    </div>
-  </div>
-
-  <div class="sakes-form-row">
-    <%= form.label(:alcohol, { class: "sakes-form-badged-label" }) %>
-    <div class="sakes-form-badge">
-      <span class="badge bg-secondary"><%= t("helpers.badge.obligation") %></span>
-    </div>
-    <div class="sakes-form-short-form">
-      <%= form.number_field(:alcohol,
-                            { step: "any", class: "form-control" }) %>
     </div>
   </div>
 
@@ -223,6 +223,18 @@
   </div>
 
   <div class="sakes-form-row">
+    <%= form.label(:warimizu, { class: "sakes-form-label" }) %>
+    <div class="sakes-form-short-form">
+      <%= form.select(:warimizu,
+                      Sake.warimizus_i18n.keys.map do |k|
+                        [I18n.t("enums.sake.warimizu.#{k}"), k]
+                      end,
+                      {},
+                      { class: "form-select" }) %>
+    </div>
+  </div>
+
+  <div class="sakes-form-row">
     <%= form.label(:season, { class: "sakes-form-label" }) %>
     <div class="col">
       <%= form.text_field(:season, { class: "form-control" }) %>
@@ -247,18 +259,6 @@
     <%= form.label(:aminosando, { class: "sakes-form-label" }) %>
     <div class="sakes-form-short-form">
       <%= form.number_field(:aminosando, { step: "any", class: "form-control" }) %>
-    </div>
-  </div>
-
-  <div class="sakes-form-row">
-    <%= form.label(:warimizu, { class: "sakes-form-label" }) %>
-    <div class="sakes-form-short-form">
-      <%= form.select(:warimizu,
-                      Sake.warimizus_i18n.keys.map do |k|
-                        [I18n.t("enums.sake.warimizu.#{k}"), k]
-                      end,
-                      {},
-                      { class: "form-select" }) %>
     </div>
   </div>
 

--- a/app/views/sakes/show.html.erb
+++ b/app/views/sakes/show.html.erb
@@ -39,10 +39,17 @@
       <% @sake.photos.each do |photo| %>
         <div class="col-lg-4 col-6">
           <%= link_to(cl_image_tag(photo.image.thumb.url, { class: "img-thumbnail" }),
-           photo.image.url) %>
+                      photo.image.url) %>
         </div>
       <% end %>
     </div>
+  </div>
+
+  <div class="sakes-show-label">
+    <b><%= Sake.human_attribute_name(:alcohol) %></b>
+  </div>
+  <div class="sakes-show-body">
+    <%= empty_to_default(@sake.alcohol, "-") %>
   </div>
 
   <div class="sakes-show-label">
@@ -78,13 +85,6 @@
   </div>
   <div class="sakes-show-body">
     <%= empty_to_default(@sake.size, "-") %> ml
-  </div>
-
-  <div class="sakes-show-label">
-    <b><%= Sake.human_attribute_name(:alcohol) %></b>
-  </div>
-  <div class="sakes-show-body">
-    <%= empty_to_default(@sake.alcohol, "-") %>
   </div>
 
   <div class="sakes-show-label">
@@ -145,6 +145,13 @@
   </div>
 
   <div class="sakes-show-label">
+    <b><%= Sake.human_attribute_name(:warimizu) %></b>
+  </div>
+  <div class="sakes-show-body">
+    <%= @sake.warimizu_i18n %>
+  </div>
+
+  <div class="sakes-show-label">
     <b><%= Sake.human_attribute_name(:season) %></b>
   </div>
   <div class="sakes-show-body">
@@ -170,13 +177,6 @@
   </div>
   <div class="sakes-show-body">
     <%= empty_to_default(@sake.aminosando, "-") %>
-  </div>
-
-  <div class="sakes-show-label">
-    <b><%= Sake.human_attribute_name(:warimizu) %></b>
-  </div>
-  <div class="sakes-show-body">
-    <%= @sake.warimizu_i18n %>
   </div>
 
   <div class="sakes-show-label">


### PR DESCRIPTION
close #168

### やったこと

- 実際の酒瓶ラベルで度数は先にくることが多いため、度数フォームを最初のほうに移動した。
- 加水については、前火入れ・貯蔵や加水・後火入れ、の順のため火入れの後に配置した。

### その他

- show画面かっこよくしたいね。indexの表と合ってる雰囲気のviewをかっこよくしたい。