### PR TITLE
味・香りでのソートを追加した

### DIFF
--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -33,8 +33,8 @@
     </div>
   </div>
 
-  <div class="col-md mt-md-0 col-12 mt-2">
-    <div class="btn-group float-md-end" role="group" aria-label="Sort">
+  <div class="col-lg mt-lg-0 col-12 mt-2">
+    <div class="btn-group float-lg-end" role="group" aria-label="Sort">
       <%= sort_link(@searched,
                     :tokutei_meisho,
                     t("activerecord.attributes.sake.tokutei_meisho")) %>
@@ -44,6 +44,14 @@
       <%= sort_link(@searched,
                     :bottle_level,
                     t("activerecord.attributes.sake.bottle_level")) %>
+      <%= sort_link(@searched,
+                    :taste_value,
+                    t("activerecord.attributes.sake.taste_impression"),
+                    default_order: :desc) %>
+      <%= sort_link(@searched,
+                    :aroma_value,
+                    t("activerecord.attributes.sake.aroma_impression"),
+                    default_order: :desc) %>
     </div>
   </div>
 <% end %>

--- a/config/initializers/ransack.rb
+++ b/config/initializers/ransack.rb
@@ -2,4 +2,9 @@ Ransack.configure do |c|
   # Raise errors if a query contains an unknown predicate or attribute.
   # Default is true (do not raise error on unknown conditions).
   c.ignore_unknown_conditions = false
+
+  # ソート時NULL値を一番小さな数値として扱う
+  # TODO: Ransackのバージョンが上がったら:nulls_always_last（常に最後）を採用する
+  c.postgres_fields_sort_option = :nulls_first
+  # c.postgres_fields_sort_option = :nulls_always_last
 end


### PR DESCRIPTION
close #279
Issue #126 に関連

味・香りのソート欲しくなったの。

## やったこと

- 味・香りソートを追加
- ソート項目が横長になったので早めに折り返されるようデザインを調整
- 味・香りソートで未評価（NULL）を最小値と扱うようにした
  - Ransackがアップデートされたら:nulls_always_lastを使ってどんなソートでもNULLは最後にしたい
  - 現状、5月に実装済みだが、リリースバージョンに乗っていない
