### PR TITLE
elasticsearchを動くようにした

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Install build tools, posgresql-client, yarn and node
 RUN apt-get update -qq && \
     DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
-    curl=7.64.* build-essential=12.6 gnupg2=2.2.* imagemagick=8:6.9.* && \
+    curl=7.64.* build-essential=12.6 gnupg2=2.2.* imagemagick=8:6.9.* git=1:2.20.* && \
     apt-get clean && \
     rm -rf /var/cache/apt/archives/* && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Install build tools, posgresql-client, yarn and node
 RUN apt-get update -qq && \
     DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
-    curl=7.64.* build-essential=12.6 gnupg2=2.2.* imagemagick=8:6.9.* git=1:2.20.* && \
+    curl=7.64.* build-essential=12.6 gnupg2=2.2.* imagemagick=8:6.9.* \
+    git=1:2.20.* && \
     apt-get clean && \
     rm -rf /var/cache/apt/archives/* && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \

--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ gem "era_ja"
 
 # ElasticSearch
 gem "bonsai-elasticsearch-rails"
-gem "elasticsearch-model"
+gem "elasticsearch-model", github: "indirect/elasticsearch-rails"
 gem "elasticsearch-rails"
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: https://github.com/indirect/elasticsearch-rails.git
+  revision: 20efbf2ca6a4d310b3e11638334d85017d923ffe
+  specs:
+    elasticsearch-model (7.1.0)
+      activesupport (> 3)
+      elasticsearch (~> 7)
+      hashie
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -135,10 +144,6 @@ GEM
       elasticsearch-transport (= 7.13.1)
     elasticsearch-api (7.13.1)
       multi_json
-    elasticsearch-model (7.1.1)
-      activesupport (> 3)
-      elasticsearch (> 1)
-      hashie
     elasticsearch-rails (7.1.1)
     elasticsearch-transport (7.13.1)
       faraday (~> 1)
@@ -426,7 +431,7 @@ DEPENDENCIES
   devise
   devise-i18n
   dotenv-rails
-  elasticsearch-model
+  elasticsearch-model!
   elasticsearch-rails
   enum_help
   era_ja

--- a/app/views/elasticsearch/index.html.erb
+++ b/app/views/elasticsearch/index.html.erb
@@ -1,18 +1,22 @@
 <h2><%= link_to(t("views.elasticsearch.title"), elasticsearch_path, { class: "text-dark" }) %></h2>
 
-<%= form_with({ scope: :elasticsearch,
-                url: elasticsearch_path,
-                method: :get,
-                local: true,
-                class: "form-inline my-1", }) do |f| %>
-  <%= f.label("search", class: "sr-only") %>
-  <%= f.text_field(:word,
-                   { placeholder: "Keyword",
-                     value: params.dig(:elasticsearch, :word),
-                     class: "form-control mr-sm-2", }) %>
-  <%= button_tag(type: :submit, class: "btn btn-secondary") do %>
-    <%= bootstrap_icon("search") %>
-  <% end %>
+<%= form_with( scope: :elasticsearch,
+               url: elasticsearch_path,
+               method: :get,
+               local: true,
+               class: "row my-1",) do |f| %>
+  <div class="col-auto">
+    <%= f.label("search", class: "visually-hidden") %>
+    <%= f.text_field(:word,
+                    { placeholder: "Keyword",
+                      value: params.dig(:elasticsearch, :word),
+                      class: "form-control mr-sm-2", }) %>
+  </div>
+  <div class="col-auto">
+    <%= button_tag(type: :submit, class: "btn btn-secondary") do %>
+      <%= tag.i(class: "bi-search") %>
+    <% end %>
+  </div>
 <% end %>
 
 <% @sakes.each do |sake| %>

--- a/app/views/elasticsearch/index.html.erb
+++ b/app/views/elasticsearch/index.html.erb
@@ -1,16 +1,15 @@
-<h2><%= link_to(t("views.elasticsearch.title"), elasticsearch_path, { class: "text-dark" }) %></h2>
+<h2><%= t("views.elasticsearch.title") %></h2>
 
-<%= form_with( scope: :elasticsearch,
-               url: elasticsearch_path,
-               method: :get,
-               local: true,
-               class: "row my-1",) do |f| %>
+<%= form_with(scope: :elasticsearch,
+              url: elasticsearch_path,
+              method: :get,
+              local: true,
+              class: "row my-1",) do |f| %>
   <div class="col-auto">
-    <%= f.label("search", class: "visually-hidden") %>
+  <%= f.label(:word, { class: "form-label visually-hidden" }) %>
     <%= f.text_field(:word,
-                    { placeholder: "Keyword",
-                      value: params.dig(:elasticsearch, :word),
-                      class: "form-control mr-sm-2", }) %>
+                    { value: params.dig(:elasticsearch, :word),
+                      class: "form-control", }) %>
   </div>
   <div class="col-auto">
     <%= button_tag(type: :submit, class: "btn btn-secondary") do %>

--- a/app/views/elasticsearch/index.html.erb
+++ b/app/views/elasticsearch/index.html.erb
@@ -6,10 +6,10 @@
               local: true,
               class: "row my-1",) do |f| %>
   <div class="col-auto">
-  <%= f.label(:word, { class: "form-label visually-hidden" }) %>
+    <%= f.label(:word, { class: "form-label visually-hidden" }) %>
     <%= f.text_field(:word,
-                    { value: params.dig(:elasticsearch, :word),
-                      class: "form-control", }) %>
+                     { value: params.dig(:elasticsearch, :word),
+                       class: "form-control", }) %>
   </div>
   <div class="col-auto">
     <%= button_tag(type: :submit, class: "btn btn-secondary") do %>


### PR DESCRIPTION
#224 が動かなかったので修正した

e3d62a8
bootstrap5化によるviewの変更を忘れていたので対応した。

24e3117
[elasticsearch-rails](https://github.com/elastic/elasticsearch-rails)が現状ruby3対応しておらず、DBのデータをelasticsearch側にimportするときにエラーが起こる。[修正のプルリク](https://github.com/elastic/elasticsearch-rails/pull/992)は出ていたがreleaseがいつになるかは不明。https://github.com/elastic/elasticsearch-rails/issues/989#issuecomment-826519648 で、せっかちな人はこうしてねと書かれていた方法に従った。
githubのリポジトリを指定しgemをダウンロードするため、docker環境にもgitをインストールした。

