### PR TITLE
float-buttonがfooterに被らないようにした

### DIFF
--- a/app/packs/src/stylesheet/common.scss
+++ b/app/packs/src/stylesheet/common.scss
@@ -137,6 +137,9 @@ div.sakes-form-label + div input:checked[type="checkbox"] + label::after {
 
 footer {
   @extend .bg-light;
+  @extend .p-3;
+  @extend .pb-lg-3;
+  @extend .pb-5;
 
   font-size: 0.9em;
   color: #777;

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,4 +1,4 @@
-<footer class="p-3">
+<footer>
   <div class="container-xxl">
     <div class="my-1">
       © 2021 Copyright: <a href="https://github.com/momocus/sakazuki">SAKAZUKI</a>

--- a/app/views/sakes/_float-button.html.erb
+++ b/app/views/sakes/_float-button.html.erb
@@ -1,4 +1,4 @@
-<div class="fixed-bottom mb-4 click-transparent">
+<div class="fixed-bottom mb-lg-4 mb-2 click-transparent">
   <div class="px-xxl-5 px-3 text-end">
     <% if controller.action_name == "show" %>
       <%= link_to(tag.i(class: "bi-pencil-square me-2", style: "font-size: 1.05em;") + t(".edit"),


### PR DESCRIPTION
fix #258

![image](https://user-images.githubusercontent.com/849256/132295719-85559108-e6fe-462d-b7ae-78bdc886722e.png)

# 変更点

- 画面サイズが小さいときはfooterの下方向の余白を増やした。
- 画面サイズが小さいときはfloat-buttonの下方向の余白を小さくした。
