### PR TITLE
turbolinksによってグラフが消える不具合を修正

### DIFF
--- a/app/packs/src/typescript/show_taste_graph.ts
+++ b/app/packs/src/typescript/show_taste_graph.ts
@@ -20,7 +20,7 @@ const hasCanvasID = (elem: HTMLCanvasElement): boolean => {
 
 // Main
 {
-  document.addEventListener("DOMContentLoaded", function () {
+  document.addEventListener("turbolinks:load", function () {
     const canvases = Array.from(document.getElementsByTagName("canvas"))
     const graphs = canvases.filter(hasCanvasID)
     graphs.forEach((canvas) => {


### PR DESCRIPTION
close #259

1行で治ったわ

## やったこと

- TS/JSの発火イベントをDOMContentLoadedからturbolinks:loadに変更した

## やらなかったこと

- turbolinksされないTS/JSの発火イベントはDOMContentLoadedのまま。
  - 問題が起こるページ遷移は酒indexにしかなさそうなので、問題が起きたら考えるlazy。
