### PR TITLE
酒Showページのh1見出しを酒の名前にした 

### DIFF
--- a/app/views/sakes/show.html.erb
+++ b/app/views/sakes/show.html.erb
@@ -7,8 +7,7 @@
 
 <%= render("float-button") %>
 
-<div data-testid="<%= sake_path(@sake) %>" style="visibility:hidden"></div>
-<h1 data-testid="sake-name"><%= @sake.name %></h1>
+<h1 data-testid="<%= sake_path(@sake) %>"><%= @sake.name %></h1>
 
 <%# ツイートボタン %>
 <%= tweet_button(t("helper.tweet.text", sake: @sake)) %>

--- a/app/views/sakes/show.html.erb
+++ b/app/views/sakes/show.html.erb
@@ -7,7 +7,8 @@
 
 <%= render("float-button") %>
 
-<h1 data-testid="<%= sake_path(@sake) %>"><%= t(".title") %></h1>
+<div data-testid="<%= sake_path(@sake) %>" style="visibility:hidden"></div>
+<h1 data-testid="sake-name"><%= @sake.name %></h1>
 
 <%# ツイートボタン %>
 <%= tweet_button(t("helper.tweet.text", sake: @sake)) %>
@@ -17,13 +18,6 @@
 <h2 class="my-2"><%= t(".labelinfo") %></h2>
 
 <div class="row">
-  <div class="sakes-show-label">
-    <b><%= Sake.human_attribute_name(:name) %></b>
-  </div>
-  <div class="sakes-show-body" data-testid="sake-name">
-    <%= @sake.name %>
-  </div>
-
   <div class="sakes-show-label">
     <b><%= Sake.human_attribute_name(:kura) %></b>
   </div>

--- a/spec/system/sake_create_spec.rb
+++ b/spec/system/sake_create_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "AfterUpdateAction", type: :system do
     end
 
     it "has specified sake name" do
-      expect(find(:test_id, "sake-name")).to have_text(sake_name)
+      expect(find("h1")).to have_text(sake_name)
     end
 
     it "redirect to created sake page" do


### PR DESCRIPTION
Close #269

酒Showページのh1見出しを酒の名前にした。
![image](https://user-images.githubusercontent.com/6294782/133416691-4753e7e4-3463-41ff-b6db-45893bd39033.png)

visibility:hiddenのdivタグ作ってwait_for_page用のdata-tesidをつけたけど、これでいいかな？

