### PR TITLE
ページ見出しをh1から始めるようにした

### DIFF
--- a/app/packs/src/stylesheet/bootstrap_custom.scss
+++ b/app/packs/src/stylesheet/bootstrap_custom.scss
@@ -6,3 +6,5 @@ $warning: #8e8a19;
 $info: #198e8e;
 $light: #dee2e6;
 $white: #f8f9fa;
+
+$h1-font-size: 2.25rem;

--- a/app/packs/src/stylesheet/common.scss
+++ b/app/packs/src/stylesheet/common.scss
@@ -1,6 +1,10 @@
 @import "bootstrap_custom";
 @import "~bootstrap/scss/bootstrap";
 
+h1 {
+  @extend .my-2;
+}
+
 .click-transparent {
   pointer-events: none;
 }

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,4 +1,4 @@
-<h2><%= t(".resend_confirmation_instructions") %></h2>
+<h1><%= t(".resend_confirmation_instructions") %></h1>
 
 <%= form_for(resource,
              as: resource_name,

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,4 +1,4 @@
-<h2><%= t(".change_your_password") %></h2>
+<h1><%= t(".change_your_password") %></h1>
 
 <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
   <%= render("devise/shared/error_messages", resource: resource) %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,4 +1,4 @@
-<h2><%= t(".forgot_your_password") %></h2>
+<h1><%= t(".forgot_your_password") %></h1>
 
 <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
   <%= render("devise/shared/error_messages", resource: resource) %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,4 +1,4 @@
-<h2><%= t(".title", resource: resource.model_name.human) %></h2>
+<h1><%= t(".title", resource: resource.model_name.human) %></h1>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
   <%= render("devise/shared/error_messages", resource: resource) %>
@@ -51,7 +51,7 @@
   </div>
 <% end %>
 
-<h3><%= t(".unhappy") %></h3>
+<h2><%= t(".unhappy") %></h2>
 
 <div class="devise-submit-row">
   <div class="col-auto">

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,4 +1,4 @@
-<h2 data-testid="<%= new_user_session_path %>"><%= t(".sign_in") %></h2>
+<h1 data-testid="<%= new_user_session_path %>"><%= t(".sign_in") %></h1>
 
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
 

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -1,4 +1,4 @@
-<h2><%= t(".resend_unlock_instructions") %></h2>
+<h1><%= t(".resend_unlock_instructions") %></h1>
 
 <%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
   <%= render("devise/shared/error_messages", resource: resource) %>

--- a/app/views/elasticsearch/index.html.erb
+++ b/app/views/elasticsearch/index.html.erb
@@ -1,4 +1,4 @@
-<h2><%= t("views.elasticsearch.title") %></h2>
+<h1><%= t("views.elasticsearch.title") %></h1>
 
 <%= form_with(scope: :elasticsearch,
               url: elasticsearch_path,

--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -16,12 +16,12 @@
   <%# 表示義務ありのラベル情報 %>
   <div class="accordion my-2" id="accordionLabelInfo">
     <div class="accordion-item">
-      <h3 class="accordion-header" id="headingLabelInfo">
+      <h2 class="accordion-header" id="headingLabelInfo">
         <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseLabelInfo"
           aria-expanded="true" aria-controls="collapseLabelInfo">
           <%= t(".labelinfo") %>
         </button>
-      </h3>
+      </h2>
       <div id="collapseLabelInfo" class="accordion-collapse collapse show" aria-labelledby="headingLabelInfo"
         data-bs-parent="#accordionLabelInfo">
         <div class="accordion-body">
@@ -175,12 +175,12 @@
   <%# 表示義務なしのラベル情報 %>
   <div class="accordion my-2" id="accordionLabelInfoOption">
     <div class="accordion-item">
-      <h3 class="accordion-header" id="headingLabelInfoOption">
+      <h2 class="accordion-header" id="headingLabelInfoOption">
         <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
           data-bs-target="#collapseLabelInfoOption" aria-expanded="false" aria-controls="collapseLabelInfoOption">
           <%= t(".labelinfo_option") %>
         </button>
-      </h3>
+      </h2>
       <div id="collapseLabelInfoOption" class="accordion-collapse collapse"
         aria-labelledby="headingLabelInfoOption" data-bs-parent="#accordionLabelInfoOption">
         <div class="accordion-body">
@@ -290,12 +290,12 @@
   <%# 開けてから %>
   <div class="accordion my-2" id="accordionTasteInfo">
     <div class="accordion-item">
-      <h3 class="accordion-header" id="headingLabelInfoOption">
+      <h2 class="accordion-header" id="headingLabelInfoOption">
         <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
           data-bs-target="#collapseTasteInfo" aria-expanded="false" aria-controls="collapseTasteInfo">
           <%= t(".tasteinfo") %>
         </button>
-      </h3>
+      </h2>
       <div id="collapseTasteInfo" class="accordion-collapse collapse"
         aria-labelledby="headingTasteInfo" data-bs-parent="#accordionTasteInfo">
         <div class="accordion-body">

--- a/app/views/sakes/edit.html.erb
+++ b/app/views/sakes/edit.html.erb
@@ -1,3 +1,3 @@
-<h2 data-testid="<%= edit_sake_path(@sake) %>"><%= t(".title") %></h2>
+<h1 data-testid="<%= edit_sake_path(@sake) %>"><%= t(".title") %></h1>
 
 <%= render("form", sake: @sake) %>

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -5,7 +5,7 @@
 <%= render("float-button") %>
 
 <% include_empty = params.dig(:q, :bottle_level_not_eq) == bottom_bottle.to_s %>
-<h2><%= "#{t('.title')} - #{to_shakkan(Sake.alcohol_stock(include_empty: include_empty))}" %></h2>
+<h1><%= "#{t('.title')} - #{to_shakkan(Sake.alcohol_stock(include_empty: include_empty))}" %></h1>
 
 <%= search_form_for(@searched, { class: "row my-2 align-items-center" }) do |f| %>
   <div class="col input-group">

--- a/app/views/sakes/new.html.erb
+++ b/app/views/sakes/new.html.erb
@@ -1,3 +1,3 @@
-<h2><%= t(".title") %></h2>
+<h1><%= t(".title") %></h1>
 
 <%= render("form", sake: @sake) %>

--- a/app/views/sakes/show.html.erb
+++ b/app/views/sakes/show.html.erb
@@ -7,14 +7,14 @@
 
 <%= render("float-button") %>
 
-<h2 data-testid="<%= sake_path(@sake) %>"><%= t(".title") %></h2>
+<h1 data-testid="<%= sake_path(@sake) %>"><%= t(".title") %></h1>
 
 <%# ツイートボタン %>
 <%= tweet_button(t("helper.tweet.text", sake: @sake)) %>
 <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 
 <%# 表示義務ありのラベル情報 %>
-<h3 class="my-2"><%= t(".labelinfo") %></h3>
+<h2 class="my-2"><%= t(".labelinfo") %></h2>
 
 <div class="row">
   <div class="sakes-show-label">
@@ -195,7 +195,7 @@
 </div>
 
 <%# 開けてから %>
-<h3 class="my-2"><%= t(".tasteinfo") %></h3>
+<h2 class="my-2"><%= t(".tasteinfo") %></h2>
 
 <div class="row">
   <div class="sakes-show-label">


### PR DESCRIPTION
#263 の作り直し
close #261.

## 今までと問題点

- 今までは見出しがh2から始まっていた
  - 理由はh1タグでのBootstrapデフォルト文字サイズが大きすぎて見栄えが悪いから
- 見出しh1はブラウザや検索クローラから特殊扱いされることがあり、1ページに1つが推奨されている

## やったこと

- 見出しタグをh1から始めた
  - 合わせてh3以降の見出しも順番通り使うように変更した
- Bootstrapをカスタマイズしてh1文字サイズを調整した
  - 内容は[Wiki](https://github.com/momocus/sakazuki/wiki/Design)に書いておいた
- 見出しh1部がヘッダーと近すぎたため、微調整した
