### PR TITLE
Update: 酒蔵視点の言葉「表示義務」をユーザ視点の言葉「ラベル記載」に変更した

### DIFF
--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -27,7 +27,7 @@
   <div class="sakes-form-row">
     <%= form.label(:kura, { class: "sakes-form-badged-label" }) %>
     <div class="sakes-form-badge">
-      <span class="badge bg-secondary"><%= t(".badge.obligation") %></span>
+      <span class="badge bg-secondary"><%= t(".badge.labeled") %></span>
     </div>
     <div class="col">
       <%= form.text_field(:kura, { class: "form-control", autocomplete: "on", list: "sakagura" }) %>
@@ -77,7 +77,7 @@
   <div class="sakes-form-row">
     <%= form.label(:alcohol, { class: "sakes-form-badged-label" }) %>
     <div class="sakes-form-badge">
-      <span class="badge bg-secondary"><%= t(".badge.obligation") %></span>
+      <span class="badge bg-secondary"><%= t(".badge.labeled") %></span>
     </div>
     <div class="sakes-form-short-form">
       <%= form.number_field(:alcohol,
@@ -88,7 +88,7 @@
   <div class="sakes-form-row">
     <%= form.label(:tokutei_meisho, { class: "sakes-form-badged-label" }) %>
     <div class="sakes-form-badge">
-      <span class="badge bg-secondary"><%= t(".badge.obligation") %></span>
+      <span class="badge bg-secondary"><%= t(".badge.labeled") %></span>
     </div>
     <div class="sakes-form-short-form">
       <%= form.select(:tokutei_meisho,
@@ -103,7 +103,7 @@
   <div class="sakes-form-row">
     <%= form.label(:seimai_buai, { class: "sakes-form-badged-label" }) %>
     <div class="sakes-form-badge">
-      <span class="badge bg-secondary"><%= t(".badge.obligation") %></span>
+      <span class="badge bg-secondary"><%= t(".badge.labeled") %></span>
     </div>
     <div class="sakes-form-short-form">
       <%= form.number_field(:seimai_buai, { class: "form-control" }) %>
@@ -113,7 +113,7 @@
   <div class="sakes-form-row">
     <%= form.label(:bindume_date, { class: "sakes-form-badged-label" }) %>
     <div class="sakes-form-badge">
-      <span class="badge bg-secondary"><%= t(".badge.obligation") %></span>
+      <span class="badge bg-secondary"><%= t(".badge.labeled") %></span>
     </div>
     <%# HACK: 年と月の入力フォームを分けて横並びに配置する。 %>
     <%#       Railsデフォルトでは年月が縦並びになってしまう。%>
@@ -149,7 +149,7 @@
   <div class="sakes-form-row">
     <%= form.label(:size, { class: "sakes-form-badged-label" }) %>
     <div class="sakes-form-badge">
-      <span class="badge bg-secondary"><%= t(".badge.obligation") %></span>
+      <span class="badge bg-secondary"><%= t(".badge.labeled") %></span>
     </div>
     <div class="sakes-form-short-form">
       <%= form.number_field(:size, { class: "form-control" }) %>
@@ -159,7 +159,7 @@
   <div class="sakes-form-row">
     <%= form.label(:price, { class: "sakes-form-badged-label" }) %>
     <div class="sakes-form-badge">
-      <span class="badge bg-secondary"><%= t(".badge.obligation") %></span>
+      <span class="badge bg-secondary"><%= t(".badge.labeled") %></span>
     </div>
     <div class="sakes-form-short-form">
       <%= form.number_field(:price, { class: "form-control" }) %>

--- a/config/locales/views/sake.ja.yml
+++ b/config/locales/views/sake.ja.yml
@@ -27,4 +27,4 @@ ja:
       tasteinfo: :sakes.show.tasteinfo
       badge:
         presence: 必須
-        obligation: 表示義務
+        labeled: ラベル記載


### PR DESCRIPTION
close #186

### やったこと

- 「表示義務」を「ラベル記載」に変更した

### どうして

- [ユーザの言葉を使う](https://www.sociomedia.co.jp/9108)
  - 表示義務は酒蔵やシステム開発者の言葉。
  - exoegoさん指摘の通り、ユーザにはなんのことかわからない。
