### PR TITLE
Twitterでリンクサムネイルが壊れていた問題を修正

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,39 +1,38 @@
 module ApplicationHelper
   # rubocop:disable Metrics/MethodLength
   def seo_meta_tags
-    set_meta_tags(icon: [
-                    {
-                      rel: "apple-touch-icon-precomposed",
-                      sizes: "180x180",
-                      href: asset_pack_path("media/images/apple-touch-icon.png"),
-                      type: "image/png",
-                    },
-                    {
-                      rel: "icon",
-                      sizes: "32x32",
-                      href: asset_pack_path("media/images/favicon-32x32.png"),
-                      type: "image/png",
-                    },
-                  ],
-                  site: "SAKAZUKI",
-                  title: "",
-                  separator: "-",
-                  reverse: true,
-                  description: t(".description"),
-                  og: {
-                    title: :title,
-                    url: request.original_url,
-                    type: "website",
-                    image: {
-                      _: asset_pack_path("media/images/choko.png"),
-                      width: 600,
-                      height: 600,
-                    },
-                    description: :description,
-                  },
-                  twitter: { card: "summary" })
     set_meta_tags(fb: { app_id: ENV["FB_APP_ID"] }) if ENV["FB_APP_ID"]
-    display_meta_tags
+    display_meta_tags(icon: [
+                        {
+                          rel: "apple-touch-icon-precomposed",
+                          sizes: "180x180",
+                          href: asset_pack_path("media/images/apple-touch-icon.png"),
+                          type: "image/png",
+                        },
+                        {
+                          rel: "icon",
+                          sizes: "32x32",
+                          href: asset_pack_path("media/images/favicon-32x32.png"),
+                          type: "image/png",
+                        },
+                      ],
+                      site: "SAKAZUKI",
+                      title: "",
+                      separator: "-",
+                      reverse: true,
+                      description: t(".description"),
+                      og: {
+                        title: :title,
+                        url: request.original_url,
+                        type: "website",
+                        image: {
+                          _: asset_pack_path("media/images/choko.png"),
+                          width: 600,
+                          height: 600,
+                        },
+                        description: :description,
+                      },
+                      twitter: { card: "summary" })
   end
 
   # rubocop:enable Metrics/MethodLength

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,38 +1,47 @@
 module ApplicationHelper
+  # サイトデフォルト設定のメタタグのハッシュを取得する
+  #
+  # @return [Hash] meta_tagsで利用できるハッシュ
   # rubocop:disable Metrics/MethodLength
-  def seo_meta_tags
-    set_meta_tags(fb: { app_id: ENV["FB_APP_ID"] }) if ENV["FB_APP_ID"]
-    display_meta_tags(icon: [
-                        {
-                          rel: "apple-touch-icon-precomposed",
-                          sizes: "180x180",
-                          href: asset_pack_path("media/images/apple-touch-icon.png"),
-                          type: "image/png",
-                        },
-                        {
-                          rel: "icon",
-                          sizes: "32x32",
-                          href: asset_pack_path("media/images/favicon-32x32.png"),
-                          type: "image/png",
-                        },
-                      ],
-                      site: "SAKAZUKI",
-                      title: "",
-                      separator: "-",
-                      reverse: true,
-                      description: t(".description"),
-                      og: {
-                        title: :title,
-                        url: request.original_url,
-                        type: "website",
-                        image: {
-                          _: asset_pack_path("media/images/choko.png"),
-                          width: 600,
-                          height: 600,
-                        },
-                        description: :description,
-                      },
-                      twitter: { card: "summary" })
+  def default_meta_tags
+    {
+      icon: [
+        {
+          rel: "apple-touch-icon-precomposed",
+          sizes: "180x180",
+          href: asset_pack_path("media/images/apple-touch-icon.png"),
+          type: "image/png",
+        },
+        {
+          rel: "icon",
+          sizes: "32x32",
+          href: asset_pack_path("media/images/favicon-32x32.png"),
+          type: "image/png",
+        },
+      ],
+      site: "SAKAZUKI",
+      title: "",
+      separator: "-",
+      reverse: true,
+      description: t(".description"),
+      og: {
+        title: :title,
+        url: request.original_url,
+        type: "website",
+        image: {
+          _: asset_pack_path("media/images/choko.png"),
+          width: 600,
+          height: 600,
+        },
+        description: :description,
+      },
+      twitter: {
+        card: "summary",
+      },
+      fb: {
+        app_id: ENV["FB_APP_ID"].presence,
+      },
+    }
   end
 
   # rubocop:enable Metrics/MethodLength

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,7 +4,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-    <%= seo_meta_tags %>
+    <%= display_meta_tags(default_meta_tags) %>
     <%= adsense_tags %>
     <%= render("layouts/webpack_meta_tags") %>
   </head>


### PR DESCRIPTION
fix #362 

めためた

## 問題の背景

display_meta_tagsの内容をset_meta_tagsやtitleで上書きができる。
しかしset_meta_tagsの内容はtitleで上書きしようとすると、順番依存が発生する。

## やったこと

- デフォルトのメタタグを作成した
- application.html.erbでは`display_meta_tags(default_meta_tags)`する
  - `set_meta_tags`をまったく使わない！
- 各種ページで`set_meta_tags(...)`や`title`を使い設定を上書きする
