### PR TITLE
ページのタイトルを個別に変えた

### DIFF
--- a/app/controllers/sakes_controller.rb
+++ b/app/controllers/sakes_controller.rb
@@ -31,7 +31,6 @@ class SakesController < ApplicationController
   # GET /sakes/1
   # GET /sakes/1.json
   def show
-    set_twitter_meta_tags
   end
 
   # GET /sakes/new
@@ -132,11 +131,6 @@ class SakesController < ApplicationController
   # paramsの件名つき蔵名から県名を取り除く
   def strip_todofuken_from_params!
     params["sake"]["kura"] = strip_todofuken(params["sake"]["kura"]) if params.dig(:sake, :kura)
-  end
-
-  def set_twitter_meta_tags
-    set_meta_tags(og: { title: "SAKAZUKI - #{@sake.name}" })
-    set_meta_tags(og: { image: @sake.photos.first.image.thumb.url }) if @sake.photos.any?
   end
 
   # Use callbacks to share common setup or constraints between actions.

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,8 +1,2 @@
 module ApplicationHelper
-  # ツイートボタンを表示するためのメタタグを挿入する
-  # @return [String] ツイッターのHTMLメタタグ
-  def twitter_meta_tags
-    display_meta_tags(twitter: { card: "summary" },
-                      og: { title: "SAKAZUKI" })
-  end
 end

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,4 +1,4 @@
-<h1><%= t(".resend_confirmation_instructions") %></h1>
+<h1><%= title(t(".resend_confirmation_instructions")) %></h1>
 
 <%= form_for(resource,
              as: resource_name,

--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -1,4 +1,4 @@
-<h1><%= t("devise.invitations.edit.header") %></h1>
+<h1><%= title(t("devise.invitations.edit.header")) %></h1>
 <%= form_for(resource, as: resource_name, url: invitation_path(resource_name), html: { method: :put }) do |f| %>
   <%= render("devise/shared/error_messages", resource: resource) %>
   <%= f.hidden_field(:invitation_token, readonly: true) %>

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -1,4 +1,4 @@
-<h1><%= t("devise.invitations.new.header") %></h1>
+<h1><%= title(t("devise.invitations.new.header")) %></h1>
 
 <%= form_for(resource, as: resource_name, url: invitation_path(resource_name), html: { method: :post }) do |f| %>
   <%= render("devise/shared/error_messages", resource: resource) %>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,4 +1,4 @@
-<h1><%= t(".change_your_password") %></h1>
+<h1><%= title(t(".change_your_password")) %></h1>
 
 <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
   <%= render("devise/shared/error_messages", resource: resource) %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,4 +1,4 @@
-<h1><%= t(".forgot_your_password") %></h1>
+<h1><%= title(t(".forgot_your_password")) %></h1>
 
 <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
   <%= render("devise/shared/error_messages", resource: resource) %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,4 +1,4 @@
-<h1><%= t(".title", resource: resource.model_name.human) %></h1>
+<h1><%= title(t(".title", resource: resource.model_name.human)) %></h1>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
   <%= render("devise/shared/error_messages", resource: resource) %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,4 +1,4 @@
-<h1 data-testid="<%= new_user_session_path %>"><%= t(".sign_in") %></h1>
+<h1 data-testid="<%= new_user_session_path %>"><%= title(t(".sign_in")) %></h1>
 
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
 

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -1,4 +1,4 @@
-<h1><%= t(".resend_unlock_instructions") %></h1>
+<h1><%= title(t(".resend_unlock_instructions")) %></h1>
 
 <%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
   <%= render("devise/shared/error_messages", resource: resource) %>

--- a/app/views/elasticsearch/index.html.erb
+++ b/app/views/elasticsearch/index.html.erb
@@ -1,4 +1,4 @@
-<h1><%= t(".title") %></h1>
+<h1><%= title(t(".title")) %></h1>
 
 <%= form_with(scope: :elasticsearch,
               url: elasticsearch_path,

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,7 +9,7 @@
                           separator: "-",
                           reverse: true,
                           twitter: { card: "summary" },
-                          og: { title: title }, ) %>
+                          og: { title: title }) %>
 
     <% if content_for?(:pack_style) %>
       <%= yield(:pack_style) %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,11 +1,15 @@
 <!DOCTYPE html>
 <html lang="<%= I18n.locale %>">
   <head>
-    <title>SAKAZUKI</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-    <%= twitter_meta_tags %>
+    <%= display_meta_tags(site: "SAKAZUKI",
+                          title: title,
+                          separator: "-",
+                          reverse: true,
+                          twitter: { card: "summary" },
+                          og: { title: title }, ) %>
 
     <% if content_for?(:pack_style) %>
       <%= yield(:pack_style) %>

--- a/app/views/sakes/edit.html.erb
+++ b/app/views/sakes/edit.html.erb
@@ -1,3 +1,3 @@
-<h1 data-testid="<%= edit_sake_path(@sake) %>"><%= t(".title") %></h1>
+<h1 data-testid="<%= edit_sake_path(@sake) %>"><%= title(t(".title")) %></h1>
 
 <%= render("form", sake: @sake) %>

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -5,7 +5,7 @@
 <%= render("float-button") %>
 
 <% include_empty = params.dig(:q, :bottle_level_not_eq) == bottom_bottle.to_s %>
-<h1><%= "#{t('.title')} - #{to_shakkan(Sake.alcohol_stock(include_empty: include_empty))}" %></h1>
+<h1><%= title("#{t('.title')} - #{to_shakkan(Sake.alcohol_stock(include_empty: include_empty))}") %></h1>
 
 <%= search_form_for(@searched, { class: "row my-2 align-items-center" }) do |f| %>
   <div class="col input-group">

--- a/app/views/sakes/new.html.erb
+++ b/app/views/sakes/new.html.erb
@@ -1,3 +1,3 @@
-<h1><%= t(".title") %></h1>
+<h1><%= title(t(".title")) %></h1>
 
 <%= render("form", sake: @sake) %>

--- a/app/views/sakes/show.html.erb
+++ b/app/views/sakes/show.html.erb
@@ -44,6 +44,8 @@
       <% end %>
     </div>
   </div>
+  <%# tweet用のサムネイルをセット %>
+  <% set_meta_tags(og: { image: @sake.photos.first.image.thumb.url }) if @sake.photos.any? %>
 
   <div class="sakes-show-label">
     <b><%= Sake.human_attribute_name(:alcohol) %></b>

--- a/app/views/sakes/show.html.erb
+++ b/app/views/sakes/show.html.erb
@@ -7,7 +7,7 @@
 
 <%= render("float-button") %>
 
-<h1 data-testid="<%= sake_path(@sake) %>"><%= @sake.name %></h1>
+<h1 data-testid="<%= sake_path(@sake) %>"><%= title(@sake.name) %></h1>
 
 <%# ツイートボタン %>
 <%= tweet_button(t("helper.tweet.text", sake: @sake)) %>


### PR DESCRIPTION
Close #288

各ページのタイトル（ブラウザのタブに表示されるテキスト）を、"h1見出し - SAKAZUKI"となるようにした。
![image](https://user-images.githubusercontent.com/6294782/135217990-91441969-6764-4801-9a6d-d94d1f429fe8.png)
