### PR TITLE
scssの`devise-`とか`sakes-form-`とかを消した

### DIFF
--- a/app/packs/entrypoints/devise.scss
+++ b/app/packs/entrypoints/devise.scss
@@ -6,7 +6,7 @@
   @extend .mb-lg-2;
 }
 
-.devise-submit-row {
+.submit-row {
   @extend .devise-row;
   @extend .mt-2;
   @extend .justify-content-center;

--- a/app/packs/entrypoints/sakes/form.scss
+++ b/app/packs/entrypoints/sakes/form.scss
@@ -1,51 +1,51 @@
 @import "../../src/stylesheet/bootstrap_custom";
 @import "~bootstrap/scss/bootstrap";
 
-.sakes-form-row {
+.form-row {
   @extend .row;
   @extend .mb-lg-2;
 }
 
-.sakes-form-label {
+.form-label {
   @extend .col-lg-3;
   @extend .col-12;
   @extend .col-form-label;
 }
 
 // バッジ付きラベル
-.sakes-form-badged-label {
+.badged-label {
   @extend .col-lg-2;
   @extend .col-8;
   @extend .col-form-label;
 }
 
-.sakes-form-badge {
+.form-badge {
   @extend .col-lg-1;
   @extend .col-4;
   @extend .col-form-label;
 }
 
 // 常に二段組となる入力フォーム
-.sakes-form-two-column-form {
+.two-column-form {
   @extend .col-lg-4;
   @extend .col-6;
 }
 
 // ウィンドウサイズがlg以上のときに二段組入力フォームと同じサイズになる入力フォーム
-.sakes-form-short-form {
+.short-form {
   @extend .col-lg-4;
   @extend .col;
 }
 
-div.sakes-form-label + div input[type="checkbox"] {
+div.form-label + div input[type="checkbox"] {
   display: none;
 }
 
-div.sakes-form-label + div input:checked[type="checkbox"] + label img {
+div.form-label + div input:checked[type="checkbox"] + label img {
   border: 10px solid #f66;
 }
 
-div.sakes-form-label + div input:checked[type="checkbox"] + label::after {
+div.form-label + div input:checked[type="checkbox"] + label::after {
   content: "❌";
   font-size: 40px;
   display: block;

--- a/app/packs/entrypoints/sakes/form.scss
+++ b/app/packs/entrypoints/sakes/form.scss
@@ -13,7 +13,7 @@
 }
 
 // バッジ付きラベル
-.badged-label {
+.badged-form-label {
   @extend .col-lg-2;
   @extend .col-8;
   @extend .col-form-label;

--- a/app/packs/entrypoints/sakes/index.scss
+++ b/app/packs/entrypoints/sakes/index.scss
@@ -1,7 +1,7 @@
 @import "../../src/stylesheet/bootstrap_custom";
 @import "~bootstrap/scss/bootstrap";
 
-.sakes-index-name-link {
+.name-link {
   font-size: 1.1em;
   font-weight: 600;
 }

--- a/app/packs/entrypoints/sakes/show.scss
+++ b/app/packs/entrypoints/sakes/show.scss
@@ -11,12 +11,12 @@
   }
 }
 
-.sakes-show-label {
+.show-label {
   @extend .col-lg-3;
   @extend .col-12;
 }
 
-.sakes-show-body {
+.show-body {
   @extend .col-lg-9;
   @extend .col-12;
 }

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -22,7 +22,7 @@
       </div>
   </div>
 
-  <div class="devise-submit-row">
+  <div class="submit-row">
     <div class="col-auto">
       <%= f.submit(t(".resend_confirmation_instructions"), { class: "btn btn-primary" }) %>
     </div>

--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -22,7 +22,7 @@
     </div>
  <% end %>
 
-  <div class="devise-submit-row">
+  <div class="submit-row">
     <div class="col-auto">
       <%= f.submit(t("devise.invitations.edit.submit_button"), { class: "btn btn-primary" }) %>
     </div>

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -14,7 +14,7 @@
     <% end %>
   </div>
 
-  <div class="devise-submit-row">
+  <div class="submit-row">
     <div class="col-auto">
       <%= f.submit(t("devise.invitations.new.submit_button"), { class: "btn btn-primary" }) %>
     </div>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -24,7 +24,7 @@
     </div>
   </div>
 
-  <div class="devise-submit-row">
+  <div class="submit-row">
     <div class="col-auto">
       <%= f.submit(t(".change_my_password"), class: "btn btn-primary") %>
     </div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -12,7 +12,7 @@
     </div>
   </div>
 
-  <div class="devise-submit-row">
+  <div class="submit-row">
     <div class="col-auto">
       <%= f.submit(t(".send_me_reset_password_instructions"), class: "btn btn-primary") %>
     </div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -46,7 +46,7 @@
     </div>
   </div>
 
-  <div class="devise-submit-row">
+  <div class="submit-row">
     <div class="col-auto">
       <%= f.submit(t(".update"), class: "btn btn-primary mx-3") %>
     </div>
@@ -55,7 +55,7 @@
 
 <h2><%= t(".unhappy") %></h2>
 
-<div class="devise-submit-row">
+<div class="submit-row">
   <div class="col-auto">
     <%= button_to(t(".cancel_my_account"),
                   registration_path(resource_name),

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -18,7 +18,7 @@
     </div>
   </div>
 
-  <div class="devise-submit-row align-items-center">
+  <div class="submit-row align-items-center">
     <div class="col-auto">
       <%= f.submit(t(".sign_in"), class: "btn btn-primary") %>
     </div>

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -12,7 +12,7 @@
     </div>
   </div>
 
-  <div class="devise-submit-row">
+  <div class="submit-row">
     <div class="col-auto">
       <%= f.submit(t(".resend_unlock_instructions"), class: "btn btn-primary") %>
     </div>

--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -24,9 +24,9 @@
       <div id="collapseLabelInfo" class="accordion-collapse collapse show" aria-labelledby="headingLabelInfo"
         data-bs-parent="#accordionLabelInfo">
         <div class="accordion-body">
-          <div class="sakes-form-row">
-            <%= form.label(:name, { class: "sakes-form-badged-label" }) %>
-            <div class="sakes-form-badge">
+          <div class="form-row">
+            <%= form.label(:name, { class: "badged-label" }) %>
+            <div class="form-badge">
               <span class="badge bg-primary"><%= t(".badge.presence") %></span>
             </div>
             <div class="col">
@@ -34,8 +34,8 @@
             </div>
           </div>
 
-          <div class="sakes-form-row">
-            <%= form.label(:kura, { class: "sakes-form-label" }) %>
+          <div class="form-row">
+            <%= form.label(:kura, { class: "form-label" }) %>
             <div class="col">
               <%= form.text_field(:kura, { class: "form-control", autocomplete: "on", list: "sakagura" }) %>
               <%= render("sakagura-datalist") %>
@@ -45,8 +45,8 @@
             </div>
           </div>
 
-          <div class="sakes-form-row">
-            <%= form.label(:photos, { class: "sakes-form-label" }) %>
+          <div class="form-row">
+            <%= form.label(:photos, { class: "form-label" }) %>
             <div class="col">
               <%= form.file_field(:photos,
                                   { multiple: true,
@@ -57,7 +57,7 @@
 
           <% if @sake.photos.any? %>
             <div class="row">
-              <div class="sakes-form-label"></div>
+              <div class="form-label"></div>
               <div class="col">
                 <div class="row">
                   <span class="form-text col-12">
@@ -81,17 +81,17 @@
             </div>
           <% end %>
 
-          <div class="sakes-form-row">
-            <%= form.label(:alcohol, { class: "sakes-form-label" }) %>
-            <div class="sakes-form-short-form">
+          <div class="form-row">
+            <%= form.label(:alcohol, { class: "form-label" }) %>
+            <div class="short-form">
               <%= form.number_field(:alcohol,
                                     { step: "any", class: "form-control" }) %>
             </div>
           </div>
 
-          <div class="sakes-form-row">
-            <%= form.label(:tokutei_meisho, { class: "sakes-form-label" }) %>
-            <div class="sakes-form-short-form">
+          <div class="form-row">
+            <%= form.label(:tokutei_meisho, { class: "form-label" }) %>
+            <div class="short-form">
               <%= form.select(:tokutei_meisho,
                               Sake.tokutei_meishos_i18n.keys.map { |k|
                                 [I18n.t("enums.sake.tokutei_meisho.#{k}"), k]
@@ -101,34 +101,34 @@
             </div>
           </div>
 
-          <div class="sakes-form-row">
-            <%= form.label(:seimai_buai, { class: "sakes-form-label" }) %>
-            <div class="sakes-form-short-form">
+          <div class="form-row">
+            <%= form.label(:seimai_buai, { class: "form-label" }) %>
+            <div class="short-form">
               <%= form.number_field(:seimai_buai, { class: "form-control" }) %>
             </div>
           </div>
 
-          <div class="sakes-form-row">
-            <%= form.label(:bindume_date, { class: "sakes-form-label" }) %>
+          <div class="form-row">
+            <%= form.label(:bindume_date, { class: "form-label" }) %>
             <%# HACK: 年と月の入力フォームを分けて横並びに配置する。 %>
             <%#       Railsデフォルトでは年月が縦並びになってしまう。%>
             <%#       そのため、2つフォームを設置してTSで同期する。 %>
-            <div class="sakes-form-two-column-form">
+            <div class="two-column-form">
               <%= year_select_with_japanese_era(id = "bindume_year",
                                                 name = "sake[bindume_date(1i)]",
                                                 begin_year = Date.current.year,
                                                 selected_year: @sake.bindume_date&.year || Date.current.year) %>
             </div>
-            <div class="sakes-form-two-column-form">
+            <div class="two-column-form">
               <%= form.date_select(:bindume_date,
                                    { discard_day: true, discard_year: true },
                                    { class: "form-select", id: "bindume_month" }) %>
             </div>
           </div>
 
-          <div class="sakes-form-row">
-            <%= form.label(:brew_year, { class: "sakes-form-label" }) %>
-            <div class="sakes-form-two-column-form">
+          <div class="form-row">
+            <%= form.label(:brew_year, { class: "form-label" }) %>
+            <div class="two-column-form">
               <% current_by = to_by(Date.current).year %>
               <%= year_select_with_japanese_era(id = "sake_brew_year_1i",
                                                 name = "sake[brew_year(1i)]",
@@ -141,23 +141,23 @@
             </div>
           </div>
 
-          <div class="sakes-form-row">
-            <%= form.label(:size, { class: "sakes-form-label" }) %>
-            <div class="sakes-form-short-form">
+          <div class="form-row">
+            <%= form.label(:size, { class: "form-label" }) %>
+            <div class="short-form">
               <%= form.number_field(:size, { class: "form-control" }) %>
             </div>
           </div>
 
-          <div class="sakes-form-row">
-            <%= form.label(:price, { class: "sakes-form-label" }) %>
-            <div class="sakes-form-short-form">
+          <div class="form-row">
+            <%= form.label(:price, { class: "form-label" }) %>
+            <div class="short-form">
               <%= form.number_field(:price, { class: "form-control" }) %>
             </div>
           </div>
 
-          <div class="sakes-form-row">
-            <%= form.label(:bottle_level, { class: "sakes-form-label" }) %>
-            <div class="sakes-form-short-form">
+          <div class="form-row">
+            <%= form.label(:bottle_level, { class: "form-label" }) %>
+            <div class="short-form">
               <%= form.select(:bottle_level,
                               Sake.bottle_levels_i18n.keys.map { |k|
                                 [I18n.t("enums.sake.bottle_level.#{k}"), k]
@@ -183,15 +183,15 @@
       <div id="collapseLabelInfoOption" class="accordion-collapse collapse"
         aria-labelledby="headingLabelInfoOption" data-bs-parent="#accordionLabelInfoOption">
         <div class="accordion-body">
-          <div class="sakes-form-row">
-            <%= form.label(:genryomai, { class: "sakes-form-label" }) %>
+          <div class="form-row">
+            <%= form.label(:genryomai, { class: "form-label" }) %>
             <div class="col">
               <%= form.text_field(:genryomai, class: "form-control", autocomplete: "on", list: "sakamai-list") %>
             </div>
           </div>
 
-          <div class="sakes-form-row">
-            <%= form.label(:kakemai, { class: "sakes-form-label" }) %>
+          <div class="form-row">
+            <%= form.label(:kakemai, { class: "form-label" }) %>
             <div class="col">
               <%= form.text_field(:kakemai, class: "form-control", autocomplete: "on", list: "sakamai-list") %>
             </div>
@@ -199,16 +199,16 @@
 
           <%= render("sakamai-datalist") %>
 
-          <div class="sakes-form-row">
-            <%= form.label(:kobo, { class: "sakes-form-label" }) %>
+          <div class="form-row">
+            <%= form.label(:kobo, { class: "form-label" }) %>
             <div class="col">
               <%= form.text_field(:kobo, { class: "form-control" }) %>
             </div>
           </div>
 
-          <div class="sakes-form-row">
-            <%= form.label(:moto, { class: "sakes-form-label" }) %>
-            <div class="sakes-form-short-form">
+          <div class="form-row">
+            <%= form.label(:moto, { class: "form-label" }) %>
+            <div class="short-form">
               <%= form.select(:moto,
                               Sake.motos_i18n.keys.map { |k|
                                 [I18n.t("enums.sake.moto.#{k}"), k]
@@ -218,8 +218,8 @@
             </div>
           </div>
 
-          <div class="sakes-form-row">
-            <%= form.label(:roka, { class: "sakes-form-label" }) %>
+          <div class="form-row">
+            <%= form.label(:roka, { class: "form-label" }) %>
             <div class="col">
               <%= form.text_field(:roka, { class: "form-control", autocomplete: "on", list: "roka-list" }) %>
               <datalist id="roka-list">
@@ -229,8 +229,8 @@
             </div>
           </div>
 
-          <div class="sakes-form-row">
-            <%= form.label(:shibori, { class: "sakes-form-label" }) %>
+          <div class="form-row">
+            <%= form.label(:shibori, { class: "form-label" }) %>
             <div class="col">
               <%= form.text_field(:shibori, { class: "form-control", autocomplete: "on", list: "shibori-list" }) %>
               <datalist id="shibori-list">
@@ -251,9 +251,9 @@
             </div>
           </div>
 
-          <div class="sakes-form-row">
-            <%= form.label(:hiire, { class: "sakes-form-label" }) %>
-            <div class="sakes-form-short-form">
+          <div class="form-row">
+            <%= form.label(:hiire, { class: "form-label" }) %>
+            <div class="short-form">
               <%= form.select(:hiire,
                               Sake.hiires_i18n.keys.map { |k|
                                 [I18n.t("enums.sake.hiire.#{k}"), k]
@@ -263,9 +263,9 @@
             </div>
           </div>
 
-          <div class="sakes-form-row">
-            <%= form.label(:warimizu, { class: "sakes-form-label" }) %>
-            <div class="sakes-form-short-form">
+          <div class="form-row">
+            <%= form.label(:warimizu, { class: "form-label" }) %>
+            <div class="short-form">
               <%= form.select(:warimizu,
                               Sake.warimizus_i18n.keys.map { |k|
                                 [I18n.t("enums.sake.warimizu.#{k}"), k]
@@ -275,8 +275,8 @@
             </div>
           </div>
 
-          <div class="sakes-form-row">
-            <%= form.label(:season, { class: "sakes-form-label" }) %>
+          <div class="form-row">
+            <%= form.label(:season, { class: "form-label" }) %>
             <div class="col">
               <%= form.text_field(:season, { class: "form-control", autocomplete: "on", list: "season-list" }) %>
               <datalist id="season-list">
@@ -289,23 +289,23 @@
             </div>
           </div>
 
-          <div class="sakes-form-row">
-            <%= form.label(:nihonshudo, { class: "sakes-form-label" }) %>
-            <div class="sakes-form-short-form">
+          <div class="form-row">
+            <%= form.label(:nihonshudo, { class: "form-label" }) %>
+            <div class="short-form">
               <%= form.number_field(:nihonshudo, { step: "any", class: "form-control" }) %>
             </div>
           </div>
 
-          <div class="sakes-form-row">
-            <%= form.label(:sando, { class: "sakes-form-label" }) %>
-            <div class="sakes-form-short-form">
+          <div class="form-row">
+            <%= form.label(:sando, { class: "form-label" }) %>
+            <div class="short-form">
               <%= form.number_field(:sando, { step: "any", class: "form-control" }) %>
             </div>
           </div>
 
-          <div class="sakes-form-row">
-            <%= form.label(:aminosando, { class: "sakes-form-label" }) %>
-            <div class="sakes-form-short-form">
+          <div class="form-row">
+            <%= form.label(:aminosando, { class: "form-label" }) %>
+            <div class="short-form">
               <%= form.number_field(:aminosando, { step: "any", class: "form-control" }) %>
             </div>
           </div>
@@ -326,21 +326,21 @@
       <div id="collapseTasteInfo" class="accordion-collapse collapse"
         aria-labelledby="headingTasteInfo" data-bs-parent="#accordionTasteInfo">
         <div class="accordion-body">
-          <div class="sakes-form-row">
-            <%= form.label(:color, { class: "sakes-form-label" }) %>
+          <div class="form-row">
+            <%= form.label(:color, { class: "form-label" }) %>
             <div class="col">
               <%= form.text_field(:color, { class: "form-control" }) %>
             </div>
           </div>
 
-          <div class="sakes-form-row">
-            <%= form.label(:nigori, { class: "sakes-form-label" }) %>
+          <div class="form-row">
+            <%= form.label(:nigori, { class: "form-label" }) %>
             <div class="col">
               <%= form.text_field(:nigori, { class: "form-control" }) %>
             </div>
           </div>
 
-          <div class="sakes-form-row mt-2">
+          <div class="form-row mt-2">
             <%= form.label("#{t('activerecord.attributes.sake.taste_value')}, #{t('activerecord.attributes.sake.aroma_value')}",
                            { class: "col-lg-3 col-7 col-form-label" }) %>
             <div class="col-lg-9 col-5">
@@ -361,29 +361,29 @@
             </div>
           </div>
 
-          <div class="sakes-form-row">
-            <%= form.label(:aroma_impression, { class: "sakes-form-label" }) %>
+          <div class="form-row">
+            <%= form.label(:aroma_impression, { class: "form-label" }) %>
             <div class="col">
               <%= form.text_area(:aroma_impression, { class: "form-control" }) %>
             </div>
           </div>
 
-          <div class="sakes-form-row">
-            <%= form.label(:taste_impression, { class: "sakes-form-label" }) %>
+          <div class="form-row">
+            <%= form.label(:taste_impression, { class: "form-label" }) %>
             <div class="col">
               <%= form.text_area(:taste_impression, { class: "form-control" }) %>
             </div>
           </div>
 
-          <div class="sakes-form-row">
-            <%= form.label(:awa, { class: "sakes-form-label" }) %>
+          <div class="form-row">
+            <%= form.label(:awa, { class: "form-label" }) %>
             <div class="col">
               <%= form.text_field(:awa, { class: "form-control" }) %>
             </div>
           </div>
 
-          <div class="sakes-form-row">
-            <%= form.label(:note, { class: "sakes-form-label" }) %>
+          <div class="form-row">
+            <%= form.label(:note, { class: "form-label" }) %>
             <div class="col">
               <%= form.text_area(:note, { class: "form-control" }) %>
             </div>

--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -25,7 +25,7 @@
         data-bs-parent="#accordionLabelInfo">
         <div class="accordion-body">
           <div class="form-row">
-            <%= form.label(:name, { class: "badged-label" }) %>
+            <%= form.label(:name, { class: "badged-form-label" }) %>
             <div class="form-badge">
               <span class="badge bg-primary"><%= t(".badge.presence") %></span>
             </div>

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -62,7 +62,7 @@
         <td class="col-lg-6 col-12">
           <div class="row m-0 border-bottom">
             <div class="col p-0">
-              <%= link_to(sake.name, sake_path(sake), { class: "sakes-index-name-link" }) %>
+              <%= link_to(sake.name, sake_path(sake), { class: "name-link" }) %>
             </div>
             <div class="col-auto">
               <%= link_to(tag.i(class: "bi-pencil-square me-2", style: "font-size: 1.05em;") + t(".edit"),

--- a/app/views/sakes/show.html.erb
+++ b/app/views/sakes/show.html.erb
@@ -27,24 +27,24 @@
 <h2 class="my-2"><%= t(".labelinfo") %></h2>
 
 <div class="row">
-  <div class="sakes-show-label">
+  <div class="show-label">
     <b><%= Sake.human_attribute_name(:kura) %></b>
   </div>
-  <div class="sakes-show-body">
+  <div class="show-body">
     <%= empty_to_default(@sake.kura, "-") %>
   </div>
 
-  <div class="sakes-show-label">
+  <div class="show-label">
     <b><%= Sake.human_attribute_name(:todofuken) %></b>
   </div>
-  <div class="sakes-show-body">
+  <div class="show-body">
     <%= empty_to_default(@sake.todofuken, "-") %>
   </div>
 
-  <div class="sakes-show-label">
+  <div class="show-label">
     <b><%= Sake.human_attribute_name(:photos) %></b>
   </div>
-  <div class="sakes-show-body">
+  <div class="show-body">
     <div class="row photo-gallery">
       <% @sake.photos.each do |photo| %>
         <div class="col-lg-4 col-6">
@@ -57,165 +57,165 @@
   <%# tweet用のサムネイルをセット %>
   <% set_meta_tags(og: { image: @sake.photos.first.image.thumb.url }) if @sake.photos.any? %>
 
-  <div class="sakes-show-label">
+  <div class="show-label">
     <b><%= Sake.human_attribute_name(:alcohol) %></b>
   </div>
-  <div class="sakes-show-body">
+  <div class="show-body">
     <%= empty_to_default(@sake.alcohol, "-") %>
   </div>
 
-  <div class="sakes-show-label">
+  <div class="show-label">
     <b><%= Sake.human_attribute_name(:tokutei_meisho) %></b>
   </div>
-  <div class="sakes-show-body">
+  <div class="show-body">
     <%= @sake.tokutei_meisho_i18n %>
   </div>
 
-  <div class="sakes-show-label">
+  <div class="show-label">
     <b><%= Sake.human_attribute_name(:seimai_buai) %></b>
   </div>
-  <div class="sakes-show-body">
+  <div class="show-body">
     <%= empty_to_default(@sake.seimai_buai, "-") %> %
   </div>
 
-  <div class="sakes-show-label">
+  <div class="show-label">
     <b><%= Sake.human_attribute_name(:bindume_date) %></b>
   </div>
-  <div class="sakes-show-body">
+  <div class="show-body">
     <%= @sake.bindume_date ? @sake.bindume_date.strftime("%Y / %m") : "- / -" %>
   </div>
 
-  <div class="sakes-show-label">
+  <div class="show-label">
     <b><%= Sake.human_attribute_name(:brew_year) %></b>
   </div>
-  <div class="sakes-show-body">
+  <div class="show-body">
     <%= @sake.brew_year ? @sake.brew_year.strftime("%Y") : "-" %>
   </div>
 
-  <div class="sakes-show-label">
+  <div class="show-label">
     <b><%= Sake.human_attribute_name(:size) %></b>
   </div>
-  <div class="sakes-show-body">
+  <div class="show-body">
     <%= empty_to_default(@sake.size, "-") %> ml
   </div>
 
-  <div class="sakes-show-label">
+  <div class="show-label">
     <b><%= Sake.human_attribute_name(:price) %></b>
   </div>
-  <div class="sakes-show-body">
+  <div class="show-body">
     <%= @sake.price.nil? ? "-" : @sake.price.to_s(:delimited) %>
     <%= t("activerecord.attributes.sake.price_unit") %>
   </div>
 
-  <div class="sakes-show-label">
+  <div class="show-label">
     <b><%= Sake.human_attribute_name(:genryomai) %></b>
   </div>
-  <div class="sakes-show-body">
+  <div class="show-body">
     <%= empty_to_default(@sake.genryomai, "-") %>
   </div>
 
-  <div class="sakes-show-label">
+  <div class="show-label">
     <b><%= Sake.human_attribute_name(:kakemai) %></b>
   </div>
-  <div class="sakes-show-body">
+  <div class="show-body">
     <%= empty_to_default(@sake.kakemai, "-") %>
   </div>
 
-  <div class="sakes-show-label">
+  <div class="show-label">
     <b><%= Sake.human_attribute_name(:kobo) %></b>
   </div>
-  <div class="sakes-show-body">
+  <div class="show-body">
     <%= empty_to_default(@sake.kobo, "-") %>
   </div>
 
-  <div class="sakes-show-label">
+  <div class="show-label">
     <b><%= Sake.human_attribute_name(:moto) %></b>
   </div>
-  <div class="sakes-show-body">
+  <div class="show-body">
     <%= @sake.moto_i18n %>
   </div>
 
-  <div class="sakes-show-label">
+  <div class="show-label">
     <b><%= Sake.human_attribute_name(:roka) %></b>
   </div>
-  <div class="sakes-show-body">
+  <div class="show-body">
     <%= empty_to_default(@sake.roka, "-") %>
   </div>
 
-  <div class="sakes-show-label">
+  <div class="show-label">
     <b><%= Sake.human_attribute_name(:shibori) %></b>
   </div>
-  <div class="sakes-show-body">
+  <div class="show-body">
     <%= empty_to_default(@sake.shibori, "-") %>
   </div>
 
-  <div class="sakes-show-label">
+  <div class="show-label">
     <b><%= Sake.human_attribute_name(:hiire) %></b>
   </div>
-  <div class="sakes-show-body">
+  <div class="show-body">
     <%= @sake.hiire_i18n %>
   </div>
 
-  <div class="sakes-show-label">
+  <div class="show-label">
     <b><%= Sake.human_attribute_name(:warimizu) %></b>
   </div>
-  <div class="sakes-show-body">
+  <div class="show-body">
     <%= @sake.warimizu_i18n %>
   </div>
 
-  <div class="sakes-show-label">
+  <div class="show-label">
     <b><%= Sake.human_attribute_name(:season) %></b>
   </div>
-  <div class="sakes-show-body">
+  <div class="show-body">
     <%= empty_to_default(@sake.season, "-") %>
   </div>
 
-  <div class="sakes-show-label">
+  <div class="show-label">
     <b><%= Sake.human_attribute_name(:nihonshudo) %></b>
   </div>
-  <div class="sakes-show-body">
+  <div class="show-body">
     <%= empty_to_default(@sake.nihonshudo, "-") %>
   </div>
 
-  <div class="sakes-show-label">
+  <div class="show-label">
     <b><%= Sake.human_attribute_name(:sando) %></b>
   </div>
-  <div class="sakes-show-body">
+  <div class="show-body">
     <%= empty_to_default(@sake.sando, "-") %>
   </div>
 
-  <div class="sakes-show-label">
+  <div class="show-label">
     <b><%= Sake.human_attribute_name(:aminosando) %></b>
   </div>
-  <div class="sakes-show-body">
+  <div class="show-body">
     <%= empty_to_default(@sake.aminosando, "-") %>
   </div>
 
-  <div class="sakes-show-label">
+  <div class="show-label">
     <b><%= Sake.human_attribute_name(:bottle_level) %></b>
   </div>
-  <div class="sakes-show-body">
+  <div class="show-body">
     <%= @sake.bottle_level_i18n %>
   </div>
 
-  <div class="sakes-show-label">
+  <div class="show-label">
     <b><%= Sake.human_attribute_name(:created_at) %></b>
   </div>
-  <div class="sakes-show-body" data-testid="created-at">
+  <div class="show-body" data-testid="created-at">
     <%= l(@sake.created_at.to_date) %>
   </div>
 
-  <div class="sakes-show-label">
+  <div class="show-label">
     <b><%= Sake.human_attribute_name(:opened_at) %></b>
   </div>
-  <div class="sakes-show-body" data-testid="opened-at">
+  <div class="show-body" data-testid="opened-at">
     <%= @sake.bottle_level == "sealed" ? "-" : l(@sake.opened_at.to_date) %>
   </div>
 
-  <div class="sakes-show-label">
+  <div class="show-label">
     <b><%= Sake.human_attribute_name(:emptied_at) %></b>
   </div>
-  <div class="sakes-show-body" data-testid="emptied-at">
+  <div class="show-body" data-testid="emptied-at">
     <%= @sake.bottle_level == "empty" ? l(@sake.emptied_at.to_date) : "-" %>
   </div>
 </div>
@@ -224,62 +224,62 @@
 <h2 class="my-2"><%= t(".tasteinfo") %></h2>
 
 <div class="row">
-  <div class="sakes-show-label">
+  <div class="show-label">
     <b><%= Sake.human_attribute_name(:color) %></b>
   </div>
-  <div class="sakes-show-body">
+  <div class="show-body">
     <%= empty_to_default(@sake.color, "-") %>
   </div>
 
-  <div class="sakes-show-label">
+  <div class="show-label">
     <b><%= Sake.human_attribute_name(:nigori) %></b>
   </div>
-  <div class="sakes-show-body">
+  <div class="show-body">
     <%= empty_to_default(@sake.nigori, "-") %>
   </div>
 
-  <div class="sakes-show-label">
+  <div class="show-label">
     <b><%= "#{t('activerecord.attributes.sake.taste_value')}, #{t('activerecord.attributes.sake.aroma_value')}" %></b>
   </div>
-  <div class="sakes-show-body">
+  <div class="show-body">
     <canvas id="sake-<%= @sake.id %>"
             data-taste-value="<%= @sake.taste_value %>"
             data-aroma-value="<%= @sake.aroma_value %>">
     </canvas>
   </div>
 
-  <div class="sakes-show-label">
+  <div class="show-label">
     <b><%= Sake.human_attribute_name(:aroma_impression) %></b>
   </div>
-  <div class="sakes-show-body">
+  <div class="show-body">
     <%= empty_to_default(@sake.aroma_impression, "-") %>
   </div>
 
-  <div class="sakes-show-label">
+  <div class="show-label">
     <b><%= Sake.human_attribute_name(:taste_impression) %></b>
   </div>
-  <div class="sakes-show-body">
+  <div class="show-body">
     <%= empty_to_default(@sake.taste_impression, "-") %>
   </div>
 
-  <div class="sakes-show-label">
+  <div class="show-label">
     <b><%= Sake.human_attribute_name(:awa) %></b>
   </div>
-  <div class="sakes-show-body">
+  <div class="show-body">
     <%= empty_to_default(@sake.awa, "-") %>
   </div>
 
-  <div class="sakes-show-label">
+  <div class="show-label">
     <b><%= Sake.human_attribute_name(:note) %></b>
   </div>
-  <div class="sakes-show-body">
+  <div class="show-body">
     <%= empty_to_default(@sake.note, "-") %>
   </div>
 
-  <div class="sakes-show-label">
+  <div class="show-label">
     <b><%= Sake.human_attribute_name(:updated_at) %></b>
   </div>
-  <div class="sakes-show-body" data-testid="updated-at">
+  <div class="show-body" data-testid="updated-at">
     <%= l(@sake.updated_at.to_date) %>
   </div>
 </div>


### PR DESCRIPTION
Close #322

rename後の名前がBootstrapのクラス（row、badgeとか）やHTMLセレクタ（labelとか）に被らないよう、元の名前を残しているものもある。
具体的にはこんな感じ。
`sakes-form-row` -> `form-row`
`sakes-form-label` -> `form-label`
`devise-row` -> `devise-row`

