### PR TITLE
日本酒の在庫量を表示するようにした

### DIFF
--- a/app/helpers/sakes_helper.rb
+++ b/app/helpers/sakes_helper.rb
@@ -53,10 +53,18 @@ module SakesHelper
   #   to_shakkan(300) #=> "1合"
   # @example 石より大きな単位はないため、10石を越えても新たな単位はつかない
   #   to_shakkan(2_222_100) #=> "12石3斗4升5合"
+  # @example 1斗ぴったりでは升や合は省略される
+  #   to_shakkan(18000) #=> "1斗"
+  # @example 0には合をつけて返す
+  #   to_shakkan(0) #=> "0合"
   # @param [Integer] amount 酒の量[ml]
   # @return [String] 尺貫法の体積で表した酒量の文字列
   def to_shakkan(amount)
-    (amount / 180).to_s.reverse.each_char.zip(UNITS).reverse.join
+    if amount == 0
+      "0合"
+    else
+      (amount / 180).to_s.reverse.each_char.zip(UNITS).filter { |value, _| value != "0" }.reverse.join
+    end
   end
 
   private_constant :UNITS

--- a/app/helpers/sakes_helper.rb
+++ b/app/helpers/sakes_helper.rb
@@ -57,10 +57,12 @@ module SakesHelper
   #   to_shakkan(18000) #=> "1斗"
   # @example 0には合をつけて返す
   #   to_shakkan(0) #=> "0合"
+  # @example 180ml未満は0合を返す
+  #   to_shakkan(100) #=> "0合"
   # @param [Integer] amount 酒の量[ml]
   # @return [String] 尺貫法の体積で表した酒量の文字列
   def to_shakkan(amount)
-    if amount == 0
+    if amount < 180
       "0合"
     else
       (amount / 180).to_s.reverse.each_char.zip(UNITS).filter { |value, _| value != "0" }.reverse.join

--- a/app/helpers/sakes_helper.rb
+++ b/app/helpers/sakes_helper.rb
@@ -42,6 +42,9 @@ module SakesHelper
     -1
   end
 
+  # @type [Array<String>]
+  UNITS = %w[合 升 斗 石]
+
   # 酒の量[ml]を尺貫法の体積にした文字列で返す
   #
   # @example 4500 mlは2升5合
@@ -56,6 +59,5 @@ module SakesHelper
     (amount / 180).to_s.reverse.each_char.zip(UNITS).reverse.join
   end
 
-  private
-  UNITS = %w[合 升 斗 石]
+  private_constant :UNITS
 end

--- a/app/helpers/sakes_helper.rb
+++ b/app/helpers/sakes_helper.rb
@@ -41,4 +41,21 @@ module SakesHelper
   def bottom_bottle
     -1
   end
+
+  # 酒の量[ml]を尺貫法の体積にした文字列で返す
+  #
+  # @example 4500 mlは2升5合
+  #   to_shakkan(4500) #=> "2升5合"
+  # @example 300 mlのような数は端数切り捨てされて1合になる
+  #   to_shakkan(300) #=> "1合"
+  # @example 石より大きな単位はないため、10石を越えても新たな単位はつかない
+  #   to_shakkan(2_222_100) #=> "12石3斗4升5合"
+  # @param [Integer] amount 酒の量[ml]
+  # @return [String] 尺貫法の体積で表した酒量の文字列
+  def to_shakkan(amount)
+    (amount / 180).to_s.reverse.each_char.zip(UNITS).reverse.join
+  end
+
+  private
+  UNITS = %w[合 升 斗 石]
 end

--- a/app/models/sake.rb
+++ b/app/models/sake.rb
@@ -138,4 +138,17 @@ class Sake < ApplicationRecord
   def unimpressed?
     self.taste_value.nil? && self.aroma_value.nil?
   end
+
+  # 残っている酒の総量をmlで返す
+  #
+  # 開封済みのお酒は瓶の半量が残っているとして概算する。
+  # @param [Boolean] include_empty trueなら飲んだ分も含めた総量を計算する
+  # @return [Integer] 酒の総量[ml]
+  def self.alcohol_stock(include_empty: false)
+    if include_empty
+      all.sum(:size)
+    else
+      where(bottle_level: "sealed").sum(:size) + where(bottle_level: "opened").sum(:size) / 2
+    end
+  end
 end

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -1,4 +1,5 @@
-<h2><%= "#{t('.title')} - #{to_shakkan(Sake.alcohol_stock)}" %></h2>
+<% include_empty = params.dig(:q, :bottle_level_not_eq) == bottom_bottle.to_s %>
+<h2><%= "#{t('.title')} - #{to_shakkan(Sake.alcohol_stock(include_empty: include_empty))}" %></h2>
 
 <%= render("float-button") %>
 

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -1,4 +1,4 @@
-<h2><%= t(".title") %></h2>
+<h2><%= "#{t('.title')} - #{to_shakkan(Sake.alcohol_stock)}" %></h2>
 
 <%= render("float-button") %>
 

--- a/spec/helpers/sakes_helper_spec.rb
+++ b/spec/helpers/sakes_helper_spec.rb
@@ -101,5 +101,9 @@ RSpec.describe SakesHelper, type: :helper do
     it "returns zero with Go" do
       expect(to_shakkan(0)).to eq("0合")
     end
+
+    it "returns zero Go with argument less than 180" do
+      expect(to_shakkan(100)).to eq ("0合")
+    end
   end
 end

--- a/spec/helpers/sakes_helper_spec.rb
+++ b/spec/helpers/sakes_helper_spec.rb
@@ -93,5 +93,13 @@ RSpec.describe SakesHelper, type: :helper do
     it "returns value without new unit over 10 Koku" do
       expect(to_shakkan(2_222_100)).to eq("12石3斗4升5合")
     end
+
+    it "returns without the not beggiest zero" do
+      expect(to_shakkan(18000)).to eq("1斗")
+    end
+
+    it "returns zero with Go" do
+      expect(to_shakkan(0)).to eq("0合")
+    end
   end
 end

--- a/spec/helpers/sakes_helper_spec.rb
+++ b/spec/helpers/sakes_helper_spec.rb
@@ -80,4 +80,18 @@ RSpec.describe SakesHelper, type: :helper do
       expect(bottom_bottle).to eq(-1)
     end
   end
+
+  describe "to_shakkan" do
+    it "returns value by Shakkan" do
+      expect(to_shakkan(4500)).to eq("2升5合")
+    end
+
+    it "truncates and returns value" do
+      expect(to_shakkan(300)).to eq("1合")
+    end
+
+    it "returns value without new unit over 10 Koku" do
+      expect(to_shakkan(2_222_100)).to eq("12石3斗4升5合")
+    end
+  end
 end

--- a/spec/models/sake_spec.rb
+++ b/spec/models/sake_spec.rb
@@ -56,9 +56,9 @@ RSpec.describe Sake, type: :model do
     end
   end
 
-  let(:sealed_sake) { FactoryBot.create(:sake, bottle_level: "sealed") }
-  let(:opened_sake) { FactoryBot.create(:sake, bottle_level: "opened") }
-  let(:impressed_sake) { FactoryBot.create(:sake, bottle_level: "opened", aroma_value: 1, taste_value: 2) }
+  let!(:sealed_sake) { FactoryBot.create(:sake, bottle_level: "sealed", size: 720) }
+  let!(:opened_sake) { FactoryBot.create(:sake, bottle_level: "opened", size: 1800) }
+  let!(:impressed_sake) { FactoryBot.create(:sake, bottle_level: "opened", aroma_value: 1, taste_value: 2, size: 1800) }
 
   describe "check sealed" do
     it "returns true" do
@@ -84,6 +84,16 @@ RSpec.describe Sake, type: :model do
     end
     it "returns false" do
       expect(impressed_sake.unimpressed?).to be_falsy
+    end
+  end
+
+  describe "alcohol stock" do
+    it "returns 2520" do
+      expect(Sake.alcohol_stock).to eq(2520)
+    end
+
+    it "returns 4320 including empty bottle" do
+      expect(Sake.alcohol_stock(include_empty: true)).to eq(4320)
     end
   end
 end


### PR DESCRIPTION
### やったこと

- 日本酒の量を尺貫法で酒indexに表示した
  - これで在庫が一瞬で丸わかり
  - 買いすぎも飲みすぎも防げるね
- 開封済みの酒瓶は半量を計算することにし、ざっくり計算にした。

![Uploading image.png…]()

### びこー

- ここに表記でいいのか？