### PR TITLE
味香りグラフの濃淡をわかりやすくした

### DIFF
--- a/app/packs/src/typescript/taste_graph.ts
+++ b/app/packs/src/typescript/taste_graph.ts
@@ -164,6 +164,7 @@ export class TasteGraph implements InteractiveGraph {
         ],
         yAxes: [
           {
+            position: "left",
             ticks: ticks,
             gridLines: gridLines,
             scaleLabel: {

--- a/app/packs/src/typescript/taste_graph.ts
+++ b/app/packs/src/typescript/taste_graph.ts
@@ -136,53 +136,48 @@ export class TasteGraph implements InteractiveGraph {
       drawOnChartArea: true,
       zeroLineWidth: defaultedConfig.zeroLineWidth,
     }
+    const xAxe: Chart.ChartXAxe = {
+      position: "bottom",
+      ticks: ticks,
+      gridLines: gridLines,
+      scaleLabel: {
+        display: true,
+        labelString: "香りが低い",
+      },
+    }
+    const dummyXAxe: Chart.ChartXAxe = {
+      position: "top",
+      ticks: baseTicks,
+      gridLines: baseGridLines,
+      scaleLabel: {
+        display: true,
+        labelString: "香りが高い",
+      },
+    }
+    const yAxe: Chart.ChartYAxe = {
+      position: "left",
+      ticks: ticks,
+      gridLines: gridLines,
+      scaleLabel: {
+        display: true,
+        labelString: "味が淡い",
+      },
+    }
+    const dummyYAxe: Chart.ChartYAxe = {
+      position: "right",
+      ticks: baseTicks,
+      gridLines: baseGridLines,
+      scaleLabel: {
+        display: true,
+        labelString: "味が濃い",
+      },
+    }
     const options: Chart.ChartOptions = {
       onClick: this.clickable ? this.onClickUpdate : (_event) => {},
       legend: { display: false },
       elements: { point: { radius: defaultedConfig.pointRadius } },
       // HACK: ダミーの軸を使って高低両方にラベルをつける
-      scales: {
-        xAxes: [
-          {
-            position: "bottom",
-            ticks: ticks,
-            gridLines: gridLines,
-            scaleLabel: {
-              display: true,
-              labelString: "香りが低い",
-            },
-          },
-          {
-            position: "top",
-            ticks: baseTicks,
-            gridLines: baseGridLines,
-            scaleLabel: {
-              display: true,
-              labelString: "香りが高い",
-            },
-          },
-        ],
-        yAxes: [
-          {
-            position: "left",
-            ticks: ticks,
-            gridLines: gridLines,
-            scaleLabel: {
-              display: true,
-              labelString: "味が淡い",
-            },
-          },
-          {
-            position: "right",
-            ticks: baseTicks,
-            gridLines: baseGridLines,
-            scaleLabel: {
-              display: true,
-              labelString: "味が濃い",
-            },
-          },
-        ],
-      },
+      scales: { xAxes: [xAxe, dummyXAxe], yAxes: [yAxe, dummyYAxe] },
     }
     // 各4象限を別々に色付けする
     // https://github.com/chartjs/Chart.js/issues/3535

--- a/app/packs/src/typescript/taste_graph.ts
+++ b/app/packs/src/typescript/taste_graph.ts
@@ -118,55 +118,53 @@ export class TasteGraph implements InteractiveGraph {
       ...config,
     }
     const margin = 0.2
-    const baseTicks: Chart.TickOptions = {
-      display: false,
-    }
     const ticks: Chart.TickOptions = {
-      ...baseTicks,
+      display: false,
       max: middle + margin,
       min: -middle - margin,
       maxTicksLimit: 2,
     }
-    const baseGridLines: Chart.GridLineOptions = {
+    const dummyGridLines: Chart.GridLineOptions = {
       drawTicks: false,
       drawOnChartArea: false,
     }
     const gridLines: Chart.GridLineOptions = {
-      ...baseGridLines,
+      drawTicks: false,
       drawOnChartArea: true,
       zeroLineWidth: defaultedConfig.zeroLineWidth,
     }
-    const xAxe: Chart.ChartXAxe = {
-      position: "bottom",
+    const baseAxe: Chart.ChartXAxe = {
       ticks: ticks,
       gridLines: gridLines,
+    }
+    const xAxe: Chart.ChartXAxe = {
+      ...baseAxe,
+      position: "bottom",
       scaleLabel: {
         display: true,
         labelString: "香りが低い",
       },
     }
     const dummyXAxe: Chart.ChartXAxe = {
+      ...baseAxe,
       position: "top",
-      ticks: baseTicks,
-      gridLines: baseGridLines,
       scaleLabel: {
         display: true,
         labelString: "香りが高い",
       },
     }
     const yAxe: Chart.ChartYAxe = {
+      ...baseAxe,
       position: "left",
-      ticks: ticks,
-      gridLines: gridLines,
       scaleLabel: {
         display: true,
         labelString: "味が淡い",
       },
     }
     const dummyYAxe: Chart.ChartYAxe = {
+      ...baseAxe,
+      gridLines: dummyGridLines, // HACK: X軸（y=0）の二重描きを防ぐ
       position: "right",
-      ticks: baseTicks,
-      gridLines: baseGridLines,
       scaleLabel: {
         display: true,
         labelString: "味が濃い",

--- a/app/packs/src/typescript/taste_graph.ts
+++ b/app/packs/src/typescript/taste_graph.ts
@@ -117,15 +117,21 @@ export class TasteGraph implements InteractiveGraph {
       ...config,
     }
     const margin = 0.2
-    const ticks: Chart.TickOptions = {
+    const baseTicks: Chart.TickOptions = {
       display: false,
+    }
+    const ticks: Chart.TickOptions = {
+      ...baseTicks,
       max: middle + margin,
       min: -middle - margin,
       maxTicksLimit: 2,
     }
-    const gridLines: Chart.GridLineOptions = {
-      drawBorder: true,
+    const baseGridLines: Chart.GridLineOptions = {
       drawTicks: false,
+      drawOnChartArea: false,
+    }
+    const gridLines: Chart.GridLineOptions = {
+      ...baseGridLines,
       drawOnChartArea: true,
       zeroLineWidth: defaultedConfig.zeroLineWidth,
     }
@@ -133,14 +139,25 @@ export class TasteGraph implements InteractiveGraph {
       onClick: this.clickable ? this.onClickUpdate : (_event) => {},
       legend: { display: false },
       elements: { point: { radius: defaultedConfig.pointRadius } },
+      // HACK: ダミーの軸を使って高低両方にラベルをつける
       scales: {
         xAxes: [
           {
+            position: "bottom",
             ticks: ticks,
             gridLines: gridLines,
             scaleLabel: {
               display: true,
-              labelString: "香",
+              labelString: "香りが低い",
+            },
+          },
+          {
+            position: "top",
+            ticks: baseTicks,
+            gridLines: baseGridLines,
+            scaleLabel: {
+              display: true,
+              labelString: "香りが高い",
             },
           },
         ],
@@ -150,7 +167,16 @@ export class TasteGraph implements InteractiveGraph {
             gridLines: gridLines,
             scaleLabel: {
               display: true,
-              labelString: "味",
+              labelString: "味が淡い",
+            },
+          },
+          {
+            position: "right",
+            ticks: baseTicks,
+            gridLines: baseGridLines,
+            scaleLabel: {
+              display: true,
+              labelString: "味が濃い",
             },
           },
         ],

--- a/app/packs/src/typescript/taste_graph.ts
+++ b/app/packs/src/typescript/taste_graph.ts
@@ -96,8 +96,9 @@ export class TasteGraph implements InteractiveGraph {
     const points = data != null ? [data] : []
     const datasets: Chart.ChartDataSets = {
       data: points,
-      pointBackgroundColor: "rgba(190, 20, 20, 0.7)",
-      pointBorderColor: "rgba(190, 20, 20, 0.9)",
+      // accent color: #b7282e = 183,40,46
+      pointBackgroundColor: "rgba(183, 40, 46, 0.9)",
+      pointBorderColor: "rgba(183, 40, 46, 1.0)",
     }
     const cd: Chart.ChartData = {
       datasets: [datasets],


### PR DESCRIPTION
fix #125
close #270

## やる前

![image](https://user-images.githubusercontent.com/849256/134774912-180bb042-e9fa-4d57-a666-d7e70027cbe8.png)

## やった後

![image](https://user-images.githubusercontent.com/849256/134775003-ad90bd2d-2c33-42f1-8b89-2b3eca9c6c9c.png)


## やったこと

- グラフの4象限に色付けした
- グラフの左右上下に濃淡についてラベル文字列を追加した
- グラフの点の色を茜色にした

## やり残したこと

- グラフの色の濃さはどの程度がいいのか
- グラフの味と香りの色合いを変えるべきか
- アクセントカラーは本当に茜色でいいか
- グラフの色を象限分けじゃなくグラデーション化
- 香りが高い、の文字の回転。chart.jsにはないのでプラグインで内部文字列オブジェクトを書き換える？

## 参考になったところ

- https://github.com/chartjs/Chart.js/issues/3535