### PR TITLE
Update: お品書きのルーティングとアクションを追加

### DIFF
--- a/app/controllers/sakes_controller.rb
+++ b/app/controllers/sakes_controller.rb
@@ -111,8 +111,8 @@ class SakesController < ApplicationController
 
   # GET /sakes
   def drink_menu
-    @sakes = Sake.ransack({ bottle_level_not_eq: Sake.bottle_levels["empty"],
-                            s: "id desc", }).result(distinct: true)
+    @sakes = Sake.ransack(bottle_level_not_eq: Sake.bottle_levels["empty"],
+                          s: "id desc").result(distinct: true)
   end
 
   private

--- a/app/controllers/sakes_controller.rb
+++ b/app/controllers/sakes_controller.rb
@@ -109,6 +109,12 @@ class SakesController < ApplicationController
     params.dig(:q, :bottle_level_not_eq) == bottom_bottle.to_s
   end
 
+  # GET /sakes
+  def drink_menu
+    @sakes = Sake.ransack({ bottle_level_not_eq: Sake.bottle_levels["empty"],
+                            s: "id desc", }).result(distinct: true)
+  end
+
   private
 
   def to_multi_search!(query)

--- a/app/views/sakes/drink_menu.html.erb
+++ b/app/views/sakes/drink_menu.html.erb
@@ -1,0 +1,7 @@
+<h1>お品書き</h1>
+
+<% @sakes.each do |sake| %>
+  <div class="col-auto">
+    <%= link_to(sake.name.to_s, sake_path(sake.id)) %>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   root "sakes#index"
   resources :sakes do
     get :elasticsearch, on: :collection
+    get :drink_menu, on: :collection
   end
   get "/elasticsearch" => "elasticsearch#index", as: "elasticsearch"
 


### PR DESCRIPTION
お品書きをおしゃれに見せたいゾ！！！
プルリクが大きくなりそうなので分割したゾ。このプルリクは、oshinagakiブランチへのプルリクだゾ。

refer: [Sakazuki wiki-お品書き](https://github.com/momocus/sakazuki/wiki/%E3%81%8A%E5%93%81%E6%9B%B8%E3%81%8D)

- /sakes/drink_menu でお品書きページが表示されるよう、アクションとルーティングを追加した
  - drink_menu.html.erbはアクションの確認用で、デザインはまだ
- 空のボトルは表示しない
- ページネーションはなしで、在庫はすべて表示する（indexのデフォルトに合わせる）
- 表示順はidソート（indexのデフォルトに合わせる）
