### PR TITLE
PR時にautofixをコメントでのコマンドでできるようにした

### DIFF
--- a/.github/workflows/fix-command.yml
+++ b/.github/workflows/fix-command.yml
@@ -37,13 +37,12 @@ jobs:
 
       - name: Add refactor commit to PR
         run: |
-          # who commits
-          git config --global user.name "github-action[bot]"
-          git config --global user.email "58130806+actions-bot@users.noreply.github.com"
           # autofix
           yarn run lint:eslint:fix
           yarn run lint:prettier:fix
           bundle exec rubocop --auto-correct
-          # commit and push
+          # commit
+          git config --global user.name "github-action[bot]"
+          git config --global user.email "58130806+actions-bot@users.noreply.github.com"
           git commit --all --message="Refactor: autofix"
           git push

--- a/.github/workflows/fix-command.yml
+++ b/.github/workflows/fix-command.yml
@@ -1,0 +1,49 @@
+name: Fix Command
+on:
+  repository_dispatch:
+    types: [fix-command]
+jobs:
+  fix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.client_payload.pull_request.head.ref }}
+
+      - name: Get Yarn chache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+      - name: Restore Yarn cache
+        uses: actions/cache@v2
+        id: yarn-cache
+        env:
+          cache-env: dev
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ env.cache-env }}-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-${{ env.cache-env }}-
+            ${{ runner.os }}-yarn- # enable to match production env
+      - name: Install Yarn Dependencies
+        run: yarn install
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - name: Install bundle dependencies
+        run: |
+          bundle install
+
+      - name: Add refactor commit to PR
+        run: |
+          # who commits
+          git config --global user.name "github-action[bot]"
+          git config --global user.email "58130806+actions-bot@users.noreply.github.com"
+          # autofix
+          yarn run lint:eslint:fix
+          yarn run lint:prettier:fix
+          bundle exec rubocop --auto-correct
+          # commit and push
+          git commit --all --message="Refactor: autofix"
+          git push

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -1,0 +1,14 @@
+name: Slash Command Dispatch
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  slashCommandDispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Slash Command Dispatch
+        uses: peter-evans/slash-command-dispatch@v2
+        with:
+          token: ${{ secrets.PAT }}
+          commands: fix
+          issue-type: pull-request


### PR DESCRIPTION
close #349
after #353

手動でESLintしてPrettierしてRubocopして…、つまらないことは自動化した！

## 今までの面倒

- 開発者「頑張ってPR出したぞ！」
- GitHub Actions「だめでーーーすwww」
- オーナー「直して（コマンドで自動で直す方法あるから簡単だよ）」
- 開発者「直さないと。でもどうやって。コマンドもわからん。PRやめよ」

## どうなるのか

[こんな感じになる](https://github.com/momocus/sakazuki/pull/355)

- 開発者「頑張ってPR出したぞ！」
- GitHub Actions「だめでーーーすwww」
- オーナー「自動で直すわ"""/fix"""」
- オーナー「自動で直ったからおk or 自動で直らないところあるから直して」
- 開発者「やるぞー！」

## レポジトリオーナー（momocus）がやる必要があること

1. Public Repositoryに許可権限を持つPersonal Access Tokenをつくる
    - 参考：[GitHub Docs - 個人アクセストークンを使用する](https://docs.github.com/ja/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
    - 作成後にできる文字列をコピーしておく
2. SAKAZUKIレポジトリの設定のSecretsに、1で作ったToken（文字列）を「PAT」の名前で登録する
    - SAKAZUKI→Settings→Secrets→New Repository Secret

## やったこと

- PRに自動でautofixしたコミットをつけてくれる/fixコマンドを実現した
  - GitHub Actionsと[slash-command-dispatch](https://github.com/peter-evans/slash-command-dispatch)を使った
  - レポジトリにWrite権限を持つ人のみコマンドを実行できる
