### PR TITLE
ユーザー招待制にした

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ gem "rails-i18n"
 # For authentication
 gem "bcrypt"
 gem "devise"
+gem "devise_invitable"
 gem "devise-i18n"
 
 # Create seed data files from the existing data in database

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,6 +131,9 @@ GEM
       warden (~> 1.2.3)
     devise-i18n (1.10.0)
       devise (>= 4.8.0)
+    devise_invitable (2.0.5)
+      actionmailer (>= 5.0)
+      devise (>= 4.6)
     diff-lcs (1.4.4)
     docile (1.4.0)
     domain_name (0.5.20190701)
@@ -433,6 +436,7 @@ DEPENDENCIES
   cloudinary
   devise
   devise-i18n
+  devise_invitable
   dotenv-rails
   elasticsearch-model!
   elasticsearch-rails

--- a/app/controllers/users/InvitationsController.rb
+++ b/app/controllers/users/InvitationsController.rb
@@ -1,0 +1,15 @@
+module Users
+  class InvitationsController < Devise::InvitationsController
+    before_action :accept_admin, only: %i[new create]
+
+    private
+
+    # 招待メールを送れるのはadmin限定とする
+    def accept_admin
+      return if current_user.admin
+
+      flash[:danger] = t("controllers.user.permission_denied")
+      redirect_to(root_url)
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,12 @@
 #  email                  :string           default(""), not null
 #  encrypted_password     :string           default(""), not null
 #  failed_attempts        :integer          default(0), not null
+#  invitation_accepted_at :datetime
+#  invitation_created_at  :datetime
+#  invitation_limit       :integer
+#  invitation_sent_at     :datetime
+#  invitation_token       :string
+#  invited_by_type        :string
 #  last_sign_in_at        :datetime
 #  last_sign_in_ip        :string
 #  locked_at              :datetime
@@ -23,10 +29,12 @@
 #  unlock_token           :string
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
+#  invited_by_id          :integer
 #
 # Indexes
 #
 #  index_users_on_email                 (email) UNIQUE
+#  index_users_on_invitation_token      (invitation_token) UNIQUE
 #  index_users_on_reset_password_token  (reset_password_token) UNIQUE
 #  index_users_on_unlock_token          (unlock_token) UNIQUE
 #
@@ -35,5 +43,6 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
-         :lockable, :timeoutable, :trackable, :confirmable
+         :lockable, :timeoutable, :trackable, :confirmable,
+         :invitable
 end

--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -1,4 +1,4 @@
-<h2><%= t("devise.invitations.edit.header") %></h2>
+<h1><%= t("devise.invitations.edit.header") %></h1>
 <%= form_for(resource, as: resource_name, url: invitation_path(resource_name), html: { method: :put }) do |f| %>
   <%= render("devise/shared/error_messages", resource: resource) %>
   <%= f.hidden_field(:invitation_token, readonly: true) %>

--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -1,0 +1,27 @@
+<h2><%= t("devise.invitations.edit.header") %></h2>
+<%= form_for(resource, as: resource_name, url: invitation_path(resource_name), html: { method: :put }) do |f| %>
+  <%= render("devise/shared/error_messages", resource: resource) %>
+  <%= f.hidden_field(:invitation_token, readonly: true) %>
+
+  <% if f.object.class.require_password_on_accepting %>
+    <div class="devise-row">
+      <%= f.label(:password, { class: "devise-label" }) %>
+      <div class="col">
+        <%= f.password_field(:password, class: "form-control") %>
+      </div>
+    </div>
+
+    <div class="devise-row">
+      <%= f.label(:password_confirmation, { class: "devise-label" }) %>
+      <div class="col">
+        <%= f.password_field(:password_confirmation, class: "form-control") %>
+       </div>
+    </div>
+ <% end %>
+
+  <div class="devise-submit-row">
+    <div class="col-auto">
+      <%= f.submit(t("devise.invitations.edit.submit_button"), { class: "btn btn-primary" }) %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -1,0 +1,20 @@
+<h2><%= t("devise.invitations.new.header") %></h2>
+
+<%= form_for(resource, as: resource_name, url: invitation_path(resource_name), html: { method: :post }) do |f| %>
+  <%= render("devise/shared/error_messages", resource: resource) %>
+
+  <div class="devise-row">
+    <% resource.class.invite_key_fields.each do |field| -%>
+        <%= f.label(field, { class: "devise-label" }) %>
+      <div class="col">
+        <%= f.text_field(field, autofocus: true, class: "form-control") %>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="devise-submit-row">
+    <div class="col-auto">
+      <%= f.submit(t("devise.invitations.new.submit_button"), { class: "btn btn-primary" }) %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -1,4 +1,4 @@
-<h2><%= t("devise.invitations.new.header") %></h2>
+<h1><%= t("devise.invitations.new.header") %></h1>
 
 <%= form_for(resource, as: resource_name, url: invitation_path(resource_name), html: { method: :post }) do |f| %>
   <%= render("devise/shared/error_messages", resource: resource) %>

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -4,7 +4,7 @@
   <%= render("devise/shared/error_messages", resource: resource) %>
 
   <div class="devise-row">
-    <% resource.class.invite_key_fields.each do |field| -%>
+    <% resource.class.invite_key_fields.each do |field| %>
         <%= f.label(field, { class: "devise-label" }) %>
       <div class="col">
         <%= f.text_field(field, autofocus: true, class: "form-control") %>

--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -1,0 +1,12 @@
+<p><%= t("devise.mailer.invitation_instructions.hello", email: @resource.email) %></p>
+
+<p><%= t("devise.mailer.invitation_instructions.someone_invited_you", url: root_url) %></p>
+
+<p><%= link_to(t("devise.mailer.invitation_instructions.accept"), accept_invitation_url(@resource, invitation_token: @token)) %></p>
+
+<% if @resource.invitation_due_at %>
+  <p><%= t("devise.mailer.invitation_instructions.accept_until",
+due_date: l(@resource.invitation_due_at, format: :'devise.mailer.invitation_instructions.accept_until_format')) %></p>
+<% end %>
+
+<p><%= sanitize(t("devise.mailer.invitation_instructions.ignore")) %></p>

--- a/app/views/devise/mailer/invitation_instructions.text.erb
+++ b/app/views/devise/mailer/invitation_instructions.text.erb
@@ -1,0 +1,12 @@
+<%= t("devise.mailer.invitation_instructions.hello", email: @resource.email) %>
+
+<%= t("devise.mailer.invitation_instructions.someone_invited_you", url: root_url) %>
+
+<%= accept_invitation_url(@resource, invitation_token: @token) %>
+
+<% if @resource.invitation_due_at %>
+  <%= t("devise.mailer.invitation_instructions.accept_until",
+due_date: l(@resource.invitation_due_at, format: :'devise.mailer.invitation_instructions.accept_until_format')) %>
+<% end %>
+
+<%= t("devise.mailer.invitation_instructions.ignore") %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,22 +1,22 @@
 <div class="row row-cols-1">
-  <%- if controller_name != "sessions" %>
+  <% if controller_name != "sessions" %>
     <%= link_to(t(".sign_in"), new_session_path(resource_name), class: "col") %>
   <% end %>
 
-  <%- if devise_mapping.recoverable? && controller_name != "passwords" && controller_name != "registrations" %>
+  <% if devise_mapping.recoverable? && controller_name != "passwords" && controller_name != "registrations" %>
     <%= link_to(t(".forgot_your_password"), new_password_path(resource_name), class: "col") %>
   <% end %>
 
-  <%- if devise_mapping.confirmable? && controller_name != "confirmations" %>
+  <% if devise_mapping.confirmable? && controller_name != "confirmations" %>
     <%= link_to(t(".didn_t_receive_confirmation_instructions"), new_confirmation_path(resource_name), class: "col") %>
   <% end %>
 
-  <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != "unlocks" %>
+  <% if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != "unlocks" %>
     <%= link_to(t(".didn_t_receive_unlock_instructions"), new_unlock_path(resource_name), class: "col") %>
   <% end %>
 
-  <%- if devise_mapping.omniauthable? %>
-    <%- resource_class.omniauth_providers.each do |provider| %>
+  <% if devise_mapping.omniauthable? %>
+    <% resource_class.omniauth_providers.each do |provider| %>
       <%= link_to(t(".sign_in_with_provider", provider: OmniAuth::Utils.camelize(provider)),
                   omniauth_authorize_path(resource_name, provider),
                   class: "col") %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -5,7 +5,7 @@
         <% each_page do |page| %>
           <% if page.left_outer? || page.right_outer? || page.inside_window? %>
             <%= page_tag(page) %>
-          <% elsif !page.was_truncated? -%>
+          <% elsif !page.was_truncated? %>
             <%= gap_tag %>
           <% end %>
         <% end %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -21,7 +21,7 @@
             </li>
             <% if current_user.admin %>
               <li class="nav-item">
-                <%= link_to("Invitation", new_user_invitation_path, class: "nav-link", "data-testid": "invitation") %>
+                <%= link_to("Invitation", new_user_invitation_path, class: "nav-link", "data-testid": "invitation-link") %>
               </li>
             <% end %>
             <li class="nav-item">

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -19,6 +19,11 @@
             <li class="nav-item">
               <%= link_to(current_user.email, edit_user_registration_path, class: "nav-link") %>
             </li>
+            <% if current_user.admin %>
+              <li class="nav-item">
+                <%= link_to("Invitation", new_user_invitation_path, class: "nav-link", "data-testid": "invitation") %>
+              </li>
+            <% end %>
             <li class="nav-item">
               <%= link_to("Sign out", destroy_user_session_path, method: :delete, class: "nav-link") %>
             </li>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -140,6 +140,55 @@ Devise.setup do |config|
   # Send a notification email when the user's password is changed.
   # config.send_password_change_notification = false
 
+  # ==> Configuration for :invitable
+  # The period the generated invitation token is valid.
+  # After this period, the invited resource won't be able to accept the invitation.
+  # When invite_for is 0 (the default), the invitation won't expire.
+  config.invite_for = 1.weeks
+
+  # Number of invitations users can send.
+  # - If invitation_limit is nil, there is no limit for invitations, users can
+  # send unlimited invitations, invitation_limit column is not used.
+  # - If invitation_limit is 0, users can't send invitations by default.
+  # - If invitation_limit n > 0, users can send n invitations.
+  # You can change invitation_limit column for some users so they can send more
+  # or less invitations, even with global invitation_limit = 0
+  # Default: nil
+  # config.invitation_limit = 5
+
+  # The key to be used to check existing users when sending an invitation
+  # and the regexp used to test it when validate_on_invite is not set.
+  # config.invite_key = { email: /\A[^@]+@[^@]+\z/ }
+  # config.invite_key = { email: /\A[^@]+@[^@]+\z/, username: nil }
+
+  # Ensure that invited record is valid.
+  # The invitation won't be sent if this check fails.
+  # Default: false
+  # config.validate_on_invite = true
+
+  # Resend invitation if user with invited status is invited again
+  # Default: true
+  # config.resend_invitation = false
+
+  # The class name of the inviting model. If this is nil,
+  # the #invited_by association is declared to be polymorphic.
+  # Default: nil
+  # config.invited_by_class_name = 'User'
+
+  # The foreign key to the inviting model (if invited_by_class_name is set)
+  # Default: :invited_by_id
+  # config.invited_by_foreign_key = :invited_by_id
+
+  # The column name used for counter_cache column. If this is nil,
+  # the #invited_by association is declared without counter_cache.
+  # Default: nil
+  # config.invited_by_counter_cache = :invitations_count
+
+  # Auto-login after the user accepts the invite. If this is false,
+  # the user will need to manually log in after accepting the invite.
+  # Default: true
+  # config.allow_insecure_sign_in_after_accept = false
+
   # ==> Configuration for :confirmable
   # A period that the user is allowed to access the website even without
   # confirming their account. For instance, if set to 2.days, the user will be

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: {
     registrations: "users/registrations",
+    invitations: "users/invitations",
   }
   root "sakes#index"
   resources :sakes do

--- a/db/migrate/20210829172516_add_devise_invitable_to_users.rb
+++ b/db/migrate/20210829172516_add_devise_invitable_to_users.rb
@@ -1,0 +1,12 @@
+class AddDeviseInvitableToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :invitation_token, :string
+    add_column :users, :invitation_created_at, :datetime
+    add_column :users, :invitation_sent_at, :datetime
+    add_column :users, :invitation_accepted_at, :datetime
+    add_column :users, :invitation_limit, :integer
+    add_column :users, :invited_by_id, :integer
+    add_column :users, :invited_by_type, :string
+    add_index :users, :invitation_token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_26_072328) do
+ActiveRecord::Schema.define(version: 2021_08_29_172516) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -79,7 +79,15 @@ ActiveRecord::Schema.define(version: 2021_01_26_072328) do
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email"
+    t.string "invitation_token"
+    t.datetime "invitation_created_at"
+    t.datetime "invitation_sent_at"
+    t.datetime "invitation_accepted_at"
+    t.integer "invitation_limit"
+    t.integer "invited_by_id"
+    t.string "invited_by_type"
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
   end

--- a/spec/system/user_invitation_spec.rb
+++ b/spec/system/user_invitation_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe "User invitation", type: :system do
+  let!(:admin) { FactoryBot.create(:user, admin: true) }
+  let!(:bartender) { FactoryBot.create(:user, admin: false) }
+
+  before do
+    sign_out(admin)
+    sign_out(bartender)
+  end
+
+  context "when someone accesses to invitation url" do
+    describe "admin" do
+      before do
+        sign_in(admin)
+        visit new_user_invitation_path
+      end
+      it "can visit user invitation page" do
+        expect(page).to have_current_path new_user_invitation_path
+      end
+    end
+    describe "bartender" do
+      before do
+        sign_in(bartender)
+        visit new_user_invitation_path
+      end
+
+      it "is redirected to index page" do
+        expect(page).to have_current_path root_path
+      end
+    end
+    describe "not signed in user" do
+      before do
+        visit new_user_invitation_path
+      end
+      it "is redirected to sign in page" do
+        expect(page).to have_current_path new_user_session_path
+      end
+    end
+  end
+end

--- a/spec/system/user_invitation_spec.rb
+++ b/spec/system/user_invitation_spec.rb
@@ -2,39 +2,45 @@ require "rails_helper"
 
 RSpec.describe "User invitation", type: :system do
   let!(:admin) { FactoryBot.create(:user, admin: true) }
-  let!(:bartender) { FactoryBot.create(:user, admin: false) }
+  let!(:user) { FactoryBot.create(:user, admin: false) }
 
   before do
     sign_out(admin)
-    sign_out(bartender)
+    sign_out(user)
   end
 
-  context "when someone accesses to invitation url" do
-    describe "admin" do
-      before do
+  describe "accesses to user invitation page" do
+    context "when sign in as admin" do
+      it "allows to access user invitation page" do
         sign_in(admin)
         visit new_user_invitation_path
-      end
-      it "can visit user invitation page" do
         expect(page).to have_current_path new_user_invitation_path
       end
     end
-    describe "bartender" do
-      before do
-        sign_in(bartender)
-        visit new_user_invitation_path
-      end
 
-      it "is redirected to index page" do
+    context "when sign in as user" do
+      it "redirects to index page" do
+        sign_in(user)
+        visit new_user_invitation_path
         expect(page).to have_current_path root_path
       end
-    end
-    describe "not signed in user" do
-      before do
+
+      it "has error message" do
+        sign_in(user)
         visit new_user_invitation_path
+        expect(page).to have_css(".alert-danger")
       end
-      it "is redirected to sign in page" do
+    end
+
+    context "when not sign in" do
+      it "redirects to sign in page" do
+        visit new_user_invitation_path
         expect(page).to have_current_path new_user_session_path
+      end
+
+      it "has error message" do
+        visit new_user_invitation_path
+        expect(page).to have_css(".alert-danger")
       end
     end
   end


### PR DESCRIPTION
#67

Adminユーザーから招待メールを送ってユーザー追加できるようにした。
使ったgemはこちら-> https://github.com/scambra/devise_invitable

招待するリンクはとりあえずヘッダーに配置した。（※リンクは移設予定なので翻訳していない。）
![image](https://user-images.githubusercontent.com/6294782/132459832-177bab2f-2724-4c5a-aa20-48e729774f54.png)

招待された側にはメールが届く。
![image](https://user-images.githubusercontent.com/6294782/132459694-c51a6d68-5805-4a6d-95c6-4d7e51ef0dad.png)

---
やっていないこと: 
ユーザー管理画面はまだない。たとえばこんなの↓
https://railstutorial.jp/chapters/updating_and_deleting_users?version=4.2#sec-showing_all_users
ユーザー管理画面をつくったら、現在ヘッダーに置いているInvitationボタンを移設する。
また、ユーザー管理画面から、Adminがほかのユーザーを削除したり、Admin権限を持つユーザーを増やせるようにしよっかな～って考えてる。