### PR TITLE
Fix: yardoc 引数の書き方を修正する #237

### DIFF
--- a/app/helpers/devise_helper.rb
+++ b/app/helpers/devise_helper.rb
@@ -6,7 +6,7 @@ module DeviseHelper
   #   bootstrap_alert("notice") #=> "success" ex. ログイン成功
   #   bootstrap_alert("alert") #=> "danger" ex. パスワードミス
   #   bootstrap_alert("timedout") #=> "timedout" ex. タイムアウト
-  # @param [String] message_type deviseが生成するメッセージタイプ
+  # @param message_type [String] deviseが生成するメッセージタイプ
   # @return [String] bootstrapのアラートタイプ
   def bootstrap_alert(message_type)
     case message_type
@@ -20,7 +20,7 @@ module DeviseHelper
   # @example
   #   minimum_password_message(6) #=> "（6文字以上）"
   #   minimum_password_message(nil) #=> ""
-  # @param [Integer, nil] minimum_password_length パスワードの最小文字数
+  # @param minimum_password_length [Integer, nil] パスワードの最小文字数
   # @return [String] （n文字以上）という文字列または空文字
   def minimum_password_message(minimum_password_length)
     if minimum_password_length

--- a/app/helpers/sakes_helper.rb
+++ b/app/helpers/sakes_helper.rb
@@ -2,8 +2,8 @@ require "era_ja/date"
 
 module SakesHelper
   # nilと空文字列を指定の値に変換する
-  # @param [Object, nil] value 対象の値
-  # @param [Object] default 空のとき返す値
+  # @param value [Object, nil] 対象の値
+  # @param default [Object] 空のとき返す値
   # @return [Object] valueをそのまま返すか、valueが空ならdefaultを返す
   def empty_to_default(value, default)
     value.presence || default
@@ -13,7 +13,7 @@ module SakesHelper
   # @example
   #   to_by(Date(2021, 6, 30)) #=> Date(2020, 7, 1)
   #   to_by(Date(2021, 7, 2)) #=> Date(2021, 7, 1)
-  # @param [Date] date 日付
+  # @param date [Date] 日付
   # @return [Date] 入力された日付に対応するBY、月日はBYの始まりである7/1となる
   def to_by(date)
     by_year = date.year - (date.month >= 7 ? 0 : 1)
@@ -22,11 +22,11 @@ module SakesHelper
   end
 
   # 和暦付きの年のHTMLセレクタを生成する
-  # @param [String] id HTMLのid
-  # @param [String] name HTMLのname
-  # @param [Integer] begin_year 開始年
-  # @param [Integer] selected_year 初期選択年
-  # @param [Boolean] include_blank trueなら選択肢に空が含まれる
+  # @param id [String] HTMLのid
+  # @param name [String] HTMLのname
+  # @param begin_year [Integer] 開始年
+  # @param selected_year [Integer] 初期選択年
+  # @param include_blank [Boolean] trueなら選択肢に空が含まれる
   # @return [String] 年のHTMLセレクタ
   def year_select_with_japanese_era(id, name, begin_year, selected_year: begin_year, include_blank: false)
     options = year_range(begin_year).map do |year|
@@ -61,7 +61,7 @@ module SakesHelper
   #   to_shakkan(0) #=> "0合"
   # @example 180ml未満は0合を返す
   #   to_shakkan(100) #=> "0合"
-  # @param [Integer] amount 酒の量[ml]
+  # @param amount [Integer] 酒の量[ml]
   # @return [String] 尺貫法の体積で表した酒量の文字列
   def to_shakkan(amount)
     if amount < 180
@@ -80,14 +80,14 @@ module SakesHelper
   end
 
   # 日付を和暦付き文字列に変換する
-  # @param [Date] date 日付
+  # @param date [Date] 日付
   # @return [String] "2021 / 令和3年"のような文字列
   def with_japanese_era(date)
     "#{date.year} / #{date.to_era("%O%-E年")}"
   end
 
   # 酒情報に入力可能な年範囲を作成する
-  # @param [Integer] begin_year 開始年
+  # @param begin_year [Integer] 開始年
   # @return [Range<Integer>] 年範囲
   def year_range(begin_year)
     (begin_year - start_year_limit)..begin_year

--- a/app/helpers/tweet_helper.rb
+++ b/app/helpers/tweet_helper.rb
@@ -1,6 +1,6 @@
 module TweetHelper
   # Tweetボタンを生成する
-  # @param [String] tweet_text ツイートボタンを押したときのツイート内容
+  # @param tweet_text [String] ツイートボタンを押したときのツイート内容
   # @return [String] TweetボタンのHTMLタグ
   def tweet_button(tweet_text)
     share_twitter = "https://twitter.com/share?ref_src=twsrc%5Etfw"

--- a/app/models/sake.rb
+++ b/app/models/sake.rb
@@ -146,7 +146,7 @@ class Sake < ApplicationRecord
   # 残っている酒の総量をmlで返す
   #
   # 開封済みのお酒は瓶の半量が残っているとして概算する。
-  # @param [Boolean] include_empty trueなら飲んだ分も含めた総量を計算する
+  # @param include_empty [Boolean] trueなら飲んだ分も含めた総量を計算する
   # @return [Integer] 酒の総量[ml]
   def self.alcohol_stock(include_empty: false)
     if include_empty

--- a/config/locales/helpers/tweet.ja.rb
+++ b/config/locales/helpers/tweet.ja.rb
@@ -1,7 +1,7 @@
 module TweetHelperJa
   # 文末に句点がない場合は追加する
-  # @param [String] text 対象テキスト
-  # @param [String] period 句点、デフォルトは。
+  # @param text [String] 対象テキスト
+  # @param period [String] 句点、デフォルトは。
   # @return [String] 句点を追加したテキスト
   def add_period(text, period = I18n.t("helper.tweet.punctuation"))
     if text.empty? || text.end_with?(period) then text else "#{text}#{period}" end
@@ -11,7 +11,7 @@ module TweetHelperJa
   #
   # @see https://0g0.org/ 囲み文字
   # @see https://hiramatu-hifuka.com/onyak/kotoba-1/hojin.html 法人等略語一覧表
-  # @param [String] text 蔵名を含む文字列
+  # @param text [String] 蔵名を含む文字列
   # @return [String] 法人名が略語になった文字列
   def to_enclosed(text)
     text = text.gsub("株式会社", "㈱")
@@ -23,11 +23,11 @@ module TweetHelperJa
 
   # 酒の情報からツイートメッセージを生成する
   #
-  # @param [String] name 酒の名前
-  # @param [String] kura 酒の蔵名
-  # @param [String] color 酒の色
-  # @param [String] aroma 酒の香り
-  # @param [String] taste 酒の味
+  # @param name [String] 酒の名前
+  # @param kura [String] 酒の蔵名
+  # @param color [String] 酒の色
+  # @param aroma [String] 酒の香り
+  # @param taste [String] 酒の味
   # @return [String] ツイートメッセージ
   def make_text(name, kura, color, aroma, taste)
     # 酒の名前のみがnon nil、他パラメータは空の場合を考慮する。

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -32,7 +32,7 @@ end
 # @example index.htmlの場合
 #   wait_for_page(sakes_path)
 #
-# @param [String] page_path ページのパス
+# @param page_path [String] ページのパス
 def wait_for_page(page_path)
   find(:test_id, page_path, visible: false)
 end

--- a/spec/support/sign_in.rb
+++ b/spec/support/sign_in.rb
@@ -1,13 +1,13 @@
 module SignIn
   # ヘッダーのSign inボタンをクリックし、サインインする
-  # @param [Object] user ファクトリーボットで作ったuserオブジェクト
+  # @param user [Object] ファクトリーボットで作ったuserオブジェクト
   def sign_in_via_header_button(user)
     find(:test_id, "sign-in").click
     signin_process_on_signin_page(user)
   end
 
   # email、passwordを入力し、サインインボタンをクリックする
-  # @param [Object] user ファクトリーボットで作ったuserオブジェクト
+  # @param user [Object] ファクトリーボットで作ったuserオブジェクト
   # @raise [RuntimeError] 現在のページがSign inページではない場合
   def signin_process_on_signin_page(user)
     if current_path != new_user_session_path


### PR DESCRIPTION
Close #237

note: 正規表現でマッチした箇所を後方参照して置換した
検索文字列: `@param\s(\[.+\])\s([a-zA-Z0-9_]+)`
置換文字列: `@param $2 $1`