### PR TITLE
Dockerfileをheredoc対応した

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -69,7 +69,7 @@ jobs:
         run: bundle exec erblint --lint-all
 
       # lint by hadolint
-      - name: Hadolint
-        uses: brpaz/hadolint-action@master
+      - name: Run Hadolint
+        uses: hadolint/hadolint-action@master
         with:
           dockerfile: Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,11 +17,11 @@ RUN <<EOF
   echo "deb https://dl.yarnpkg.com/debian/ stable main" | \
     tee /etc/apt/sources.list.d/yarn.list
 
-  curl -sL https://deb.nodesource.com/setup_12.x | bash -
+  curl -sL https://deb.nodesource.com/setup_16.x | bash -
 
   apt-get update -qq
   DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
-    nodejs=12.* postgresql-client-13=13.* libpq-dev=15.* yarn=1.22.* \
+    nodejs=16.* postgresql-client-13=13.* libpq-dev=15.* yarn=1.22.* \
     imagemagick=8:6.9.*
 
   apt-get clean

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN <<EOF
   apt-get update -qq
   DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
-    curl=7.64.* build-essential=12.6 gnupg2=2.2.* imagemagick=8:6.9.*
+    curl=7.64.* build-essential=12.6 gnupg2=2.2.*
   apt-get clean
   rm -rf /var/cache/apt/archives/*
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
@@ -25,7 +25,9 @@ RUN <<EOF
 
   apt-get update -qq
   DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
-    nodejs=12.* postgresql-client-13=13.* libpq-dev=15.* yarn=1.22.*
+    nodejs=12.* postgresql-client-13=13.* libpq-dev=15.* yarn=1.22.* \
+    imagemagick=8:6.9.*
+
   apt-get clean
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
   truncate -s 0 /var/log/**/*log

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN <<EOF
 
   curl -sSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
   echo "deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main" \
-    > /etc/apt/sources.list.d/pgdg.list && \
+    > /etc/apt/sources.list.d/pgdg.list
 
   curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
   echo "deb https://dl.yarnpkg.com/debian/ stable main" | \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,6 @@ RUN <<EOF
   apt-get update -qq
   DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
     curl=7.64.* build-essential=12.6 gnupg2=2.2.*
-  apt-get clean
-  rm -rf /var/cache/apt/archives/*
-  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-  truncate -s 0 /var/log/**/*log
 
   curl -sSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
   echo "deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main" \
@@ -29,7 +25,7 @@ RUN <<EOF
     imagemagick=8:6.9.*
 
   apt-get clean
-  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+  rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/* /tmp/* /var/tmp/*
   truncate -s 0 /var/log/**/*log
 EOF
 

--- a/cli-scripts/run-all-checks.sh
+++ b/cli-scripts/run-all-checks.sh
@@ -59,5 +59,5 @@ if [ -n "${HADOLINT}" ]; then
         eval "${HADOLINT} ${file}"
     done
 else
-    warning "[SKIP] hadolint is not installed."
+    warning "[SKIP] Hadolint, hadolint or Docker is required."
 fi


### PR DESCRIPTION
heredoc書けるようになったよ！

### heredocを使うと

- &&\地獄から抜けれる
- RUNをまとめてスッキリ書ける

### やったこと

- RUNをheredoc化
- apt installの順番を、基本コマンドとSAKAZUKI依存パッケージで分けた
- SAKAZUKI依存パッケージのapt installの順番をセットアップ順に揃えた
- aptのクリーニング作業を1つにまとめた
- nodeのバージョンを次期LTSの16にした
  - 12もLTSだがすでにEOL、新しいLTS出たので更新した。

### 参考

- https://www.docker.com/blog/introduction-to-heredocs-in-dockerfiles/
