### PR TITLE
ESLintがJavaScriptでもTypeScriptでも正しく動くようにした

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,22 +4,38 @@ module.exports = {
     es2020: true,
     node: true,
   },
-  parser: "@typescript-eslint/parser",
   parserOptions: {
     ecmaVersion: "2020",
     sourceType: "module",
-    tsconfigRootDir: ".",
-    project: ["./tsconfig.json"],
   },
-  plugins: ["@typescript-eslint"],
-  extends: [
-    "eslint:recommended",
-    "plugin:@typescript-eslint/recommended",
-    "plugin:@typescript-eslint/recommended-requiring-type-checking",
-    "prettier",
-  ],
+  ignorePatterns: ["/coverage/", "/public/packs*"],
+  plugins: [],
+  extends: ["eslint:recommended", "prettier"],
   rules: {
-    "@typescript-eslint/no-unused-vars": "off",
-    "@typescript-eslint/no-unused-vars-experimental": "warn",
+    indent: ["error", 2],
+    "linebreak-style": ["error", "unix"],
+    quotes: ["error", "double"],
+    semi: ["error", "never"],
   },
+  overrides: [
+    {
+      files: ["*.ts", "*.tsx"],
+      parser: "@typescript-eslint/parser",
+      parserOptions: {
+        tsconfigRootDir: ".",
+        project: ["./tsconfig.json"],
+      },
+      plugins: ["@typescript-eslint"],
+      extends: [
+        "eslint:recommended",
+        "plugin:@typescript-eslint/recommended",
+        "plugin:@typescript-eslint/recommended-requiring-type-checking",
+        "prettier",
+      ],
+      rules: {
+        "@typescript-eslint/no-unused-vars": "off",
+        "@typescript-eslint/no-unused-vars-experimental": "warn",
+      },
+    },
+  ],
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,8 +33,10 @@ module.exports = {
         "prettier",
       ],
       rules: {
-        "@typescript-eslint/no-unused-vars": "off",
-        "@typescript-eslint/no-unused-vars-experimental": "warn",
+        "@typescript-eslint/no-unused-vars": [
+          "warn",
+          { argsIgnorePattern: "^_" },
+        ],
       },
     },
   ],

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -29,11 +29,11 @@ jobs:
     - name: Install Dependencies
       run: yarn install
     - name: Run ESLint
-      run: yarn lint:eslint
+      run: yarn run lint:eslint
     - name: Run Markdownlint
-      run: yarn lint:markdownlint
+      run: yarn run lint:markdownlint
     - name: Run Stylelint
-      run: yarn lint:stylelint
+      run: yarn run lint:stylelint
 
     # lint by rubocop
     - name: Set up Ruby

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -29,11 +29,11 @@ jobs:
     - name: Install Dependencies
       run: yarn install
     - name: Run ESLint
-      run: yarn lint-ts
+      run: yarn lint:eslint
     - name: Run Markdownlint
-      run: yarn lint-md
+      run: yarn lint:markdownlint
     - name: Run Stylelint
-      run: yarn lint-style
+      run: yarn lint:stylelint
 
     # lint by rubocop
     - name: Set up Ruby

--- a/app/packs/channels/consumer.js
+++ b/app/packs/channels/consumer.js
@@ -3,6 +3,4 @@
 
 import { createConsumer } from "@rails/actioncable"
 
-/* eslint-disable @typescript-eslint/no-unsafe-call */
 export default createConsumer()
-/* eslint-enable @typescript-eslint/no-unsafe-call */

--- a/app/packs/channels/index.js
+++ b/app/packs/channels/index.js
@@ -1,9 +1,5 @@
 // Load all the channels within this directory and all subdirectories.
 // Channel files must be named *_channel.js.
 
-/* eslint-disable
-   @typescript-eslint/no-unsafe-assignment,
-   @typescript-eslint/no-unsafe-member-access,
-   @typescript-eslint/no-unsafe-call */
 const channels = require.context(".", true, /_channel\.js$/)
 channels.keys().forEach(channels)

--- a/app/packs/entrypoints/common.js
+++ b/app/packs/entrypoints/common.js
@@ -3,9 +3,6 @@
 // a relevant structure within app/javascript and only use these pack files to reference
 // that code so it'll be compiled.
 
-/* eslint-disable
-   @typescript-eslint/no-unsafe-member-access,
-   @typescript-eslint/no-unsafe-call */
 import Rails from "@rails/ujs"
 import Turbolinks from "turbolinks"
 import * as ActiveStorage from "@rails/activestorage"
@@ -14,9 +11,6 @@ import "channels"
 Rails.start()
 Turbolinks.start()
 ActiveStorage.start()
-/* eslint-enable
-   @typescript-eslint/no-unsafe-member-access,
-   @typescript-eslint/no-unsafe-call */
 
 // js
 import "../src/javascript/bootstrap_plugins.js"
@@ -25,14 +19,6 @@ import "../src/javascript/bootstrap_plugins.js"
 // Uncomment to copy all static images under ../images to the output folder and reference
 // them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)
 // or the `imagePath` JavaScript helper below.
-/* eslint-disable
-   @typescript-eslint/no-unsafe-call,
-   @typescript-eslint/no-unsafe-assignment,
-   @typescript-eslint/no-unused-vars-experimental */
 require.context("../images", true)
-/* eslint-enable
-   @typescript-eslint/no-unused-vars-experimental,
-   @typescript-eslint/no-unsafe-assignment,
-   @typescript-eslint/no-unsafe-call */
 // const images = require.context("../images", true)
 // const imagePath = (name) => images(name, true)

--- a/cli-scripts/run-all-checks.sh
+++ b/cli-scripts/run-all-checks.sh
@@ -23,13 +23,13 @@ message "##### Run EOF Check"
 # node packages
 
 message "##### Run ESLint"
-yarn lint:eslint
+yarn run lint:eslint
 
 message "##### Run markdownlint"
-yarn lint:markdownlint
+yarn run lint:markdownlint
 
 message "##### Run stylelint"
-yarn lint:stylelint
+yarn run lint:stylelint
 
 # gems
 

--- a/cli-scripts/run-all-checks.sh
+++ b/cli-scripts/run-all-checks.sh
@@ -23,13 +23,13 @@ message "##### Run EOF Check"
 # node packages
 
 message "##### Run ESLint"
-yarn lint-ts
+yarn lint:eslint
 
 message "##### Run markdownlint"
-yarn lint-md
+yarn lint:markdownlint
 
 message "##### Run stylelint"
-yarn lint-style
+yarn lint:stylelint
 
 # gems
 

--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
   },
   "scripts": {
     "yard": "yard doc --tag type:\"TYPE\" {lib,app,spec,ext}/**/*.rb",
-    "lint-ts": "eslint --ext .js,.jsx,.ts,.tsx ./app/packs/",
-    "lint-md": "markdownlint README.md",
-    "lint-style": "stylelint '**/*.scss' '**/*.css' --ignore-path .gitignore"
+    "lint:eslint": "eslint --ext .js,.jsx,.ts,.tsx ./app/packs/",
+    "lint:markdownlint": "markdownlint README.md",
+    "lint:stylelint": "stylelint '**/*.scss' '**/*.css' --ignore-path .gitignore"
   },
   "packageManager": "yarn@2.4.2"
 }


### PR DESCRIPTION
プロジェクト内に設定ファイルとしてのjsファイルが結構ある。
ESLintかけたりPrettierかけたりしていきたい。

## 今まで

- `.js`ファイルにもTypeScript設定のESLintをかけていた
- `eslint-disable`マジックコメントを適宜つけていた

## これから

- JavaScriptとTypeScriptで設定の違うESLintが走る！

## やったこと

- JSとTSでESLintの設定が変わるようにした
  - JSをベースにして、TSの設定をoverridesで実現した
  - JSのESLintはインデント、改行、ダブルクオート、セミコロンなしの基本セットを追加した
- 必要なくなったeslint-disableを削除
- @typescript-eslint/no-unused-vars-experimentalの使用をやめた
  - typescript-eslintのv5.0.0で削除予定
  - そもそも@typescript-eslint/no-unused-varsのオプション設定で同じことを実現できた
- 実体に従い、Yarnのscript名を変更した
  - `yarn lint-ts`を`yarn run lint:eslint`のように変更
