### PR TITLE
RSpecのファイル名とtype指定のリファクタ

### DIFF
--- a/spec/helpers/sakes_helper_spec.rb
+++ b/spec/helpers/sakes_helper_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe SakesHelper, type: :helper do
+RSpec.describe SakesHelper do
   include described_class
 
   describe "empty_to_default" do

--- a/spec/models/photo_spec.rb
+++ b/spec/models/photo_spec.rb
@@ -10,7 +10,7 @@
 #
 require "rails_helper"
 
-RSpec.describe Photo, type: :model do
+RSpec.describe Photo do
   describe "chackbox_name" do
     subject { photo.chackbox_name }
 

--- a/spec/models/sake_spec.rb
+++ b/spec/models/sake_spec.rb
@@ -39,7 +39,7 @@
 #
 require "rails_helper"
 
-RSpec.describe Sake, type: :model do
+RSpec.describe Sake do
   describe "validates" do
     subject { sake.save }
 

--- a/spec/requests/sake_request_spec.rb
+++ b/spec/requests/sake_request_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Sakes", type: :request do
+RSpec.describe "Sakes" do
   let!(:sakes) { FactoryBot.create_list(:sake, 3) }
   let(:id) { sakes[0].id }
 

--- a/spec/system/drink_buttons_spec.rb
+++ b/spec/system/drink_buttons_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Drink Buttons", type: :system do
+RSpec.describe "Drink Buttons" do
   let!(:sealed_sake) { FactoryBot.create(:sake, bottle_level: "sealed") }
   let!(:opened_sake) { FactoryBot.create(:sake, bottle_level: "opened") }
   let!(:impressed_sake) { FactoryBot.create(:sake, bottle_level: "opened", taste_value: 1, aroma_value: 2) }

--- a/spec/system/drink_buttons_spec.rb
+++ b/spec/system/drink_buttons_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "DrinkButtons", type: :system do
+RSpec.describe "Drink Buttons", type: :system do
   let!(:sealed_sake) { FactoryBot.create(:sake, bottle_level: "sealed") }
   let!(:opened_sake) { FactoryBot.create(:sake, bottle_level: "opened") }
   let!(:impressed_sake) { FactoryBot.create(:sake, bottle_level: "opened", taste_value: 1, aroma_value: 2) }

--- a/spec/system/edit_sake_spec.rb
+++ b/spec/system/edit_sake_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "AfterUpdateAction", type: :system do
+RSpec.describe "Edit Sake", type: :system do
   let!(:opened_sake) { FactoryBot.create(:sake, bottle_level: "opened") }
   let(:sake_id) { opened_sake.id }
   let(:sake_name) { opened_sake.name }

--- a/spec/system/edit_sake_spec.rb
+++ b/spec/system/edit_sake_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Edit Sake", type: :system do
+RSpec.describe "Edit Sake" do
   let!(:opened_sake) { FactoryBot.create(:sake, bottle_level: "opened") }
   let(:sake_id) { opened_sake.id }
   let(:sake_name) { opened_sake.name }

--- a/spec/system/new_sake_spec.rb
+++ b/spec/system/new_sake_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "AfterUpdateAction", type: :system do
+RSpec.describe "New Sake", type: :system do
   let(:user) { FactoryBot.create(:user) }
   let(:sake_name) { "とても美味しいお酒" }
 

--- a/spec/system/new_sake_spec.rb
+++ b/spec/system/new_sake_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "New Sake", type: :system do
+RSpec.describe "New Sake" do
   let(:user) { FactoryBot.create(:user) }
   let(:sake_name) { "とても美味しいお酒" }
 

--- a/spec/system/sign_in_redirect_by_drinkbutton_spec.rb
+++ b/spec/system/sign_in_redirect_by_drinkbutton_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Sign-in Redirect with Drink Buttons", type: :system do
+RSpec.describe "Sign-in Redirect with Drink Buttons" do
   let!(:sealed_sake) { FactoryBot.create(:sake, bottle_level: "sealed") }
   let!(:impressed_sake) { FactoryBot.create(:sake, bottle_level: "opened", taste_value: 1, aroma_value: 2) }
   let(:user) { FactoryBot.create(:user) }

--- a/spec/system/sign_in_redirect_by_drinkbutton_spec.rb
+++ b/spec/system/sign_in_redirect_by_drinkbutton_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Sign in redirect with drink buttons", type: :system do
+RSpec.describe "Sign-in Redirect with Drink Buttons", type: :system do
   let!(:sealed_sake) { FactoryBot.create(:sake, bottle_level: "sealed") }
   let!(:impressed_sake) { FactoryBot.create(:sake, bottle_level: "opened", taste_value: 1, aroma_value: 2) }
   let(:user) { FactoryBot.create(:user) }

--- a/spec/system/sign_in_redirect_spec.rb
+++ b/spec/system/sign_in_redirect_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Sign-in Redirect", type: :system do
+RSpec.describe "Sign-in Redirect" do
   let(:sakes) { FactoryBot.create_list(:sake, 3) }
   let(:id) { sakes[0].id }
   let(:user) { FactoryBot.create(:user) }

--- a/spec/system/sign_in_redirect_spec.rb
+++ b/spec/system/sign_in_redirect_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Sign-in redirect", type: :system do
+RSpec.describe "Sign-in Redirect", type: :system do
   let(:sakes) { FactoryBot.create_list(:sake, 3) }
   let(:id) { sakes[0].id }
   let(:user) { FactoryBot.create(:user) }

--- a/spec/system/user_invitation_spec.rb
+++ b/spec/system/user_invitation_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "User invitation", type: :system do
+RSpec.describe "User Invitation", type: :system do
   let!(:admin) { FactoryBot.create(:user, admin: true) }
   let!(:user) { FactoryBot.create(:user, admin: false) }
 

--- a/spec/system/user_invitation_spec.rb
+++ b/spec/system/user_invitation_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "User Invitation", type: :system do
+RSpec.describe "User Invitation" do
   let!(:admin) { FactoryBot.create(:user, admin: true) }
   let!(:user) { FactoryBot.create(:user, admin: false) }
 

--- a/spec/views/sakes/index.html.erb_spec.rb
+++ b/spec/views/sakes/index.html.erb_spec.rb
@@ -1,6 +1,7 @@
 require "rails_helper"
 
-RSpec.describe "sakes/index" do
+# Capybaraを使うためにsystem specを指定する
+RSpec.describe "sakes/index", type: :system do
   let(:user) { FactoryBot.create(:user) }
   let!(:sake) { FactoryBot.create(:sake) }
 

--- a/spec/views/sakes/index.html.erb_spec.rb
+++ b/spec/views/sakes/index.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "sakes/index", type: :view do
+RSpec.describe "sakes/index" do
   let(:user) { FactoryBot.create(:user) }
   let!(:sake) { FactoryBot.create(:sake) }
 

--- a/spec/views/sakes/index.html.erb_spec.rb
+++ b/spec/views/sakes/index.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "EditInIndexPage", type: :system do
+RSpec.describe "sakes/index", type: :view do
   let(:user) { FactoryBot.create(:user) }
   let!(:sake) { FactoryBot.create(:sake) }
 


### PR DESCRIPTION
RSpec書こうとしたら気になる点が多かったので先に整理

## やったこと

- RSpecのファイル名と配置を見直した　
- 上記をすることで、必要なくなったRSpecのtype指定を削除した
- 一部viewテストでcapybaraを使うためにtype: systemを指定した
