### PR TITLE
小さい画面でページネーションを隠さないようにした

### DIFF
--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,3 +1,3 @@
-<li class="page-item-lg disabled">
+<li class="page-item disabled">
   <%= link_to(sanitize(t("views.pagination.truncate")), "#", { class: "page-link" }) %>
 </li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,3 +1,3 @@
 <li class="page-item <%= "disabled" if current_page.last? %>">
-  <%= link_to(sanitize(t("views.pagination.next")), url, { rel: "next", remote: remote, class: "page-link" }) %>
+  <%= link_to(tag.i(class: "bi-chevron-right"), url, { rel: "next", remote: remote, class: "page-link" }) %>
 </li>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,9 +1,9 @@
 <% if page.current? %>
-  <li class="page-item-lg active">
+  <li class="page-item active">
     <%= tag.a(page, data: { remote: remote }, class: "page-link", rel: page.rel) %>
   </li>
 <% else %>
-  <li class="page-item-lg">
+  <li class="page-item">
     <%= link_to(page, url, { remote: remote, rel: page.rel, class: "page-link" }) %>
   </li>
 <% end %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -9,7 +9,7 @@
           <%= gap_tag %>
         <% end %>
       <% end %>
-      <%= next_page_tag unless current_page.last? %>
+      <%= next_page_tag %>
     </ul>
   </nav>
 <% end %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,15 +1,15 @@
 <%= paginator.render do %>
-    <nav>
-      <ul class="pagination" style="justify-content: center">
-        <%= prev_page_tag %>
-        <% each_page do |page| %>
-          <% if page.left_outer? || page.right_outer? || page.inside_window? %>
-            <%= page_tag(page) %>
-          <% elsif !page.was_truncated? %>
-            <%= gap_tag %>
-          <% end %>
+  <nav>
+    <ul class="pagination" style="justify-content: center">
+      <%= prev_page_tag %>
+      <% each_page do |page| %>
+        <% if page.left_outer? || page.right_outer? || page.inside_window? %>
+          <%= page_tag(page) %>
+        <% elsif !page.was_truncated? %>
+          <%= gap_tag %>
         <% end %>
-        <%= next_page_tag unless current_page.last? %>
-      </ul>
-    </nav>
+      <% end %>
+      <%= next_page_tag unless current_page.last? %>
+    </ul>
+  </nav>
 <% end %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,3 +1,3 @@
 <li class="page-item <%= "disabled" if current_page.first? %>">
-  <%= link_to(sanitize(t("views.pagination.previous")), url, { rel: "prev", remote: remote, class: "page-link" }) %>
+  <%= link_to(tag.i(class: "bi-chevron-left"), url, { rel: "prev", remote: remote, class: "page-link" }) %>
 </li>


### PR DESCRIPTION
ページネーションの細かな改善。
スマホでも結構入りきる。

![image](https://user-images.githubusercontent.com/849256/133491980-76c93aec-88f6-4773-9746-1f4d9705c3cc.png)

## やったこと

- 小さな画面サイズでもページネーション番号を隠さず表示するようにした
- ページネーションの「前」「次」ボタンを、Bootstrap Iconsの「＜」「＞」にした
- ページネーションの「＜」「＞」ボタンを常に表示するように統一した
