### PR TITLE
HTMLタグにlocale情報を追加した

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="<%= I18n.locale %>">
   <head>
     <title>SAKAZUKI</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">


### PR DESCRIPTION
close #246

たぶんいけるやろ

### 目的

- ChromeのGoogle翻訳が中国語判定するのを防ぐため
- たぶん「冨田」のような異体字があったりすると中国語判定されやすい？