### PR TITLE
酒の好みを評価できるようにした

### DIFF
--- a/app/controllers/sakes_controller.rb
+++ b/app/controllers/sakes_controller.rb
@@ -182,7 +182,7 @@ class SakesController < ApplicationController
                   :kobo, :alcohol, :aminosando, :season,
                   :warimizu, :moto, :seimai_buai, :roka,
                   :shibori, :note, :bottle_level, :hiire,
-                  :size, :price)
+                  :size, :price, :rating)
   end
 
   def store_photos

--- a/app/models/sake.rb
+++ b/app/models/sake.rb
@@ -126,6 +126,7 @@ class Sake < ApplicationRecord
   validates :size, numericality: true
   validates :opened_at, presence: true
   validates :emptied_at, presence: true
+  validates :rating, numericality: { only_integer: true }, inclusion: [0, 1, 2, 3, 4, 5]
 
   # rubocop:disable Layout/LineLength
   ransack_alias :all_text, :aroma_impression_or_awa_or_color_or_genryomai_or_kakemai_or_kobo_or_kura_or_name_or_nigori_or_note_or_roka_or_season_or_shibori_or_taste_impression_or_todofuken

--- a/app/models/sake.rb
+++ b/app/models/sake.rb
@@ -25,6 +25,7 @@
 #  note             :text
 #  opened_at        :datetime         default(Fri, 01 Jan 2021 00:00:00.000000000 JST +09:00), not null
 #  price            :integer
+#  rating           :integer          default(0), not null
 #  roka             :string
 #  sando            :float
 #  season           :string

--- a/app/packs/entrypoints/sakes/form.js
+++ b/app/packs/entrypoints/sakes/form.js
@@ -1,3 +1,4 @@
 import "../../src/typescript/autocomplete_todofuken.ts"
 import "../../src/typescript/sync_bindume_date.ts"
 import "../../src/typescript/input_taste_graph.ts"
+import "../../src/typescript/sake_rating.ts"

--- a/app/packs/src/typescript/sake_rating.ts
+++ b/app/packs/src/typescript/sake_rating.ts
@@ -1,0 +1,35 @@
+import rater from "rater-js"
+
+function getSakeRatingFromDOM(): number {
+  const element = document.getElementById("sake_rating") as HTMLInputElement
+  const ratingStr = element.getAttribute("value")
+  if (ratingStr == null) return 0
+  return parseInt(ratingStr) || 0
+}
+
+function setSakeRatingToDOM(rating: number) {
+  const sakeRatingForm = document.getElementById(
+    "sake_rating"
+  ) as HTMLInputElement
+  sakeRatingForm.setAttribute("value", rating.toString())
+}
+
+{
+  document.addEventListener("DOMContentLoaded", function () {
+    const sakeRater = rater({
+      element: document.getElementById("rater") as HTMLElement,
+      starSize: 32,
+      rateCallback: function rateCallback(rating, done) {
+        // reset 0, when pushing same star
+        if (rating == sakeRater.getRating()) rating = 0
+
+        sakeRater.setRating(rating)
+        setSakeRatingToDOM(rating)
+
+        if (done != null) done()
+      },
+    })
+    const rating = getSakeRatingFromDOM()
+    sakeRater.setRating(rating)
+  })
+}

--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -330,6 +330,14 @@
         aria-labelledby="headingTasteInfo" data-bs-parent="#accordionTasteInfo">
         <div class="accordion-body">
           <div class="form-row">
+            <%= form.label(:rating, { class: "form-label" }) %>
+            <div class="col">
+              <div id="rater"></div>
+              <%= form.number_field(:rating, hidden: true, class: "form-control", max: 5, min: 0, step: 1) %>
+            </div>
+          </div>
+
+          <div class="form-row">
             <%= form.label(:color, { class: "form-label" }) %>
             <div class="col">
               <%= form.text_field(:color, { class: "form-control" }) %>

--- a/app/views/sakes/_rating.html.erb
+++ b/app/views/sakes/_rating.html.erb
@@ -1,0 +1,10 @@
+<% if sake.rating == 0 %>
+  -
+<% else %>
+  <% sake.rating.times do %>
+    <i class="bi-star-fill text-primary"></i>
+  <% end %>
+  <% (5 - sake.rating).times do %>
+    <i class="bi-star text-primary"></i>
+  <% end %>
+<% end %>

--- a/app/views/sakes/show.html.erb
+++ b/app/views/sakes/show.html.erb
@@ -211,6 +211,13 @@
 
 <div class="row">
   <div class="show-label">
+    <b><%= Sake.human_attribute_name(:rating) %></b>
+  </div>
+  <div class="show-body" data-testid="rating">
+    <%= render("rating", sake: @sake) %>
+  </div>
+
+  <div class="show-label">
     <b><%= Sake.human_attribute_name(:color) %></b>
   </div>
   <div class="show-body">

--- a/config/locales/models/sake.ja.yml
+++ b/config/locales/models/sake.ja.yml
@@ -41,3 +41,4 @@ ja:
         updated_at: 更新日
         opened_at: 開けた日
         emptied_at: 飲みきった日
+        rating: 好み

--- a/db/migrate/20220127072306_add_review_rating_to_sakes.rb
+++ b/db/migrate/20220127072306_add_review_rating_to_sakes.rb
@@ -1,0 +1,5 @@
+class AddReviewRatingToSakes < ActiveRecord::Migration[6.1]
+  def change
+    add_column :sakes, :rating, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_04_074321) do
+ActiveRecord::Schema.define(version: 2022_01_27_072306) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "data_migrations", primary_key: "version", id: :string, force: :cascade do |t|
+  end
 
   create_table "photos", force: :cascade do |t|
     t.string "image"
@@ -58,6 +61,7 @@ ActiveRecord::Schema.define(version: 2021_10_04_074321) do
     t.datetime "updated_at", precision: 6, null: false
     t.datetime "opened_at", precision: 6, default: "2021-01-01 00:00:00", null: false
     t.datetime "emptied_at", precision: 6, default: "2021-01-01 00:00:00", null: false
+    t.integer "rating", default: 0, null: false
   end
 
   create_table "users", force: :cascade do |t|

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "bootstrap": ">=5.1.3 <6",
     "bootstrap-icons": ">=1.5.0",
     "chart.js": ">=2.9.4 <3",
+    "rater-js": ">=1.0.1 <2",
     "resolve-url-loader": "^4.0.0",
     "simplelightbox": ">=2.9.0 <3",
     "turbolinks": "5.2.0",

--- a/spec/factories/sakes.rb
+++ b/spec/factories/sakes.rb
@@ -25,6 +25,7 @@
 #  note             :text
 #  opened_at        :datetime         default(Fri, 01 Jan 2021 00:00:00.000000000 JST +09:00), not null
 #  price            :integer
+#  rating           :integer          default(0), not null
 #  roka             :string
 #  sando            :float
 #  season           :string

--- a/spec/models/sake_spec.rb
+++ b/spec/models/sake_spec.rb
@@ -25,6 +25,7 @@
 #  note             :text
 #  opened_at        :datetime         default(Fri, 01 Jan 2021 00:00:00.000000000 JST +09:00), not null
 #  price            :integer
+#  rating           :integer          default(0), not null
 #  roka             :string
 #  sando            :float
 #  season           :string

--- a/spec/views/sakes/show.html.erb_spec.rb
+++ b/spec/views/sakes/show.html.erb_spec.rb
@@ -2,13 +2,11 @@ require "rails_helper"
 
 # Capybaraを使うためにsystem specを指定する
 RSpec.describe "sakes/show", type: :system do
-  let(:sake) { FactoryBot.create(:sake, bottle_level: :sealed) }
-  let(:no_rating_sake) { FactoryBot.create(:sake) }
-  let(:rating_sake) { FactoryBot.create(:sake, rating: 3) }
-
-  some_date = %r{[0-9]+/[0-9]+/[0-9]+}
-
   describe "dates" do
+    let(:sake) { FactoryBot.create(:sake, bottle_level: :sealed) }
+
+    some_date = %r{[0-9]+/[0-9]+/[0-9]+}
+
     context "with sealed sake" do
       before do
         visit sake_path(sake.id)
@@ -79,6 +77,9 @@ RSpec.describe "sakes/show", type: :system do
   end
 
   describe "rating" do
+    let(:no_rating_sake) { FactoryBot.create(:sake) }
+    let(:rating_sake) { FactoryBot.create(:sake, rating: 3) }
+
     context "with no rating sake" do
       before do
         visit sake_path(no_rating_sake.id)

--- a/spec/views/sakes/show.html.erb_spec.rb
+++ b/spec/views/sakes/show.html.erb_spec.rb
@@ -3,10 +3,12 @@ require "rails_helper"
 # Capybaraを使うためにsystem specを指定する
 RSpec.describe "sakes/show", type: :system do
   let(:sake) { FactoryBot.create(:sake, bottle_level: :sealed) }
+  let(:no_rating_sake) { FactoryBot.create(:sake) }
+  let(:rating_sake) { FactoryBot.create(:sake, rating: 3) }
 
   some_date = %r{[0-9]+/[0-9]+/[0-9]+}
 
-  describe "show page" do
+  describe "dates" do
     context "with sealed sake" do
       before do
         visit sake_path(sake.id)
@@ -72,6 +74,32 @@ RSpec.describe "sakes/show", type: :system do
 
       it "has updated_at" do
         expect(find(:test_id, "updated-at")).to have_text(some_date)
+      end
+    end
+  end
+
+  describe "rating" do
+    context "with no rating sake" do
+      before do
+        visit sake_path(no_rating_sake.id)
+      end
+
+      it "has bar text" do
+        expect(find(:test_id, "rating")).to have_text("-")
+      end
+    end
+
+    context "with sake having 3 star rating" do
+      before do
+        visit sake_path(rating_sake.id)
+      end
+
+      it "has 3 stars-fill icons" do
+        expect(page.all("i.bi-star-fill").count).to eq 3
+      end
+
+      it "has 2 stars icons, not filled" do
+        expect(page.all("i.bi-star").count).to eq 2
       end
     end
   end

--- a/yarn.lock
+++ b/yarn.lock
@@ -9728,6 +9728,13 @@ fsevents@~2.3.1:
   languageName: node
   linkType: hard
 
+"rater-js@npm:>=1.0.1 <2":
+  version: 1.0.1
+  resolution: "rater-js@npm:1.0.1"
+  checksum: 70f00b3d80b8bd27530c69ea5b2b8280c64e5d7d9d58c970114c442df489e06bedca5e14d7605e26306b987b2632ae4374200b56d0e520b12940abac6d7f06e5
+  languageName: node
+  linkType: hard
+
 "raw-body@npm:2.4.0":
   version: 2.4.0
   resolution: "raw-body@npm:2.4.0"
@@ -10247,6 +10254,7 @@ fsevents@~2.3.1:
     eslint-config-prettier: ">=8.3.0"
     markdownlint-cli: ">=0.28.1"
     prettier: ">=2.4.1"
+    rater-js: ">=1.0.1 <2"
     resolve-url-loader: ^4.0.0
     simplelightbox: ">=2.9.0 <3"
     stylelint: ">=13.13.1"


### PR DESCRIPTION
close #369

**db migrateが必要！**

好みの酒を記録できるぞ！！

## やったこと

- 酒モデルにratingカラムを追加
- 酒showページに☆で評価を表示
- 酒formで☆で評価を入力できる
  - ☆入力にはrater-jsを使った

## やってないこと

- rater-jsの☆をbootstrap-icon化
  - bootstrap-iconsのstar.svgの読み込みがRails6だとやっかい
  - Rails7化してから考える、Rails7でもやっかいかもしれない。