### PR TITLE
色合いをロゴに合わせた

### DIFF
--- a/app/packs/src/stylesheet/bootstrap_custom.scss
+++ b/app/packs/src/stylesheet/bootstrap_custom.scss
@@ -1,0 +1,8 @@
+$primary: #19448e;
+$secondary: #d9e7ff;
+$success: #448e19;
+$danger: #8e1944;
+$warning: #8e8a19;
+$info: #198e8e;
+$light: #dee2e6;
+$white: #f8f9fa;

--- a/app/packs/src/stylesheet/common.scss
+++ b/app/packs/src/stylesheet/common.scss
@@ -41,7 +41,6 @@
 .sakes-index-name-link {
   font-size: 1.1em;
   font-weight: 600;
-  color: #212529;
 }
 
 // Ransackが生成するスタイル

--- a/app/packs/src/stylesheet/common.scss
+++ b/app/packs/src/stylesheet/common.scss
@@ -1,3 +1,4 @@
+@import "bootstrap_custom";
 @import "~bootstrap/scss/bootstrap";
 
 .click-transparent {

--- a/app/views/elasticsearch/index.html.erb
+++ b/app/views/elasticsearch/index.html.erb
@@ -13,7 +13,7 @@
                          class: "form-control", }) %>
       <%= tag.button(tag.i(class: "bi-search"),
                      type: "submit",
-                     class: "input-group-text btn btn-secondary") %>
+                     class: "input-group-text btn btn-primary") %>
     </div>
   </div>
 <% end %>

--- a/app/views/sakes/_drink-button.html.erb
+++ b/app/views/sakes/_drink-button.html.erb
@@ -7,13 +7,13 @@
                 "data-testid": "open-button-#{sake.id}", }) %>
   <%= link_to(html_escape(t(".impress")) + tag.i(class: "bi-cup-fill", style: "font-size: 1em;"),
               edit_sake_path(sake, params: { sake: { bottle_level: "opened" } }),
-              { class: "badge rounded-pill bg-secondary ms-2",
+              { class: "badge rounded-pill bg-secondary text-dark ms-2",
                 "data-testid": "open-and-impress-button-#{sake.id}", }) %>
 <% end %>
 <% if sake.opened? && sake.unimpressed? %>
   <%= link_to(html_escape(t(".impress")) + tag.i(class: "bi-cup-fill", style: "font-size: 1em;"),
               edit_sake_path(sake),
-              { class: "badge rounded-pill bg-secondary ms-2",
+              { class: "badge rounded-pill bg-secondary text-dark ms-2",
                 "data-testid": "impress-button-#{sake.id}", }) %>
 <% end %>
 <% if sake.opened? %>

--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -27,7 +27,7 @@
   <div class="sakes-form-row">
     <%= form.label(:kura, { class: "sakes-form-badged-label" }) %>
     <div class="sakes-form-badge">
-      <span class="badge bg-secondary"><%= t(".badge.obligation") %></span>
+      <span class="badge bg-secondary text-dark"><%= t(".badge.obligation") %></span>
     </div>
     <div class="col">
       <%= form.text_field(:kura, { class: "form-control", autocomplete: "on", list: "sakagura" }) %>
@@ -77,7 +77,7 @@
   <div class="sakes-form-row">
     <%= form.label(:alcohol, { class: "sakes-form-badged-label" }) %>
     <div class="sakes-form-badge">
-      <span class="badge bg-secondary"><%= t(".badge.obligation") %></span>
+      <span class="badge bg-secondary text-dark"><%= t(".badge.obligation") %></span>
     </div>
     <div class="sakes-form-short-form">
       <%= form.number_field(:alcohol,
@@ -88,7 +88,7 @@
   <div class="sakes-form-row">
     <%= form.label(:tokutei_meisho, { class: "sakes-form-badged-label" }) %>
     <div class="sakes-form-badge">
-      <span class="badge bg-secondary"><%= t(".badge.obligation") %></span>
+      <span class="badge bg-secondary text-dark"><%= t(".badge.obligation") %></span>
     </div>
     <div class="sakes-form-short-form">
       <%= form.select(:tokutei_meisho,
@@ -103,7 +103,7 @@
   <div class="sakes-form-row">
     <%= form.label(:seimai_buai, { class: "sakes-form-badged-label" }) %>
     <div class="sakes-form-badge">
-      <span class="badge bg-secondary"><%= t(".badge.obligation") %></span>
+      <span class="badge bg-secondary text-dark"><%= t(".badge.obligation") %></span>
     </div>
     <div class="sakes-form-short-form">
       <%= form.number_field(:seimai_buai, { class: "form-control" }) %>
@@ -113,7 +113,7 @@
   <div class="sakes-form-row">
     <%= form.label(:bindume_date, { class: "sakes-form-badged-label" }) %>
     <div class="sakes-form-badge">
-      <span class="badge bg-secondary"><%= t(".badge.obligation") %></span>
+      <span class="badge bg-secondary text-dark"><%= t(".badge.obligation") %></span>
     </div>
     <%# HACK: 年と月の入力フォームを分けて横並びに配置する。 %>
     <%#       Railsデフォルトでは年月が縦並びになってしまう。%>
@@ -149,7 +149,7 @@
   <div class="sakes-form-row">
     <%= form.label(:size, { class: "sakes-form-badged-label" }) %>
     <div class="sakes-form-badge">
-      <span class="badge bg-secondary"><%= t(".badge.obligation") %></span>
+      <span class="badge bg-secondary text-dark"><%= t(".badge.obligation") %></span>
     </div>
     <div class="sakes-form-short-form">
       <%= form.number_field(:size, { class: "form-control" }) %>
@@ -159,7 +159,7 @@
   <div class="sakes-form-row">
     <%= form.label(:price, { class: "sakes-form-badged-label" }) %>
     <div class="sakes-form-badge">
-      <span class="badge bg-secondary"><%= t(".badge.obligation") %></span>
+      <span class="badge bg-secondary text-dark"><%= t(".badge.obligation") %></span>
     </div>
     <div class="sakes-form-short-form">
       <%= form.number_field(:price, { class: "form-control" }) %>

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -15,7 +15,7 @@
                          value: params.dig(:q, :all_text_cont), }) %>
     <%= tag.button(tag.i(class: "bi-search"),
                    type: "submit",
-                   class: "input-group-text btn btn-secondary", "data-testid": "submit_search") %>
+                   class: "input-group-text btn btn-primary", "data-testid": "submit_search") %>
   </div>
 
   <div class="col-auto">


### PR DESCRIPTION
おしゃれー！

### やったこと

- お猪口ロゴの瑠璃紺色をメインカラーに設定
- トライアド・スプリットコンプリメンタリを使いbootstrapの色をカスタマイズ
- 色変更に伴いバッジの文字色などを反転した

### やってないこと

- ヘッダーバーの変更
  - メインカラーが決まったので、`bg-dark`から`bg-primary`にしてメインカラーにしてもいいかも
- アクセントカラーの決定
   - [朱](https://www.colordic.org/colorsample/2326)、[赤紅](https://www.colordic.org/colorsample/2440)、[茜色](https://www.colordic.org/colorsample/2009)とか
- アクセントカラーをグラフポイントなどへの適用