### PR TITLE
酒フォームのアコーディオン化

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,8 +10,6 @@ gem "puma", "~> 5.3"
 # Use SCSS for stylesheets
 # Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker
 gem "webpacker", "~> 5.4"
-# Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
-gem "turbolinks", "~> 5"
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem "jbuilder", "~> 2.7"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -387,9 +387,6 @@ GEM
       sprockets (>= 3.0.0)
     ssrf_filter (1.0.7)
     thor (1.1.0)
-    turbolinks (5.2.1)
-      turbolinks-source (~> 5.2)
-    turbolinks-source (5.2.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unf (0.1.4)
@@ -466,7 +463,6 @@ DEPENDENCIES
   simplecov
   spring
   spring-watcher-listen (~> 2.0.0)
-  turbolinks (~> 5)
   tzinfo-data
   web-console (>= 3.3.0)
   webdrivers

--- a/app/views/sakes/_float-button.html.erb
+++ b/app/views/sakes/_float-button.html.erb
@@ -3,7 +3,7 @@
     <% if controller.action_name == "show" %>
       <%= link_to(tag.i(class: "bi-pencil-square me-2", style: "font-size: 1.05em;") + t(".edit"),
                   edit_sake_path(@sake),
-                  { class: "btn btn-secondary rounded-pill mx-1 click-nontransparent",
+                  { class: "btn btn-secondary rounded-pill border border-primary mx-1 click-nontransparent",
                     style: "font-size: 1.1em;",
                     "data-testid": "edit-#{@sake.id}", }) %>
     <% end %>

--- a/app/views/sakes/_float-button.html.erb
+++ b/app/views/sakes/_float-button.html.erb
@@ -1,16 +1,27 @@
 <div class="fixed-bottom mb-4 click-transparent">
   <div class="px-xxl-5 px-3 text-end">
-    <% if params["action"] == "show" %>
+    <% if controller.action_name == "show" %>
       <%= link_to(tag.i(class: "bi-pencil-square me-2", style: "font-size: 1.05em;") + t(".edit"),
                   edit_sake_path(@sake),
                   { class: "btn btn-secondary rounded-pill mx-1 click-nontransparent",
                     style: "font-size: 1.1em;",
                     "data-testid": "edit-#{@sake.id}", }) %>
     <% end %>
-    <%= link_to(tag.i(class: "bi-plus-circle me-2", style: "font-size: 1.05em;") + t(".new"),
-                new_sake_path,
-                { class: "btn btn-primary rounded-pill mx-1 click-nontransparent",
-                  style: "font-size: 1.1em;",
-                  "data-testid": "new-sake", }) %>
+    <% if ["show", "index"].include?(controller.action_name) %>
+      <%= link_to(tag.i(class: "bi-plus-circle me-2", style: "font-size: 1.05em;") + t(".new"),
+                  new_sake_path,
+                  { class: "btn btn-primary rounded-pill mx-1 click-nontransparent",
+                    style: "font-size: 1.1em;",
+                    "data-testid": "new-sake", }) %>
+    <% end %>
+    <% if ["new", "create", "edit"].include?(controller.action_name) %>
+      <%= button_tag(type: "submit",
+                     form: "sake-form",
+                     class: "btn btn-primary rounded-pill mx-1 click-nontransparent",
+                     style: "font-size: 1.1em;",
+                     "data-testid": "form-submit") do %>
+        <%= tag.i(class: "bi-check-circle me-2") + t("submit", scope: "sakes.form.#{controller.action_name}") %>
+      <% end %>
+    <% end %>
   </div>
 </div>

--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -2,7 +2,9 @@
   <%= javascript_pack_tag("common", "sakes_form", "data-turbolinks-track": "reload") %>
 <% end %>
 
-<%= form_with(model: sake, local: true) do |form| %>
+<%= render("float-button") %>
+
+<%= form_with(model: sake, local: true, id: "sake-form") do |form| %>
 
   <%# error message %>
   <% if sake.errors.any? %>
@@ -360,12 +362,6 @@
           </div>
         </div>
       </div>
-    </div>
-  </div>
-
-  <div class="sakes-form-row mt-2 justify-content-center">
-    <div class="col-auto">
-      <%= form.submit(class: "btn btn-primary mx-3", "data-testid": "form-submit") %>
     </div>
   </div>
 

--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -12,335 +12,375 @@
   <% end %>
 
   <%# 表示義務ありのラベル情報 %>
-  <h3><%= t(".labelinfo") %></h3>
+  <div class="accordion my-2" id="accordionLabelInfo">
+    <div class="accordion-item">
+      <h3 class="accordion-header" id="headingLabelInfo">
+        <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseLabelInfo"
+          aria-expanded="true" aria-controls="collapseLabelInfo">
+          <%= t(".labelinfo") %>
+        </button>
+      </h3>
+      <div id="collapseLabelInfo" class="accordion-collapse collapse show" aria-labelledby="headingLabelInfo"
+        data-bs-parent="#accordionLabelInfo">
+        <div class="accordion-body">
+          <div class="sakes-form-row">
+            <%= form.label(:name, { class: "sakes-form-badged-label" }) %>
+            <div class="sakes-form-badge">
+              <span class="badge bg-primary"><%= t(".badge.presence") %></span>
+            </div>
+            <div class="col">
+              <%= form.text_field(:name, { class: "form-control", "data-testid": "name-textfield" }) %>
+            </div>
+          </div>
 
-  <div class="sakes-form-row">
-    <%= form.label(:name, { class: "sakes-form-badged-label" }) %>
-    <div class="sakes-form-badge">
-      <span class="badge bg-primary"><%= t(".badge.presence") %></span>
-    </div>
-    <div class="col">
-      <%= form.text_field(:name, { class: "form-control", "data-testid": "name-textfield" }) %>
-    </div>
-  </div>
+          <div class="sakes-form-row">
+            <%= form.label(:kura, { class: "sakes-form-badged-label" }) %>
+            <div class="sakes-form-badge">
+              <span class="badge bg-secondary text-dark"><%= t(".badge.obligation") %></span>
+            </div>
+            <div class="col">
+              <%= form.text_field(:kura, { class: "form-control", autocomplete: "on", list: "sakagura" }) %>
+              <%= render("sakagura-datalist") %>
+            </div>
+            <div>
+              <%= form.text_field(:todofuken, { class: "form-control", hidden: true }) %>
+            </div>
+          </div>
 
-  <div class="sakes-form-row">
-    <%= form.label(:kura, { class: "sakes-form-badged-label" }) %>
-    <div class="sakes-form-badge">
-      <span class="badge bg-secondary text-dark"><%= t(".badge.obligation") %></span>
-    </div>
-    <div class="col">
-      <%= form.text_field(:kura, { class: "form-control", autocomplete: "on", list: "sakagura" }) %>
-      <%= render("sakagura-datalist") %>
-    </div>
-    <div>
-      <%= form.text_field(:todofuken, { class: "form-control", hidden: true }) %>
-    </div>
-  </div>
+          <div class="sakes-form-row">
+            <%= form.label(:photos, { class: "sakes-form-label" }) %>
+            <div class="col">
+              <%= form.file_field(:photos,
+                                  { multiple: true,
+                                    class: "form-control col-12",
+                                    accept: "image/*;capture=camera", }) %>
+            </div>
+          </div>
 
-  <div class="sakes-form-row">
-    <%= form.label(:photos, { class: "sakes-form-label" }) %>
-    <div class="col">
-      <%= form.file_field(:photos,
-                          { multiple: true,
-                            class: "form-control col-12",
-                            accept: "image/*;capture=camera", }) %>
-    </div>
-  </div>
-
-  <% if @sake.photos.any? %>
-    <div class="row">
-      <div class="sakes-form-label"></div>
-      <div class="col">
-        <div class="row">
-          <span class="form-text col-12">
-            <%= t(".select_delete_photo") %>
-          </span>
-          <% @sake.photos.each do |photo| %>
-            <div class="col-lg-4 col-6">
-              <div class="form-check form-check-inline">
-                <%= check_box_tag(photo.chackbox_name,
-                                  "delete",
-                                  nil,
-                                  { class: "form-check-input" }) %>
-                <label class="form-check-label" for="<%= photo.chackbox_name %>">
-                  <%= cl_image_tag(photo.image.thumb.url, { class: "img-thumbnail" }) %>
-                </label>
+          <% if @sake.photos.any? %>
+            <div class="row">
+              <div class="sakes-form-label"></div>
+              <div class="col">
+                <div class="row">
+                  <span class="form-text col-12">
+                    <%= t(".select_delete_photo") %>
+                  </span>
+                  <% @sake.photos.each do |photo| %>
+                    <div class="col-lg-4 col-6">
+                      <div class="form-check form-check-inline">
+                        <%= check_box_tag(photo.chackbox_name,
+                                          "delete",
+                                          nil,
+                                          { class: "form-check-input" }) %>
+                        <label class="form-check-label" for="<%= photo.chackbox_name %>">
+                          <%= cl_image_tag(photo.image.thumb.url, { class: "img-thumbnail" }) %>
+                        </label>
+                      </div>
+                    </div>
+                  <% end %>
+                </div>
               </div>
             </div>
           <% end %>
+
+          <div class="sakes-form-row">
+            <%= form.label(:alcohol, { class: "sakes-form-badged-label" }) %>
+            <div class="sakes-form-badge">
+              <span class="badge bg-secondary text-dark"><%= t(".badge.obligation") %></span>
+            </div>
+            <div class="sakes-form-short-form">
+              <%= form.number_field(:alcohol,
+                                    { step: "any", class: "form-control" }) %>
+            </div>
+          </div>
+
+          <div class="sakes-form-row">
+            <%= form.label(:tokutei_meisho, { class: "sakes-form-badged-label" }) %>
+            <div class="sakes-form-badge">
+              <span class="badge bg-secondary text-dark"><%= t(".badge.obligation") %></span>
+            </div>
+            <div class="sakes-form-short-form">
+              <%= form.select(:tokutei_meisho,
+                              Sake.tokutei_meishos_i18n.keys.map do |k|
+                                [I18n.t("enums.sake.tokutei_meisho.#{k}"), k]
+                              end,
+                              {},
+                              { class: "form-select" }) %>
+            </div>
+          </div>
+
+          <div class="sakes-form-row">
+            <%= form.label(:seimai_buai, { class: "sakes-form-badged-label" }) %>
+            <div class="sakes-form-badge">
+              <span class="badge bg-secondary text-dark"><%= t(".badge.obligation") %></span>
+            </div>
+            <div class="sakes-form-short-form">
+              <%= form.number_field(:seimai_buai, { class: "form-control" }) %>
+            </div>
+          </div>
+
+          <div class="sakes-form-row">
+            <%= form.label(:bindume_date, { class: "sakes-form-badged-label" }) %>
+            <div class="sakes-form-badge">
+              <span class="badge bg-secondary text-dark"><%= t(".badge.obligation") %></span>
+            </div>
+            <%# HACK: 年と月の入力フォームを分けて横並びに配置する。 %>
+            <%#       Railsデフォルトでは年月が縦並びになってしまう。%>
+            <%#       そのため、2つフォームを設置してTSで同期する。 %>
+            <div class="sakes-form-two-column-form">
+              <%= year_select_with_japanese_era(id = "bindume_year",
+                                                name = "sake[bindume_date(1i)]",
+                                                begin_year = Date.current.year,
+                                                selected_year: @sake.bindume_date&.year || Date.current.year) %>
+            </div>
+            <div class="sakes-form-two-column-form">
+              <%= form.date_select(:bindume_date,
+                                   { discard_day: true, discard_year: true },
+                                   { class: "form-select", id: "bindume_month" }) %>
+            </div>
+          </div>
+
+          <div class="sakes-form-row">
+            <%= form.label(:brew_year, { class: "sakes-form-label" }) %>
+            <div class="sakes-form-two-column-form">
+              <% current_by = to_by(Date.current).year %>
+              <%= year_select_with_japanese_era(id = "sake_brew_year_1i",
+                                                name = "sake[brew_year(1i)]",
+                                                begin_year = current_by,
+                                                selected_year: @sake.brew_year&.year || current_by,
+                                                include_blank: true) %>
+              <%# 使わない月日はBY始まりの7/1とする. See to_by %>
+              <input type="hidden" id="sake_<%= :brew_year %>_2i" name="sake[<%= :brew_year %>(2i)]" value="7">
+              <input type="hidden" id="sake_<%= :brew_year %>_3i" name="sake[<%= :brew_year %>(3i)]" value="1">
+            </div>
+          </div>
+
+          <div class="sakes-form-row">
+            <%= form.label(:size, { class: "sakes-form-badged-label" }) %>
+            <div class="sakes-form-badge">
+              <span class="badge bg-secondary text-dark"><%= t(".badge.obligation") %></span>
+            </div>
+            <div class="sakes-form-short-form">
+              <%= form.number_field(:size, { class: "form-control" }) %>
+            </div>
+          </div>
+
+          <div class="sakes-form-row">
+            <%= form.label(:price, { class: "sakes-form-badged-label" }) %>
+            <div class="sakes-form-badge">
+              <span class="badge bg-secondary text-dark"><%= t(".badge.obligation") %></span>
+            </div>
+            <div class="sakes-form-short-form">
+              <%= form.number_field(:price, { class: "form-control" }) %>
+            </div>
+          </div>
+
+          <div class="sakes-form-row">
+            <%= form.label(:bottle_level, { class: "sakes-form-label" }) %>
+            <div class="sakes-form-short-form">
+              <%= form.select(:bottle_level,
+                              Sake.bottle_levels_i18n.keys.map do |k|
+                                [I18n.t("enums.sake.bottle_level.#{k}"), k]
+                              end,
+                              {},
+                              { class: "form-select" }) %>
+            </div>
+          </div>
         </div>
       </div>
-    </div>
-  <% end %>
-
-  <div class="sakes-form-row">
-    <%= form.label(:alcohol, { class: "sakes-form-badged-label" }) %>
-    <div class="sakes-form-badge">
-      <span class="badge bg-secondary text-dark"><%= t(".badge.obligation") %></span>
-    </div>
-    <div class="sakes-form-short-form">
-      <%= form.number_field(:alcohol,
-                            { step: "any", class: "form-control" }) %>
-    </div>
-  </div>
-
-  <div class="sakes-form-row">
-    <%= form.label(:tokutei_meisho, { class: "sakes-form-badged-label" }) %>
-    <div class="sakes-form-badge">
-      <span class="badge bg-secondary text-dark"><%= t(".badge.obligation") %></span>
-    </div>
-    <div class="sakes-form-short-form">
-      <%= form.select(:tokutei_meisho,
-                      Sake.tokutei_meishos_i18n.keys.map do |k|
-                        [I18n.t("enums.sake.tokutei_meisho.#{k}"), k]
-                      end,
-                      {},
-                      { class: "form-select" }) %>
-    </div>
-  </div>
-
-  <div class="sakes-form-row">
-    <%= form.label(:seimai_buai, { class: "sakes-form-badged-label" }) %>
-    <div class="sakes-form-badge">
-      <span class="badge bg-secondary text-dark"><%= t(".badge.obligation") %></span>
-    </div>
-    <div class="sakes-form-short-form">
-      <%= form.number_field(:seimai_buai, { class: "form-control" }) %>
-    </div>
-  </div>
-
-  <div class="sakes-form-row">
-    <%= form.label(:bindume_date, { class: "sakes-form-badged-label" }) %>
-    <div class="sakes-form-badge">
-      <span class="badge bg-secondary text-dark"><%= t(".badge.obligation") %></span>
-    </div>
-    <%# HACK: 年と月の入力フォームを分けて横並びに配置する。 %>
-    <%#       Railsデフォルトでは年月が縦並びになってしまう。%>
-    <%#       そのため、2つフォームを設置してTSで同期する。 %>
-    <div class="sakes-form-two-column-form">
-      <%= year_select_with_japanese_era(id = "bindume_year",
-                                        name = "sake[bindume_date(1i)]",
-                                        begin_year = Date.current.year,
-                                        selected_year: @sake.bindume_date&.year || Date.current.year) %>
-    </div>
-    <div class="sakes-form-two-column-form">
-      <%= form.date_select(:bindume_date,
-                           { discard_day: true, discard_year: true },
-                           { class: "form-select", id: "bindume_month" }) %>
-    </div>
-  </div>
-
-  <div class="sakes-form-row">
-    <%= form.label(:brew_year, { class: "sakes-form-label" }) %>
-    <div class="sakes-form-two-column-form">
-      <% current_by = to_by(Date.current).year %>
-      <%= year_select_with_japanese_era(id = "sake_brew_year_1i",
-                                        name = "sake[brew_year(1i)]",
-                                        begin_year = current_by,
-                                        selected_year: @sake.brew_year&.year || current_by,
-                                        include_blank: true) %>
-      <%# 使わない月日はBY始まりの7/1とする. See to_by %>
-      <input type="hidden" id="sake_<%= :brew_year %>_2i" name="sake[<%= :brew_year %>(2i)]" value="7">
-      <input type="hidden" id="sake_<%= :brew_year %>_3i" name="sake[<%= :brew_year %>(3i)]" value="1">
-    </div>
-  </div>
-
-  <div class="sakes-form-row">
-    <%= form.label(:size, { class: "sakes-form-badged-label" }) %>
-    <div class="sakes-form-badge">
-      <span class="badge bg-secondary text-dark"><%= t(".badge.obligation") %></span>
-    </div>
-    <div class="sakes-form-short-form">
-      <%= form.number_field(:size, { class: "form-control" }) %>
-    </div>
-  </div>
-
-  <div class="sakes-form-row">
-    <%= form.label(:price, { class: "sakes-form-badged-label" }) %>
-    <div class="sakes-form-badge">
-      <span class="badge bg-secondary text-dark"><%= t(".badge.obligation") %></span>
-    </div>
-    <div class="sakes-form-short-form">
-      <%= form.number_field(:price, { class: "form-control" }) %>
     </div>
   </div>
 
   <%# 表示義務なしのラベル情報 %>
+  <div class="accordion my-2" id="accordionLabelInfoOption">
+    <div class="accordion-item">
+      <h3 class="accordion-header" id="headingLabelInfoOption">
+        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
+          data-bs-target="#collapseLabelInfoOption" aria-expanded="false" aria-controls="collapseLabelInfoOption">
+          <%= t(".labelinfo_option") %>
+        </button>
+      </h3>
+      <div id="collapseLabelInfoOption" class="accordion-collapse collapse"
+        aria-labelledby="headingLabelInfoOption" data-bs-parent="#accordionLabelInfoOption">
+        <div class="accordion-body">
+          <div class="sakes-form-row">
+            <%= form.label(:genryomai, { class: "sakes-form-label" }) %>
+            <div class="col">
+              <%= form.text_field(:genryomai, { class: "form-control" }) %>
+            </div>
+          </div>
 
-  <div class="sakes-form-row">
-    <%= form.label(:genryomai, { class: "sakes-form-label" }) %>
-    <div class="col">
-      <%= form.text_field(:genryomai, { class: "form-control" }) %>
-    </div>
-  </div>
+          <div class="sakes-form-row">
+            <%= form.label(:kakemai, { class: "sakes-form-label" }) %>
+            <div class="col">
+              <%= form.text_field(:kakemai, { class: "form-control" }) %>
+            </div>
+          </div>
 
-  <div class="sakes-form-row">
-    <%= form.label(:kakemai, { class: "sakes-form-label" }) %>
-    <div class="col">
-      <%= form.text_field(:kakemai, { class: "form-control" }) %>
-    </div>
-  </div>
+          <div class="sakes-form-row">
+            <%= form.label(:kobo, { class: "sakes-form-label" }) %>
+            <div class="col">
+              <%= form.text_field(:kobo, { class: "form-control" }) %>
+            </div>
+          </div>
 
-  <div class="sakes-form-row">
-    <%= form.label(:kobo, { class: "sakes-form-label" }) %>
-    <div class="col">
-      <%= form.text_field(:kobo, { class: "form-control" }) %>
-    </div>
-  </div>
+          <div class="sakes-form-row">
+            <%= form.label(:moto, { class: "sakes-form-label" }) %>
+            <div class="sakes-form-short-form">
+              <%= form.select(:moto,
+                              Sake.motos_i18n.keys.map do |k|
+                                [I18n.t("enums.sake.moto.#{k}"), k]
+                              end,
+                              {},
+                              { class: "form-select" }) %>
+            </div>
+          </div>
 
-  <div class="sakes-form-row">
-    <%= form.label(:moto, { class: "sakes-form-label" }) %>
-    <div class="sakes-form-short-form">
-      <%= form.select(:moto,
-                      Sake.motos_i18n.keys.map do |k|
-                        [I18n.t("enums.sake.moto.#{k}"), k]
-                      end,
-                      {},
-                      { class: "form-select" }) %>
-    </div>
-  </div>
+          <div class="sakes-form-row">
+            <%= form.label(:roka, { class: "sakes-form-label" }) %>
+            <div class="col">
+              <%= form.text_field(:roka, { class: "form-control" }) %>
+            </div>
+          </div>
 
-  <div class="sakes-form-row">
-    <%= form.label(:roka, { class: "sakes-form-label" }) %>
-    <div class="col">
-      <%= form.text_field(:roka, { class: "form-control" }) %>
-    </div>
-  </div>
+          <div class="sakes-form-row">
+            <%= form.label(:shibori, { class: "sakes-form-label" }) %>
+            <div class="col">
+              <%= form.text_field(:shibori, { class: "form-control" }) %>
+            </div>
+          </div>
 
-  <div class="sakes-form-row">
-    <%= form.label(:shibori, { class: "sakes-form-label" }) %>
-    <div class="col">
-      <%= form.text_field(:shibori, { class: "form-control" }) %>
-    </div>
-  </div>
+          <div class="sakes-form-row">
+            <%= form.label(:hiire, { class: "sakes-form-label" }) %>
+            <div class="sakes-form-short-form">
+              <%= form.select(:hiire,
+                              Sake.hiires_i18n.keys.map do |k|
+                                [I18n.t("enums.sake.hiire.#{k}"), k]
+                              end,
+                              {},
+                              { class: "form-select", title: "test" }) %>
+            </div>
+          </div>
 
-  <div class="sakes-form-row">
-    <%= form.label(:hiire, { class: "sakes-form-label" }) %>
-    <div class="sakes-form-short-form">
-      <%= form.select(:hiire,
-                      Sake.hiires_i18n.keys.map do |k|
-                        [I18n.t("enums.sake.hiire.#{k}"), k]
-                      end,
-                      {},
-                      { class: "form-select", title: "test" }) %>
-    </div>
-  </div>
+          <div class="sakes-form-row">
+            <%= form.label(:warimizu, { class: "sakes-form-label" }) %>
+            <div class="sakes-form-short-form">
+              <%= form.select(:warimizu,
+                              Sake.warimizus_i18n.keys.map do |k|
+                                [I18n.t("enums.sake.warimizu.#{k}"), k]
+                              end,
+                              {},
+                              { class: "form-select" }) %>
+            </div>
+          </div>
 
-  <div class="sakes-form-row">
-    <%= form.label(:warimizu, { class: "sakes-form-label" }) %>
-    <div class="sakes-form-short-form">
-      <%= form.select(:warimizu,
-                      Sake.warimizus_i18n.keys.map do |k|
-                        [I18n.t("enums.sake.warimizu.#{k}"), k]
-                      end,
-                      {},
-                      { class: "form-select" }) %>
-    </div>
-  </div>
+          <div class="sakes-form-row">
+            <%= form.label(:season, { class: "sakes-form-label" }) %>
+            <div class="col">
+              <%= form.text_field(:season, { class: "form-control" }) %>
+            </div>
+          </div>
 
-  <div class="sakes-form-row">
-    <%= form.label(:season, { class: "sakes-form-label" }) %>
-    <div class="col">
-      <%= form.text_field(:season, { class: "form-control" }) %>
-    </div>
-  </div>
+          <div class="sakes-form-row">
+            <%= form.label(:nihonshudo, { class: "sakes-form-label" }) %>
+            <div class="sakes-form-short-form">
+              <%= form.number_field(:nihonshudo, { step: "any", class: "form-control" }) %>
+            </div>
+          </div>
 
-  <div class="sakes-form-row">
-    <%= form.label(:nihonshudo, { class: "sakes-form-label" }) %>
-    <div class="sakes-form-short-form">
-      <%= form.number_field(:nihonshudo, { step: "any", class: "form-control" }) %>
-    </div>
-  </div>
+          <div class="sakes-form-row">
+            <%= form.label(:sando, { class: "sakes-form-label" }) %>
+            <div class="sakes-form-short-form">
+              <%= form.number_field(:sando, { step: "any", class: "form-control" }) %>
+            </div>
+          </div>
 
-  <div class="sakes-form-row">
-    <%= form.label(:sando, { class: "sakes-form-label" }) %>
-    <div class="sakes-form-short-form">
-      <%= form.number_field(:sando, { step: "any", class: "form-control" }) %>
-    </div>
-  </div>
-
-  <div class="sakes-form-row">
-    <%= form.label(:aminosando, { class: "sakes-form-label" }) %>
-    <div class="sakes-form-short-form">
-      <%= form.number_field(:aminosando, { step: "any", class: "form-control" }) %>
-    </div>
-  </div>
-
-  <div class="sakes-form-row">
-    <%= form.label(:bottle_level, { class: "sakes-form-label" }) %>
-    <div class="sakes-form-short-form">
-      <%= form.select(:bottle_level,
-                      Sake.bottle_levels_i18n.keys.map do |k|
-                        [I18n.t("enums.sake.bottle_level.#{k}"), k]
-                      end,
-                      {},
-                      { class: "form-select" }) %>
+          <div class="sakes-form-row">
+            <%= form.label(:aminosando, { class: "sakes-form-label" }) %>
+            <div class="sakes-form-short-form">
+              <%= form.number_field(:aminosando, { step: "any", class: "form-control" }) %>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 
   <%# 開けてから %>
-  <h3><%= t(".tasteinfo") %></h3>
+  <div class="accordion my-2" id="accordionTasteInfo">
+    <div class="accordion-item">
+      <h3 class="accordion-header" id="headingLabelInfoOption">
+        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
+          data-bs-target="#collapseTasteInfo" aria-expanded="false" aria-controls="collapseTasteInfo">
+          <%= t(".tasteinfo") %>
+        </button>
+      </h3>
+      <div id="collapseTasteInfo" class="accordion-collapse collapse"
+        aria-labelledby="headingTasteInfo" data-bs-parent="#accordionTasteInfo">
+        <div class="accordion-body">
+          <div class="sakes-form-row">
+            <%= form.label(:color, { class: "sakes-form-label" }) %>
+            <div class="col">
+              <%= form.text_field(:color, { class: "form-control" }) %>
+            </div>
+          </div>
 
-  <div class="sakes-form-row">
-    <%= form.label(:color, { class: "sakes-form-label" }) %>
-    <div class="col">
-      <%= form.text_field(:color, { class: "form-control" }) %>
-    </div>
-  </div>
+          <div class="sakes-form-row">
+            <%= form.label(:nigori, { class: "sakes-form-label" }) %>
+            <div class="col">
+              <%= form.text_field(:nigori, { class: "form-control" }) %>
+            </div>
+          </div>
 
-  <div class="sakes-form-row">
-    <%= form.label(:nigori, { class: "sakes-form-label" }) %>
-    <div class="col">
-      <%= form.text_field(:nigori, { class: "form-control" }) %>
-    </div>
-  </div>
+          <div class="sakes-form-row mt-2">
+            <%= form.label("#{t('activerecord.attributes.sake.taste_value')}, #{t('activerecord.attributes.sake.aroma_value')}",
+                           { class: "col-lg-3 col-7 col-form-label" }) %>
+            <div class="col-lg-9 col-5">
+              <div class="btn btn-secondary" id="graph-reset">
+                <%= t(".reset") %>
+              </div>
+            </div>
+            <div class="col-lg-3"></div>
+            <div class="col-lg-9 col">
+              <canvas class="mt-3" id="taste_graph"></canvas>
+              <%= form.number_field(:taste_value,
+                                    hidden: true,
+                                    data: { taste_value: @sake.taste_value }) %>
+              <%= form.number_field(:aroma_value,
+                                    hidden: true,
+                                    data: { aroma_value: @sake.aroma_value }) %>
+            </div>
+          </div>
 
-  <div class="sakes-form-row mt-2">
-    <%= form.label("#{t('activerecord.attributes.sake.taste_value')}, #{t('activerecord.attributes.sake.aroma_value')}",
-                   { class: "col-lg-3 col-7 col-form-label" }) %>
-    <div class="col-lg-9 col-5">
-      <div class="btn btn-secondary" id="graph-reset">
-        <%= t(".reset") %>
+          <div class="sakes-form-row">
+            <%= form.label(:aroma_impression, { class: "sakes-form-label" }) %>
+            <div class="col">
+              <%= form.text_area(:aroma_impression, { class: "form-control" }) %>
+            </div>
+          </div>
+
+          <div class="sakes-form-row">
+            <%= form.label(:taste_impression, { class: "sakes-form-label" }) %>
+            <div class="col">
+              <%= form.text_area(:taste_impression, { class: "form-control" }) %>
+            </div>
+          </div>
+
+          <div class="sakes-form-row">
+            <%= form.label(:awa, { class: "sakes-form-label" }) %>
+            <div class="col">
+              <%= form.text_field(:awa, { class: "form-control" }) %>
+            </div>
+          </div>
+
+          <div class="sakes-form-row">
+            <%= form.label(:note, { class: "sakes-form-label" }) %>
+            <div class="col">
+              <%= form.text_area(:note, { class: "form-control" }) %>
+            </div>
+          </div>
+        </div>
       </div>
-    </div>
-    <div class="col-lg-3"></div>
-    <div class="col-lg-9 col">
-      <canvas class="mt-3" id="taste_graph"></canvas>
-      <%= form.number_field(:taste_value,
-                            hidden: true,
-                            data: { taste_value: @sake.taste_value }) %>
-      <%= form.number_field(:aroma_value,
-                            hidden: true,
-                            data: { aroma_value: @sake.aroma_value }) %>
-    </div>
-  </div>
-
-  <div class="sakes-form-row">
-    <%= form.label(:aroma_impression, { class: "sakes-form-label" }) %>
-    <div class="col">
-      <%= form.text_area(:aroma_impression, { class: "form-control" }) %>
-    </div>
-  </div>
-
-  <div class="sakes-form-row">
-    <%= form.label(:taste_impression, { class: "sakes-form-label" }) %>
-    <div class="col">
-      <%= form.text_area(:taste_impression, { class: "form-control" }) %>
-    </div>
-  </div>
-
-  <div class="sakes-form-row">
-    <%= form.label(:awa, { class: "sakes-form-label" }) %>
-    <div class="col">
-      <%= form.text_field(:awa, { class: "form-control" }) %>
-    </div>
-  </div>
-
-  <div class="sakes-form-row">
-    <%= form.label(:note, { class: "sakes-form-label" }) %>
-    <div class="col">
-      <%= form.text_area(:note, { class: "form-control" }) %>
     </div>
   </div>
 

--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -34,10 +34,7 @@
           </div>
 
           <div class="sakes-form-row">
-            <%= form.label(:kura, { class: "sakes-form-badged-label" }) %>
-            <div class="sakes-form-badge">
-              <span class="badge bg-secondary text-dark"><%= t(".badge.obligation") %></span>
-            </div>
+            <%= form.label(:kura, { class: "sakes-form-label" }) %>
             <div class="col">
               <%= form.text_field(:kura, { class: "form-control", autocomplete: "on", list: "sakagura" }) %>
               <%= render("sakagura-datalist") %>
@@ -84,10 +81,7 @@
           <% end %>
 
           <div class="sakes-form-row">
-            <%= form.label(:alcohol, { class: "sakes-form-badged-label" }) %>
-            <div class="sakes-form-badge">
-              <span class="badge bg-secondary text-dark"><%= t(".badge.obligation") %></span>
-            </div>
+            <%= form.label(:alcohol, { class: "sakes-form-label" }) %>
             <div class="sakes-form-short-form">
               <%= form.number_field(:alcohol,
                                     { step: "any", class: "form-control" }) %>
@@ -95,10 +89,7 @@
           </div>
 
           <div class="sakes-form-row">
-            <%= form.label(:tokutei_meisho, { class: "sakes-form-badged-label" }) %>
-            <div class="sakes-form-badge">
-              <span class="badge bg-secondary text-dark"><%= t(".badge.obligation") %></span>
-            </div>
+            <%= form.label(:tokutei_meisho, { class: "sakes-form-label" }) %>
             <div class="sakes-form-short-form">
               <%= form.select(:tokutei_meisho,
                               Sake.tokutei_meishos_i18n.keys.map do |k|
@@ -110,20 +101,14 @@
           </div>
 
           <div class="sakes-form-row">
-            <%= form.label(:seimai_buai, { class: "sakes-form-badged-label" }) %>
-            <div class="sakes-form-badge">
-              <span class="badge bg-secondary text-dark"><%= t(".badge.obligation") %></span>
-            </div>
+            <%= form.label(:seimai_buai, { class: "sakes-form-label" }) %>
             <div class="sakes-form-short-form">
               <%= form.number_field(:seimai_buai, { class: "form-control" }) %>
             </div>
           </div>
 
           <div class="sakes-form-row">
-            <%= form.label(:bindume_date, { class: "sakes-form-badged-label" }) %>
-            <div class="sakes-form-badge">
-              <span class="badge bg-secondary text-dark"><%= t(".badge.obligation") %></span>
-            </div>
+            <%= form.label(:bindume_date, { class: "sakes-form-label" }) %>
             <%# HACK: 年と月の入力フォームを分けて横並びに配置する。 %>
             <%#       Railsデフォルトでは年月が縦並びになってしまう。%>
             <%#       そのため、2つフォームを設置してTSで同期する。 %>
@@ -156,20 +141,14 @@
           </div>
 
           <div class="sakes-form-row">
-            <%= form.label(:size, { class: "sakes-form-badged-label" }) %>
-            <div class="sakes-form-badge">
-              <span class="badge bg-secondary text-dark"><%= t(".badge.obligation") %></span>
-            </div>
+            <%= form.label(:size, { class: "sakes-form-label" }) %>
             <div class="sakes-form-short-form">
               <%= form.number_field(:size, { class: "form-control" }) %>
             </div>
           </div>
 
           <div class="sakes-form-row">
-            <%= form.label(:price, { class: "sakes-form-badged-label" }) %>
-            <div class="sakes-form-badge">
-              <span class="badge bg-secondary text-dark"><%= t(".badge.obligation") %></span>
-            </div>
+            <%= form.label(:price, { class: "sakes-form-label" }) %>
             <div class="sakes-form-short-form">
               <%= form.number_field(:price, { class: "form-control" }) %>
             </div>

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -2,10 +2,10 @@
   <%= javascript_pack_tag("common", "sakes_index", "data-turbolinks-track": "reload") %>
 <% end %>
 
+<%= render("float-button") %>
+
 <% include_empty = params.dig(:q, :bottle_level_not_eq) == bottom_bottle.to_s %>
 <h2><%= "#{t('.title')} - #{to_shakkan(Sake.alcohol_stock(include_empty: include_empty))}" %></h2>
-
-<%= render("float-button") %>
 
 <%= search_form_for(@searched, { class: "row my-2 align-items-center" }) do |f| %>
   <div class="col input-group">

--- a/app/views/sakes/show.html.erb
+++ b/app/views/sakes/show.html.erb
@@ -5,9 +5,9 @@
   <%= javascript_pack_tag("common", "sakes_show", "data-turbolinks-track": "reload") %>
 <% end %>
 
-<h2 data-testid="<%= sake_path(@sake) %>"><%= t(".title") %></h2>
-
 <%= render("float-button") %>
+
+<h2 data-testid="<%= sake_path(@sake) %>"><%= t(".title") %></h2>
 
 <%# ツイートボタン %>
 <%= tweet_button(t("helper.tweet.text", sake: @sake)) %>

--- a/config/locales/views/sake.ja.yml
+++ b/config/locales/views/sake.ja.yml
@@ -29,7 +29,6 @@ ja:
       tasteinfo: :sakes.show.tasteinfo
       badge:
         presence: 必須
-        obligation: 表示義務
     float-button:
       edit: :sakes.index.edit
       new: 新規

--- a/config/locales/views/sake.ja.yml
+++ b/config/locales/views/sake.ja.yml
@@ -25,6 +25,7 @@ ja:
       reset: リセット
       select_delete_photo: 削除する画像を選択してください
       labelinfo: :sakes.show.labelinfo
+      labelinfo_option: オプショナル
       tasteinfo: :sakes.show.tasteinfo
       badge:
         presence: 必須

--- a/config/locales/views/sake.ja.yml
+++ b/config/locales/views/sake.ja.yml
@@ -29,6 +29,12 @@ ja:
       tasteinfo: :sakes.show.tasteinfo
       badge:
         presence: 必須
+      new:
+        submit: 登録
+      create:
+        submit: :sakes.form.new.submit
+      edit:
+        submit: 更新
     float-button:
       edit: :sakes.index.edit
       new: 新規


### PR DESCRIPTION
close #186

### やったこと

- 酒フォームのアコーディオン化
  - アコーディオンで意味をつけたので、表示義務のバッジを削除
- 酒フォームの登録・更新ボタンのfloat-button化
  - 薄い色のボタンにボーダーを追加
- turbolinksがgemとnpmで重複してたので使っていないgem側を削除
  - turbolinksの動作で不具合を踏んだので修正

### やってないこと、これから検討すること

- 新規登録、drink-buttonによるアコーディオンの動作の検討
  - 評価するとかだと味わいアコーディオンを開きたい
  - 味わいにフォーカス？URLフラグメントを使う？BAD UIにならないか？
- 評価ボタンで酒瓶状態のスタイル強調？
