### PR TITLE
酒モデルのopened_at/emptied_atにバリデーションを追加した

### DIFF
--- a/app/controllers/sakes_controller.rb
+++ b/app/controllers/sakes_controller.rb
@@ -149,17 +149,19 @@ class SakesController < ApplicationController
   def update_datetime
     case @sake.saved_change_to_attribute(:bottle_level)
     in [old, new]
-      @sake.update(opened_at: @sake.updated_at) if old == "sealed"
-      @sake.update(emptied_at: @sake.updated_at) if new == "empty"
+      @sake.assign_attributes(opened_at: @sake.updated_at) if old == "sealed"
+      @sake.assign_attributes(emptied_at: @sake.updated_at) if new == "empty"
     in nil
       nil
     end
+    @sake.save
   end
 
   # 作成された酒の瓶状態に応じて、酒が持つ日時データを更新する
   def create_datetime
-    @sake.update(opened_at: @sake.created_at) unless @sake.bottle_level == "sealed"
-    @sake.update(emptied_at: @sake.created_at) if @sake.bottle_level == "empty"
+    @sake.assign_attributes(opened_at: @sake.created_at) unless @sake.bottle_level == "sealed"
+    @sake.assign_attributes(emptied_at: @sake.created_at) if @sake.bottle_level == "empty"
+    @sake.save
   end
 
   # Only allow a list of trusted parameters through.

--- a/app/models/sake.rb
+++ b/app/models/sake.rb
@@ -12,7 +12,7 @@
 #  bottle_level     :integer          default("sealed")
 #  brew_year        :date
 #  color            :string
-#  emptied_at       :datetime         not null
+#  emptied_at       :datetime         default(Fri, 01 Jan 2021 00:00:00.000000000 JST +09:00), not null
 #  genryomai        :string
 #  hiire            :integer          default("unknown")
 #  kakemai          :string
@@ -23,7 +23,7 @@
 #  nigori           :string
 #  nihonshudo       :float
 #  note             :text
-#  opened_at        :datetime         not null
+#  opened_at        :datetime         default(Fri, 01 Jan 2021 00:00:00.000000000 JST +09:00), not null
 #  price            :integer
 #  roka             :string
 #  sando            :float

--- a/app/models/sake.rb
+++ b/app/models/sake.rb
@@ -121,6 +121,8 @@ class Sake < ApplicationRecord
   validates :hiire, presence: true
   validates :price, numericality: { allow_nil: true }
   validates :size, numericality: true
+  validates :opened_at, presence: true
+  validates :emptied_at, presence: true
 
   # rubocop:disable Layout/LineLength
   ransack_alias :all_text, :aroma_impression_or_awa_or_color_or_genryomai_or_kakemai_or_kobo_or_kura_or_name_or_nigori_or_note_or_roka_or_season_or_shibori_or_taste_impression_or_todofuken

--- a/db/migrate/20211004074321_add_open_and_empty_days_to_sakes.rb
+++ b/db/migrate/20211004074321_add_open_and_empty_days_to_sakes.rb
@@ -1,21 +1,17 @@
 class AddOpenAndEmptyDaysToSakes < ActiveRecord::Migration[6.1]
   def change
-    add_column :sakes, :opened_at, :datetime, precision: 6, default: -> { "NOW()" }, null: false
-    add_column :sakes, :emptied_at, :datetime, precision: 6, default: -> { "NOW()" }, null: false
+    add_column :sakes, :opened_at, :datetime, precision: 6, default: Time.zone.local(2021), null: false
+    add_column :sakes, :emptied_at, :datetime, precision: 6, default: Time.zone.local(2021), null: false
 
     # updated_atの更新を一時的にオフにする
     ActiveRecord::Base.record_timestamps = false
-
-    Sake.find_each do |sake|
-      sake.update(opened_at: sake.created_at, emptied_at: sake.created_at)
-    end
 
     Sake.where(bottle_level: :opened).find_each do |sake|
       sake.update(opened_at: sake.updated_at)
     end
 
     Sake.where(bottle_level: :empty).find_each do |sake|
-      sake.update(emptied_at: sake.updated_at)
+      sake.update(opened_at: sake.created_at, emptied_at: sake.updated_at)
     end
 
     ActiveRecord::Base.record_timestamps = true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -59,8 +59,8 @@ ActiveRecord::Schema.define(version: 2021_10_04_074321) do
     t.integer "size"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.datetime "opened_at", precision: 6, default: -> { "now()" }, null: false
-    t.datetime "emptied_at", precision: 6, default: -> { "now()" }, null: false
+    t.datetime "opened_at", precision: 6, default: "2021-01-01 00:00:00", null: false
+    t.datetime "emptied_at", precision: 6, default: "2021-01-01 00:00:00", null: false
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/factories/sakes.rb
+++ b/spec/factories/sakes.rb
@@ -12,7 +12,7 @@
 #  bottle_level     :integer          default("sealed")
 #  brew_year        :date
 #  color            :string
-#  emptied_at       :datetime         not null
+#  emptied_at       :datetime         default(Fri, 01 Jan 2021 00:00:00.000000000 JST +09:00), not null
 #  genryomai        :string
 #  hiire            :integer          default("unknown")
 #  kakemai          :string
@@ -23,7 +23,7 @@
 #  nigori           :string
 #  nihonshudo       :float
 #  note             :text
-#  opened_at        :datetime         not null
+#  opened_at        :datetime         default(Fri, 01 Jan 2021 00:00:00.000000000 JST +09:00), not null
 #  price            :integer
 #  roka             :string
 #  sando            :float

--- a/spec/models/sake_spec.rb
+++ b/spec/models/sake_spec.rb
@@ -12,7 +12,7 @@
 #  bottle_level     :integer          default("sealed")
 #  brew_year        :date
 #  color            :string
-#  emptied_at       :datetime         not null
+#  emptied_at       :datetime         default(Fri, 01 Jan 2021 00:00:00.000000000 JST +09:00), not null
 #  genryomai        :string
 #  hiire            :integer          default("unknown")
 #  kakemai          :string
@@ -23,7 +23,7 @@
 #  nigori           :string
 #  nihonshudo       :float
 #  note             :text
-#  opened_at        :datetime         not null
+#  opened_at        :datetime         default(Fri, 01 Jan 2021 00:00:00.000000000 JST +09:00), not null
 #  price            :integer
 #  roka             :string
 #  sando            :float

--- a/spec/models/sake_spec.rb
+++ b/spec/models/sake_spec.rb
@@ -61,6 +61,18 @@ RSpec.describe Sake do
 
       it { is_expected.to be_falsy }
     end
+
+    context "if opened_at is nil" do
+      let(:sake) { FactoryBot.build(:sake, opened_at: nil) }
+
+      it { is_expected.to be_falsy }
+    end
+
+    context "if emptied_at is nil" do
+      let(:sake) { FactoryBot.build(:sake, emptied_at: nil) }
+
+      it { is_expected.to be_falsy }
+    end
   end
 
   describe "sake.sealed?" do


### PR DESCRIPTION
これでバリバリ酒モデルを安全に作れる！

## やったこと

- 酒モデルのopened_at/emptied_atカラムにnot nullバリデーションを追加
- not nullバリデーションのspecを追加
- 酒DBカラムのデフォルトを変更
  - 前は`now()`クエリだったが、これだと`Sake.new`したときにはまだデフォルト値が入らない
  - 固定値`2021-01-01 00:00:00`に変更した
- DBに送るクエリ回数を減らした
  - `update` x2よりも`assign_attributes` x2のち`save`が優秀:+1: