### PR TITLE
Elasticsearchページのh1見出しを修正

### DIFF
--- a/app/views/elasticsearch/index.html.erb
+++ b/app/views/elasticsearch/index.html.erb
@@ -1,4 +1,4 @@
-<h1><%= t("views.elasticsearch.title") %></h1>
+<h1><%= t(".title") %></h1>
 
 <%= form_with(scope: :elasticsearch,
               url: elasticsearch_path,

--- a/config/locales/views/elasticsearch.ja.yml
+++ b/config/locales/views/elasticsearch.ja.yml
@@ -1,0 +1,4 @@
+ja:
+  elasticsearch:
+    index:
+      title: Elasticsearch


### PR DESCRIPTION
Close #286 

翻訳に失敗してElasticsearchページの見出しが「Title」になっていたのを直した