### PR TITLE
酒indexの各酒に編集ボタンを追加した

### DIFF
--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -59,7 +59,9 @@
               <%= link_to(sake.name, sake_path(sake), { class: "sakes-index-name-link" }) %>
             </div>
             <div class="col-auto">
-              <%= link_to(t(".edit"), edit_sake_path(sake), "data-testid": "sakes-index-edit-link") %>
+              <%= link_to(tag.i(class: "bi-pencil-square me-2", style: "font-size: 1.05em;") + t(".edit"),
+                          edit_sake_path(sake),
+                          "data-testid": "sakes-index-edit-link") %>
             </div>
           </div>
           <div class="row m-0 mt-2 border-bottom">

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -58,6 +58,9 @@
             <div class="col p-0">
               <%= link_to(sake.name, sake_path(sake), { class: "sakes-index-name-link" }) %>
             </div>
+            <div class="col-auto">
+              <%= link_to(t(".edit"), edit_sake_path(sake), "data-testid": "sakes-index-edit-link") %>
+            </div>
           </div>
           <div class="row m-0 mt-2 border-bottom">
             <div class="col p-0">

--- a/config/locales/views/sake.ja.yml
+++ b/config/locales/views/sake.ja.yml
@@ -3,6 +3,7 @@ ja:
     index:
       title: 日本酒リスト
       all_bottles: 空瓶を表示
+      edit: 編集
     show:
       title: 詳細
       delete: 削除

--- a/config/locales/views/sake.ja.yml
+++ b/config/locales/views/sake.ja.yml
@@ -30,5 +30,5 @@ ja:
         presence: 必須
         obligation: 表示義務
     float-button:
-      edit: 編集
+      edit: :sakes.index.edit
       new: 新規

--- a/spec/system/edit_in_index_page_spec.rb
+++ b/spec/system/edit_in_index_page_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe "EditInIndexPage", type: :system do
+  let(:user) { FactoryBot.create(:user) }
+  let!(:sake) { FactoryBot.create(:sake) }
+
+  describe "index page" do
+    before do
+      sign_in(user)
+      visit sakes_path
+    end
+
+    it "has edit button" do
+      id = "sakes-index-edit-link"
+      text = I18n.t("sakes.index.edit")
+      expect(find(:test_id, id)).to have_text(text)
+    end
+
+    it "moves to sake edit page" do
+      id = "sakes-index-edit-link"
+      path = edit_sake_path(sake.id)
+      click_link(id)
+      expect(page).to have_current_path(path, ignore_query: true)
+    end
+  end
+end


### PR DESCRIPTION
毎回showを開いてeditボタンを押して、こんな煩雑な苦悩からついに開放だ！


### やったこと

- 酒indexの各酒に編集リンクを追加した
- 編集リンクがあって動作する！というめちゃ簡単なテストをTDDで追加した

### その他

- `ja.yml`を #251 と共有化できるかも