### PR TITLE
drink-buttonバッジの薄い色にボーダーを追加した

### DIFF
--- a/app/views/sakes/_drink-button.html.erb
+++ b/app/views/sakes/_drink-button.html.erb
@@ -7,13 +7,13 @@
                 "data-testid": "open-button-#{sake.id}", }) %>
   <%= link_to(tag.i(class: "bi-cup-fill me-1", style: "font-size: 1em;") + t(".impress"),
               edit_sake_path(sake, params: { sake: { bottle_level: "opened" } }),
-              { class: "badge rounded-pill bg-secondary text-dark ms-2",
+              { class: "badge rounded-pill bg-secondary border border-primary text-dark ms-2",
                 "data-testid": "open-and-impress-button-#{sake.id}", }) %>
 <% end %>
 <% if sake.opened? && sake.unimpressed? %>
   <%= link_to(tag.i(class: "bi-cup-fill me-1", style: "font-size: 1em;") + t(".impress"),
               edit_sake_path(sake),
-              { class: "badge rounded-pill bg-secondary text-dark ms-2",
+              { class: "badge rounded-pill bg-secondary border border-primary text-dark ms-2",
                 "data-testid": "impress-button-#{sake.id}", }) %>
 <% end %>
 <% if sake.opened? %>
@@ -21,6 +21,6 @@
               sake_path(sake, params: { sake: { bottle_level: "empty" } }),
               { method: :patch,
                 data: { confirm: t(".confirm_empty") },
-                class: "badge rounded-pill bg-light text-dark ms-2",
+                class: "badge rounded-pill bg-light border border-dark text-dark ms-2",
                 "data-testid": "empty-button-#{sake.id}", }) %>
 <% end %>

--- a/app/views/sakes/_drink-button.html.erb
+++ b/app/views/sakes/_drink-button.html.erb
@@ -5,16 +5,14 @@
                 data: { confirm: t(".confirm_open") },
                 class: "badge rounded-pill bg-primary ms-2",
                 "data-testid": "open-button-#{sake.id}", }) %>
-  <%= link_to(tag.i(class: "bi-cup-fill me-1", style: "font-size: 1em;") + t(".impress"),
-              edit_sake_path(sake, params: { sake: { bottle_level: "opened" } }),
-              { class: "badge rounded-pill bg-secondary border border-primary text-dark ms-2",
-                "data-testid": "open-and-impress-button-#{sake.id}", }) %>
 <% end %>
-<% if sake.opened? && sake.unimpressed? %>
+<% if sake.sealed? || (sake.opened? && sake.unimpressed?) %>
+  <% p = sake.sealed? ? { sake: { bottle_level: "opened" } } : {} %>
+  <% testid = sake.sealed? ? "open-and-impress-button-#{sake.id}" : "impress-button-#{sake.id}" %>
   <%= link_to(tag.i(class: "bi-cup-fill me-1", style: "font-size: 1em;") + t(".impress"),
-              edit_sake_path(sake),
+              edit_sake_path(sake, params: p),
               { class: "badge rounded-pill bg-secondary border border-primary text-dark ms-2",
-                "data-testid": "impress-button-#{sake.id}", }) %>
+                "data-testid": testid, }) %>
 <% end %>
 <% if sake.opened? %>
   <%= link_to(tag.i(class: "bi-droplet me-1", style: "font-size: 0.95em;") + t(".empty"),

--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -317,7 +317,7 @@
             <%= form.label("#{t('activerecord.attributes.sake.taste_value')}, #{t('activerecord.attributes.sake.aroma_value')}",
                            { class: "col-lg-3 col-7 col-form-label" }) %>
             <div class="col-lg-9 col-5">
-              <div class="btn btn-secondary" id="graph-reset">
+              <div class="btn btn-secondary rounded-pill border border-primary" id="graph-reset">
                 <%= t(".reset") %>
               </div>
             </div>


### PR DESCRIPTION
float-buttonにつけたボーダーをdrink-buttonのバッジにもつけた。
見やすいでしょ？

## 変更点

- drink-buttonバッジにボーダーを追加した
- drink-buttonの評価するボタンを共通化リファクタリングした
- 香味グラフのリセットボタンの見た目を、他の押せるボタンと共通化した
