### PR TITLE
Update: robots.txtでクローラの除外設定をした

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,1 +1,5 @@
 # See https://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
+
+User-agent: *
+Disallow: /users
+Disallow: /elasticsearch


### PR DESCRIPTION
Fix #292

## 背景

- `noindex`や`nofollow`をしておくと、クローラからのアクセス不可を減らせるぞ！

## やったこと

- robots.txtを編集して、ユーザ関係とエラサー関係をクローラ対象外にした

## やらなかったこと

- meta-tagsジェムを使っての`noindex/nofollow`の指定
  - 新しいページやリンクごとに指定を考えるのが手間
  - 設定値が各viewに散らばり、一元管理できない
