### PR TITLE
検索文字列と検索ボタンをinput-group化してまとめた

### DIFF
--- a/app/views/elasticsearch/index.html.erb
+++ b/app/views/elasticsearch/index.html.erb
@@ -6,15 +6,15 @@
               local: true,
               class: "row my-1",) do |f| %>
   <div class="col-auto">
-    <%= f.label(:word, { class: "form-label visually-hidden" }) %>
-    <%= f.text_field(:word,
-                     { value: params.dig(:elasticsearch, :word),
-                       class: "form-control", }) %>
-  </div>
-  <div class="col-auto">
-    <%= button_tag(type: :submit, class: "btn btn-secondary") do %>
-      <%= tag.i(class: "bi-search") %>
-    <% end %>
+    <div class="input-group">
+      <%= f.label(:word, "search word", { class: "form-label visually-hidden" }) %>
+      <%= f.text_field(:word,
+                       { value: params.dig(:elasticsearch, :word),
+                         class: "form-control", }) %>
+      <%= tag.button(tag.i(class: "bi-search"),
+                     type: "submit",
+                     class: "input-group-text btn btn-secondary") %>
+    </div>
   </div>
 <% end %>
 

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -19,7 +19,8 @@
       <%= f.check_box(:bottle_level_not_eq,
                       { class: "form-check-input",
                         id: "all_bottle_level",
-                        "data-testid": "check_empty_bottle", },
+                        "data-testid": "check_empty_bottle",
+                        onChange: "this.form.submit()", },
                       bottom_bottle,
                       Sake.bottle_levels["empty"]) %>
       <%= f.label(t(".all_bottles"),

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -4,11 +4,16 @@
 <%= render("float-button") %>
 
 <%= search_form_for(@searched, { class: "row my-2 align-items-center" }) do |f| %>
-  <div class="col">
+  <div class="col input-group">
+    <%= f.label(:all_text_cont, "search word", class: "form-label visually-hidden") %>
     <%= f.search_field(:all_text_cont,
                        { class: "form-control",
                          value: params.dig(:q, :all_text_cont), }) %>
+    <%= tag.button(tag.i(class: "bi-search"),
+                   type: "submit",
+                   class: "input-group-text btn btn-secondary", "data-testid": "submit_search") %>
   </div>
+
   <div class="col-auto">
     <div class="form-check form-switch">
       <%= f.check_box(:bottle_level_not_eq,
@@ -21,9 +26,6 @@
                   { class: "form-check-label",
                     for: "all_bottle_level", }) %>
     </div>
-  </div>
-  <div class="col-auto">
-    <%= f.submit({ class: "btn btn-secondary", "data-testid": "submit_search" }) %>
   </div>
 
   <div class="col-md mt-md-0 col-12 mt-2">


### PR DESCRIPTION
近接デザイン、関係あるものは近くに。

### スクリーンショット

![image](https://user-images.githubusercontent.com/849256/125050653-1f275e00-e0dd-11eb-9314-36116b569c6b.png)
![image](https://user-images.githubusercontent.com/849256/125050681-26e70280-e0dd-11eb-9273-58791c27c5a4.png)

### やったこと

- 検索フォームをinput-group化
- ついでに空き瓶スイッチを即時反映化した
  - スイッチはステータスが即時反映されるべき、そう人間は思っている