### PR TITLE
Indexで開封する・空にするボタンを押したあとIndexにリダイレクトするようにした

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,16 +18,6 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  # flashメッセージ内に表示するリンクを生成する
-  # @example
-  #   alert_link_tag("text","path/to/somewhere") #=> "<a class="alert-link" href="path/to/somewhere">text</a>"
-  # @param text [String] 表示するテキスト
-  # @param path [String] リンクするパス
-  # @return [String] アンカーリンク
-  def alert_link_tag(text, path)
-    view_context.link_to(text, path, { class: "alert-link" })
-  end
-
   private
 
   # 下記すべての条件を満たすとき、ユーザーが居たパスを保存してよいと判定する。

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,6 +18,13 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  # flashメッセージ内に表示するリンクを生成する
+  # @param text [String]
+  # @param path [String]
+  def alert_link_tag(text, path)
+    view_context.link_to(text, path, { class: "alert-link" })
+  end
+
   private
 
   # 下記すべての条件を満たすとき、ユーザーが居たパスを保存してよいと判定する。

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,8 +19,11 @@ class ApplicationController < ActionController::Base
   end
 
   # flashメッセージ内に表示するリンクを生成する
-  # @param text [String]
-  # @param path [String]
+  # @example
+  #   alert_link_tag("text","path/to/somewhere") #=> "<a class="alert-link" href="path/to/somewhere">text</a>"
+  # @param text [String] 表示するテキスト
+  # @param path [String] リンクするパス
+  # @return [String] アンカーリンク
   def alert_link_tag(text, path)
     view_context.link_to(text, path, { class: "alert-link" })
   end

--- a/app/controllers/sakes_controller.rb
+++ b/app/controllers/sakes_controller.rb
@@ -62,7 +62,7 @@ class SakesController < ApplicationController
         store_photos
         format.html {
           redirect_to(@sake)
-          flash[:success] = t("controllers.sake.success.create", name: @sake.name)
+          flash[:success] = t("controllers.sake.success.create", name: alert_link_tag(@sake.name, sake_path(@sake)))
         }
       else
         format.html { render(:new) }

--- a/app/controllers/sakes_controller.rb
+++ b/app/controllers/sakes_controller.rb
@@ -62,7 +62,7 @@ class SakesController < ApplicationController
         store_photos
         format.html {
           redirect_to(@sake)
-          flash[:notice] = t("controllers.sake.success.create", name: @sake.name)
+          flash[:success] = t("controllers.sake.success.create", name: @sake.name)
         }
       else
         format.html { render(:new) }
@@ -79,7 +79,7 @@ class SakesController < ApplicationController
         store_photos
         format.html {
           redirect_after_update
-          flash[:notice] = t("controllers.sake.success.update", name: alert_link_tag(@sake.name, sake_path(@sake)))
+          flash[:success] = t("controllers.sake.success.update", name: alert_link_tag(@sake.name, sake_path(@sake)))
         }
       else
         format.html { render(:edit) }
@@ -95,7 +95,7 @@ class SakesController < ApplicationController
     respond_to do |format|
       format.html {
         redirect_to(sakes_url)
-        flash[:notice] = t("controllers.sake.success.destroy", name: deleted_name)
+        flash[:success] = t("controllers.sake.success.destroy", name: deleted_name)
       }
     end
   end

--- a/app/controllers/sakes_controller.rb
+++ b/app/controllers/sakes_controller.rb
@@ -187,7 +187,7 @@ class SakesController < ApplicationController
 
   # @return [Boolean] 編集画面からUpdateが行われた
   def update_from_edit?
-    request.referer && request.referer.match?("\/sakes/.*\/edit")
+    request.referer && request.referer.match?("\/sakes\/[0-9]+\/edit")
   end
 end
 

--- a/app/controllers/sakes_controller.rb
+++ b/app/controllers/sakes_controller.rb
@@ -174,9 +174,10 @@ class SakesController < ApplicationController
   end
 
   # update後のリダイレクト処理
-  # 編集画面からupdateする場合: 詳細ページにリダイレクト
-  # HTTP_REFERERが設定されていない場合: 詳細ページにリダイレクト
-  # 上記のどちらにも当てはまらない場合: ユーザーが直前にいたページにリダイレクト
+  #
+  # 編集画面からupdateする場合、詳細ページにリダイレクトする。
+  # HTTP_REFERERが設定されていない場合、詳細ページにリダイレクトする。
+  # 上記のどちらにも当てはまらない場合、ユーザーが直前にいたページにリダイレクトする。
   def redirect_after_update
     if update_from_edit?
       redirect_to(@sake)
@@ -185,7 +186,7 @@ class SakesController < ApplicationController
     end
   end
 
-  # @return [Boolean] 編集画面からUpdateが行われた
+  # @return [Boolean] 編集画面からUpdateが行われたらtrueを返す
   def update_from_edit?
     request.referer && request.referer.match?("\/sakes\/[0-9]+\/edit")
   end

--- a/app/controllers/sakes_controller.rb
+++ b/app/controllers/sakes_controller.rb
@@ -74,7 +74,10 @@ class SakesController < ApplicationController
       if @sake.update(sake_params)
         delete_photos
         store_photos
-        format.html { redirect_to(@sake, notice: t("controllers.sake.success.update")) }
+        format.html {
+          redirect_after_update
+          flash[:notice] = t("controllers.sake.success.update")
+        }
       else
         format.html { render(:edit) }
       end
@@ -161,6 +164,23 @@ class SakesController < ApplicationController
     @sake.photos.each do |photo|
       photo.destroy if params[photo.chackbox_name] == "delete"
     end
+  end
+
+  # update後のリダイレクト処理
+  # 編集画面からupdateする場合: 詳細ページにリダイレクト
+  # HTTP_REFERERが設定されていない場合: 詳細ページにリダイレクト
+  # 上記のどちらにも当てはまらない場合: ユーザーが直前にいたページにリダイレクト
+  def redirect_after_update
+    if update_from_edit?
+      redirect_to(@sake)
+    else
+      redirect_back(fallback_location: @sake)
+    end
+  end
+
+  # @return [Boolean] 編集画面からUpdateが行われた
+  def update_from_edit?
+    request.referer && request.referer.match?("\/sakes/.*\/edit")
   end
 end
 

--- a/app/controllers/sakes_controller.rb
+++ b/app/controllers/sakes_controller.rb
@@ -60,7 +60,10 @@ class SakesController < ApplicationController
     respond_to do |format|
       if @sake.save
         store_photos
-        format.html { redirect_to(@sake, notice: t("controllers.sake.success.create")) }
+        format.html {
+          redirect_to(@sake)
+          flash[:notice] = t("controllers.sake.success.create", name: @sake.name)
+        }
       else
         format.html { render(:new) }
       end
@@ -76,7 +79,7 @@ class SakesController < ApplicationController
         store_photos
         format.html {
           redirect_after_update
-          flash[:notice] = t("controllers.sake.success.update")
+          flash[:notice] = t("controllers.sake.success.update", name: alert_link_tag(@sake.name, sake_path(@sake)))
         }
       else
         format.html { render(:edit) }
@@ -87,9 +90,13 @@ class SakesController < ApplicationController
   # DELETE /sakes/1
   # DELETE /sakes/1.json
   def destroy
+    deleted_name = @sake.name
     @sake.destroy
     respond_to do |format|
-      format.html { redirect_to(sakes_url, notice: t("controllers.sake.success.destroy")) }
+      format.html {
+        redirect_to(sakes_url)
+        flash[:notice] = t("controllers.sake.success.destroy", name: deleted_name)
+      }
     end
   end
 

--- a/app/controllers/sakes_controller.rb
+++ b/app/controllers/sakes_controller.rb
@@ -190,6 +190,16 @@ class SakesController < ApplicationController
   def update_from_edit?
     request.referer && request.referer.match?("\/sakes\/[0-9]+\/edit")
   end
+
+  # flashメッセージ内に表示するリンクを生成する
+  # @example
+  #   alert_link_tag("text","path/to/somewhere") #=> "<a class="alert-link" href="path/to/somewhere">text</a>"
+  # @param text [String] 表示するテキスト
+  # @param path [String] リンクするパス
+  # @return [String] アンカーリンク
+  def alert_link_tag(text, path)
+    view_context.link_to(text, path, { class: "alert-link" })
+  end
 end
 
 # rubocop:enable Metrics/ClassLength

--- a/app/views/layouts/_flashes.html.erb
+++ b/app/views/layouts/_flashes.html.erb
@@ -1,7 +1,7 @@
 <% flash.each do |message_type, message| %>
   <%# timedoutのときだけdeviseが意味のない0メッセージを生成するため飛ばす %>
   <% next if message_type == "timedout" %>
-  <div class="alert alert-<%= bootstrap_alert(message_type) %>" data-testid="alert">
+  <div class="alert alert-<%= bootstrap_alert(message_type) %>" data-testid="flash-message">
     <%= sanitize(message) %>
   </div>
 <% end %>

--- a/app/views/layouts/_flashes.html.erb
+++ b/app/views/layouts/_flashes.html.erb
@@ -1,5 +1,7 @@
 <% flash.each do |message_type, message| %>
   <%# timedoutのときだけdeviseが意味のない0メッセージを生成するため飛ばす %>
   <% next if message_type == "timedout" %>
-  <div class="alert alert-<%= bootstrap_alert(message_type) %>"><%= message %></div>
+  <div class="alert alert-<%= bootstrap_alert(message_type) %>" data-testid="alert">
+    <%= sanitize(message) %>
+  </div>
 <% end %>

--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -342,7 +342,7 @@
 
   <div class="sakes-form-row mt-2 justify-content-center">
     <div class="col-auto">
-      <%= form.submit(class: "btn btn-primary mx-3", "data-testid": "submit") %>
+      <%= form.submit(class: "btn btn-primary mx-3", "data-testid": "form-submit") %>
     </div>
   </div>
 

--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -16,7 +16,7 @@
       <span class="badge bg-primary"><%= t(".badge.presence") %></span>
     </div>
     <div class="col">
-      <%= form.text_field(:name, { class: "form-control" }) %>
+      <%= form.text_field(:name, { class: "form-control", "data-testid": "name-textfield" }) %>
     </div>
   </div>
 

--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -342,7 +342,7 @@
 
   <div class="sakes-form-row mt-2 justify-content-center">
     <div class="col-auto">
-      <%= form.submit(class: "btn btn-primary mx-3") %>
+      <%= form.submit(class: "btn btn-primary mx-3", "data-testid": "submit") %>
     </div>
   </div>
 

--- a/app/views/sakes/show.html.erb
+++ b/app/views/sakes/show.html.erb
@@ -13,7 +13,7 @@
   <div class="sakes-show-label">
     <b><%= Sake.human_attribute_name(:name) %></b>
   </div>
-  <div class="sakes-show-body">
+  <div class="sakes-show-body" data-testid="sake-name">
     <%= @sake.name %>
   </div>
 

--- a/config/locales/controllers/application.ja.yml
+++ b/config/locales/controllers/application.ja.yml
@@ -4,6 +4,6 @@ ja:
       permission_denied: 権限がありません。
     sake:
       success:
-        create: "%{name}を登録しました。"
-        update: "%{name}を更新しました。"
-        destroy: "%{name}を削除しました。"
+        create: "%{name} を登録しました。"
+        update: "%{name} を更新しました。"
+        destroy: "%{name} を削除しました。"

--- a/config/locales/controllers/application.ja.yml
+++ b/config/locales/controllers/application.ja.yml
@@ -4,6 +4,6 @@ ja:
       permission_denied: 権限がありません。
     sake:
       success:
-        create: 作成成功しました。
-        update: 更新成功しました。
-        destroy: 削除成功しました。
+        create: "%{name}を登録しました。"
+        update: "%{name}を更新しました。"
+        destroy: "%{name}を削除しました。"

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -36,3 +36,10 @@ end
 def wait_for_page(page_path)
   find(:test_id, page_path, visible: false)
 end
+
+# alertが表示されるまで待つ
+#
+# ユーザーが現在いるページにリダイレクトされたとき、何らかのアラートが表示されるまで待つ。
+def wait_for_alert
+  find(".alert")
+end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -41,5 +41,5 @@ end
 #
 # ユーザーが現在いるページにリダイレクトされたとき、何らかのアラートが表示されるまで待つ。
 def wait_for_alert
-  find(".alert")
+  find(:test_id, "flash-message")
 end

--- a/spec/system/drink_buttons_spec.rb
+++ b/spec/system/drink_buttons_spec.rb
@@ -189,9 +189,10 @@ RSpec.describe "DrinkButtons", type: :system do
         accept_confirm do
           click_link "open-button-#{sealed_sake.id}"
         end
+        wait_for_alert
       end
 
-      it "redirects to index page" do
+      it "reloads index page" do
         expect(page).to have_current_path(sakes_path)
       end
 
@@ -199,13 +200,12 @@ RSpec.describe "DrinkButtons", type: :system do
         expect(page).to have_css(".alert-success")
       end
 
-      it "has link to the updated sake" do
+      it "has flash message containing link to updated sake" do
         expect(find(:test_id, "alert")).to have_link(sealed_sake.name, href: sake_path(sealed_sake.id))
       end
 
       it "updates sake to opened" do
         expect {
-          wait_for_alert
           sealed_sake.reload
         }.to change(sealed_sake, :bottle_level).from("sealed").to("opened")
       end
@@ -216,9 +216,10 @@ RSpec.describe "DrinkButtons", type: :system do
         accept_confirm do
           click_link "empty-button-#{impressed_sake.id}"
         end
+        wait_for_alert
       end
 
-      it "redirects to index page" do
+      it "reloads to index page" do
         expect(page).to have_current_path(sakes_path)
       end
 
@@ -226,13 +227,12 @@ RSpec.describe "DrinkButtons", type: :system do
         expect(page).to have_css(".alert-success")
       end
 
-      it "has link to the updated sake" do
+      it "has flash message containing link to updated sake" do
         expect(find(:test_id, "alert")).to have_link(impressed_sake.name, href: sake_path(impressed_sake.id))
       end
 
       it "updates sake to empty" do
         expect {
-          wait_for_alert
           impressed_sake.reload
         }.to change(impressed_sake, :bottle_level).from("opened").to("empty")
       end

--- a/spec/system/drink_buttons_spec.rb
+++ b/spec/system/drink_buttons_spec.rb
@@ -201,7 +201,7 @@ RSpec.describe "DrinkButtons", type: :system do
       end
 
       it "has flash message containing link to updated sake" do
-        expect(find(:test_id, "alert")).to have_link(sealed_sake.name, href: sake_path(sealed_sake.id))
+        expect(find(:test_id, "flash-message")).to have_link(sealed_sake.name, href: sake_path(sealed_sake.id))
       end
 
       it "updates sake to opened" do
@@ -228,7 +228,7 @@ RSpec.describe "DrinkButtons", type: :system do
       end
 
       it "has flash message containing link to updated sake" do
-        expect(find(:test_id, "alert")).to have_link(impressed_sake.name, href: sake_path(impressed_sake.id))
+        expect(find(:test_id, "flash-message")).to have_link(impressed_sake.name, href: sake_path(impressed_sake.id))
       end
 
       it "updates sake to empty" do

--- a/spec/system/drink_buttons_spec.rb
+++ b/spec/system/drink_buttons_spec.rb
@@ -185,13 +185,27 @@ RSpec.describe "DrinkButtons", type: :system do
     end
 
     describe "clicking open button of sealed bottle", js: true do
+      before do
+        accept_confirm do
+          click_link "open-button-#{sealed_sake.id}"
+        end
+      end
+
+      it "redirects to index page" do
+        expect(page).to have_current_path(sakes_path)
+      end
+
+      it "has success flash message" do
+        expect(page).to have_css(".alert-success")
+      end
+
+      it "has link to the updated sake" do
+        expect(find(:test_id, "alert")).to have_link(sealed_sake.name, href: sake_path(sealed_sake.id))
+      end
+
       it "updates sake to opened" do
         expect {
-          id = "open-button-#{sealed_sake.id}"
-          accept_confirm do
-            click_link id
-          end
-          wait_for_page sake_path(sealed_sake.id)
+          wait_for_alert
           sealed_sake.reload
         }.to change(sealed_sake, :bottle_level).from("sealed").to("opened")
       end
@@ -204,17 +218,21 @@ RSpec.describe "DrinkButtons", type: :system do
         end
       end
 
-      it "moves to sake show page" do
-        expect(page).to have_current_path sake_path(impressed_sake.id)
+      it "redirects to index page" do
+        expect(page).to have_current_path(sakes_path)
       end
 
       it "has success flash message" do
         expect(page).to have_css(".alert-success")
       end
 
+      it "has link to the updated sake" do
+        expect(find(:test_id, "alert")).to have_link(impressed_sake.name, href: sake_path(impressed_sake.id))
+      end
+
       it "updates sake to empty" do
         expect {
-          wait_for_page sake_path(impressed_sake.id)
+          wait_for_alert
           impressed_sake.reload
         }.to change(impressed_sake, :bottle_level).from("opened").to("empty")
       end

--- a/spec/system/sake_create_spec.rb
+++ b/spec/system/sake_create_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe "AfterUpdateAction", type: :system do
+  let(:user) { FactoryBot.create(:user) }
+  let(:sake_name) { "とても美味しいお酒" }
+
+  describe "create sake" do
+    before do
+      sign_in(user)
+      visit new_sake_path
+      fill_in("name-textfield", with: sake_name)
+      find(:test_id, "form-submit").click
+      wait_for_alert # 新しく作られる酒のIDが不明なため、アラートを待つ
+    end
+
+    it "has success flash message" do
+      expect(page).to have_css(".alert-success")
+    end
+
+    it "has specified sake name" do
+      expect(find(:test_id, "sake-name")).to have_text(sake_name)
+    end
+
+    it "redirect to created sake page" do
+      # 酒のIDが不明なため、showページのパスであることを確認する
+      expect(page).to have_current_path /\/sakes\/[0-9]+/
+    end
+
+    it "has flash message containing link to created sake" do
+      # 酒のIDが不明なため、フラッシュメッセージのリンク先が現在のパスと同じことを確認する
+      expect(find(".alert")).to have_link(sake_name, href: current_path)
+    end
+  end
+end

--- a/spec/system/sake_create_spec.rb
+++ b/spec/system/sake_create_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "AfterUpdateAction", type: :system do
     before do
       sign_in(user)
       visit new_sake_path
-      fill_in("name-textfield", with: sake_name)
+      find(:test_id, "name-textfield").set(sake_name)
       find(:test_id, "form-submit").click
       wait_for_alert # 新しく作られる酒のIDが不明なため、アラートを待つ
     end
@@ -28,7 +28,7 @@ RSpec.describe "AfterUpdateAction", type: :system do
 
     it "has flash message containing link to created sake" do
       # 酒のIDが不明なため、フラッシュメッセージのリンク先が現在のパスと同じことを確認する
-      expect(find(".alert")).to have_link(sake_name, href: current_path)
+      expect(find(:test_id, "flash-message")).to have_link(sake_name, href: current_path)
     end
   end
 end

--- a/spec/system/sake_update_spec.rb
+++ b/spec/system/sake_update_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe "AfterUpdateAction", type: :system do
+
+  let!(:opened_sake) { FactoryBot.create(:sake, bottle_level: "opened") }
+  let(:sake_id) { opened_sake.id }
+  let(:sake_name) { opened_sake.name }
+  let(:user) { FactoryBot.create(:user) }
+
+  describe "update from edit page" do
+    before do
+      sign_in(user)
+      visit edit_sake_path(sake_id)
+      find(:test_id, "submit").click
+    end
+
+    it "redirect to sake page" do
+      expect(page).to have_current_path sake_path(sake_id)
+    end
+
+    it "has success flash message" do
+      expect(page).to have_css(".alert-success")
+    end
+
+    it "has link to the updated sake" do
+      expect(find(".alert")).to have_link(sake_name, href: sake_path(sake_id))
+    end
+  end
+end

--- a/spec/system/sake_update_spec.rb
+++ b/spec/system/sake_update_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "AfterUpdateAction", type: :system do
     end
 
     it "has link to the updated sake" do
-      expect(find(".alert")).to have_link(sake_name, href: sake_path(sake_id))
+      expect(find(:test_id, "flash-message")).to have_link(sake_name, href: sake_path(sake_id))
     end
   end
 end

--- a/spec/system/sake_update_spec.rb
+++ b/spec/system/sake_update_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 
 RSpec.describe "AfterUpdateAction", type: :system do
-
   let!(:opened_sake) { FactoryBot.create(:sake, bottle_level: "opened") }
   let(:sake_id) { opened_sake.id }
   let(:sake_name) { opened_sake.name }
@@ -11,7 +10,7 @@ RSpec.describe "AfterUpdateAction", type: :system do
     before do
       sign_in(user)
       visit edit_sake_path(sake_id)
-      find(:test_id, "submit").click
+      find(:test_id, "form-submit").click
     end
 
     it "redirect to sake page" do


### PR DESCRIPTION
Close #197

- Indexで開封する・空にするボタンを押したあとIndexにリダイレクトするようにした。
- ユーザーが誤って開封する・空にするボタンを押してしまったときには修正できるように、酒編集後に表示するflashメッセージに酒詳細ページへのリンクを入れた。
![image](https://user-images.githubusercontent.com/6294782/125441627-3638eb51-f453-4321-8efe-913b7ac23371.png)
- おまけに、酒作成や削除時のFlashメッセージに酒の名前を表示するようにした。
![image](https://user-images.githubusercontent.com/6294782/125442142-546ea587-0334-4d13-b0ee-65ba99da5257.png)

