### PR TITLE
CloudinaryのURLにhttpsを強制するようにした

### DIFF
--- a/config/initializers/cloudinary.rb
+++ b/config/initializers/cloudinary.rb
@@ -1,4 +1,6 @@
 Cloudinary.config do |config|
+  config.secure = true
+
   if Rails.env.production?
     config.cloud_name = Rails.application.credentials.cloudinary[:cloud_name]
     config.api_key = Rails.application.credentials.cloudinary[:api_key]


### PR DESCRIPTION
fix #275

今までは特に設定をしていなかった。
そのため古いSDKではHTTPのURLが生成される可能性があった。
そこでCloudinaryの設定を変更し、常にHTTPSを強制するようにした。

参考：
https://cloudinary.com/documentation/cloudinary_sdks#configuration_parameters
