### PR TITLE
ESLintコマンドをPrettierのコマンドと揃える設定にした

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,7 +14,7 @@ module.exports = {
   rules: {
     indent: ["error", 2],
     "linebreak-style": ["error", "unix"],
-    quotes: ["error", "double"],
+    quotes: ["error", "double", { avoidEscape: true }],
     semi: ["error", "never"],
   },
   overrides: [

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "scripts": {
     "yard": "yard doc --tag type:\"TYPE\" {lib,app,spec,ext}/**/*.rb",
-    "lint:eslint": "eslint --ext .js,.jsx,.ts,.tsx ./app/packs/",
+    "lint:eslint": "eslint --ignore-path .prettierignore --ext .js,.ts .",
     "lint:prettier": "prettier --check .",
     "lint:prettier:fix": "prettier --write .",
     "lint:markdownlint": "markdownlint README.md",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "scripts": {
     "yard": "yard doc --tag type:\"TYPE\" {lib,app,spec,ext}/**/*.rb",
     "lint:eslint": "eslint --ignore-path .prettierignore --ext .js,.ts .",
+    "lint:eslint:fix": "yarn run lint:eslint --fix",
     "lint:prettier": "prettier --check .",
     "lint:prettier:fix": "prettier --write .",
     "lint:markdownlint": "markdownlint README.md",


### PR DESCRIPTION
after #348

`yarn run lint:eslint:XXX`を整理した

## やったこと

- `yarn run lint:eslint`の対象をPrettierと同じくした
  - 対象が増えたのでESLintで「ダブルクオートを含む文字列をシングルクオートとするのを許可」ルールを追加
- Prettierに揃えて`yarn run lint:eslint:fix`コマンドを追加した
