### PR TITLE
お品書きビューを追加

### DIFF
--- a/app/helpers/sakes_helper.rb
+++ b/app/helpers/sakes_helper.rb
@@ -46,6 +46,7 @@ module SakesHelper
 
   # @type [Array<String>]
   UNITS = %w[合 升 斗 石].freeze
+  private_constant :UNITS
 
   # 酒の量[ml]を尺貫法の体積にした文字列で返す
   #
@@ -75,6 +76,7 @@ module SakesHelper
 
   # @type [float] 利率
   INTEREST_RATE = 3.0
+  private_constant :INTEREST_RATE
 
   # 酒の一合当たりの値段を計算して文字列で返す
   # 値段が計算できない場合は"時価"を返す
@@ -109,7 +111,4 @@ module SakesHelper
   def year_range(begin_year)
     (begin_year - start_year_limit)..begin_year
   end
-
-  private_constant :UNITS
-  private_constant :INTEREST_RATE
 end

--- a/app/helpers/sakes_helper.rb
+++ b/app/helpers/sakes_helper.rb
@@ -78,16 +78,16 @@ module SakesHelper
   INTEREST_RATE = 3.0
   private_constant :INTEREST_RATE
 
-  # 酒の一合当たりの値段を計算して文字列で返す
-  # 値段が計算できない場合は"時価"を返す
+  # お品書きで酒の値札として表示する文字列を返す
   #
-  # @param price [Integer] 酒の買値(円)
-  # @param size [Integer] 酒の量(ml)
-  # @return [String] 売値(円)または時価
-  def selling_price(price, size)
-    return t("sakes.drink_menu.market_price") if price.blank? || size.blank?
+  # selling_price がnilの場合は"時価"を返す.
+  # そうでなければ、selling_priceに単位をつけて"xxx円"を返す。
+  # @param selling_price [Integer, nil] 売値またはnil
+  # @return [String] 酒の値札として表示する文字列
+  def price_tag(selling_price)
+    return t("sakes.drink_menu.market_price") if selling_price.nil?
 
-    (price.to_f / size * 180 * INTEREST_RATE).ceil(-1).to_i.to_s + t("activerecord.attributes.sake.price_unit")
+    selling_price.to_s + t("activerecord.attributes.sake.price_unit")
   end
 
   private

--- a/app/helpers/sakes_helper.rb
+++ b/app/helpers/sakes_helper.rb
@@ -73,6 +73,21 @@ module SakesHelper
     end
   end
 
+  # @type [float] 利率
+  INTEREST_RATE = 3.0
+
+  # 酒の一合当たりの値段を計算して文字列で返す
+  # 値段が計算できない場合は"時価"を返す
+  #
+  # @param price [Integer] 酒の買値(円)
+  # @param size [Integer] 酒の量(ml)
+  # @return [String] 売値(円)または時価
+  def selling_price(price, size)
+    return t("sakes.drink_menu.market_price") if price.blank? || size.blank?
+
+    (price.to_f / size * 180 * INTEREST_RATE).ceil(-1).to_i.to_s + t("activerecord.attributes.sake.price_unit")
+  end
+
   private
 
   # 過去何年を酒情報に入力可能にするかの値
@@ -96,4 +111,5 @@ module SakesHelper
   end
 
   private_constant :UNITS
+  private_constant :INTEREST_RATE
 end

--- a/app/helpers/sakes_helper.rb
+++ b/app/helpers/sakes_helper.rb
@@ -74,10 +74,6 @@ module SakesHelper
     end
   end
 
-  # @type [float] 利率
-  INTEREST_RATE = 3.0
-  private_constant :INTEREST_RATE
-
   # お品書きで酒の値札として表示する文字列を返す
   #
   # selling_price がnilの場合は"時価"を返す.

--- a/app/helpers/sakes_helper.rb
+++ b/app/helpers/sakes_helper.rb
@@ -87,7 +87,7 @@ module SakesHelper
   def price_tag(selling_price)
     return t("sakes.drink_menu.market_price") if selling_price.nil?
 
-    selling_price.to_s + t("activerecord.attributes.sake.price_unit")
+    "#{selling_price}#{t('activerecord.attributes.sake.price_unit')}"
   end
 
   private

--- a/app/models/sake.rb
+++ b/app/models/sake.rb
@@ -184,9 +184,9 @@ class Sake < ApplicationRecord
   # 売値が計算できない場合はnilを返す。
   # @return [Integer,nil] 酒一合当たりの売値またはnil
   def selling_price
-    return nil if price.nil? || size.nil? || size.zero?
+    return nil if price.nil? || price.zero? || size.nil? || size.zero?
 
-    (price.to_f / size * 180 * INTEREST_RATE).ceil(-1).to_i
+    (price.to_f / size * 180 * INTEREST_RATE).ceil(-1)
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/models/sake.rb
+++ b/app/models/sake.rb
@@ -161,4 +161,18 @@ class Sake < ApplicationRecord
       where(bottle_level: "sealed").sum(:size) + (where(bottle_level: "opened").sum(:size) / 2)
     end
   end
+
+  # @type [Date] 設定値以内の日付に購入した未開封の酒を、新着と判定する
+  SEALD_NEW_LIMIT = 28.days
+  # @type [Date] 設定値以内の日付に購入した開封済の酒を、新着と判定する
+  OPENED_NEW_LIMIT = 14.days
+  # 酒が新しいか
+  # @return [Boolean] 未開封または1週間以内に購入ならture、さもなくばfalse
+  def new_arrival?
+    created_at >= if sealed?
+                    Time.zone.today.ago(SEALD_NEW_LIMIT)
+                  else
+                    Time.zone.today.ago(OPENED_NEW_LIMIT)
+                  end
+  end
 end

--- a/app/models/sake.rb
+++ b/app/models/sake.rb
@@ -171,14 +171,15 @@ class Sake < ApplicationRecord
   OPENED_NEW_LIMIT = 14.days
   private_constant :OPENED_NEW_LIMIT
 
-  # 酒が新しいか
-  # @return [Boolean] 未開封または1週間以内に購入ならture、さもなくばfalse
+  # 酒が新着ならture、さもなくばfalse
+  #
+  # 下記のいずれかに当てはまる場合は新着と判定する
+  # - 未開封かつSEALD_NEW_LIMITの期間以内に購入した
+  # - 開封済かつOPENED_NEW_LIMITの期間以内に購入した
+  # @return [Boolean]
   def new_arrival?
-    created_at >= if sealed?
-                    Time.zone.today.ago(SEALD_NEW_LIMIT)
-                  else
-                    Time.zone.today.ago(OPENED_NEW_LIMIT)
-                  end
+    new_limit = sealed? ? SEALD_NEW_LIMIT : OPENED_NEW_LIMIT
+    created_at >= Time.zone.today.ago(new_limit)
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/models/sake.rb
+++ b/app/models/sake.rb
@@ -181,5 +181,20 @@ class Sake < ApplicationRecord
     new_limit = sealed? ? SEALD_NEW_LIMIT : OPENED_NEW_LIMIT
     created_at.to_date >= Time.zone.today.ago(new_limit)
   end
+
+  # @type [float] 利率
+  INTEREST_RATE = 3.0
+  private_constant :INTEREST_RATE
+
+  # 酒一合当たりの売値を計算する。
+  #
+  # 酒一本あたりの価格・内容量と、設定した利率をもとに計算。一の位は切り上げ。
+  # 売値が計算できない場合はnilを返す。
+  # @return [Integer,nil] 酒一合当たりの売値またはnil
+  def selling_price
+    return nil if price.nil? || size.nil? || size.zero?
+
+    (price.to_f / size * 180 * INTEREST_RATE).ceil(-1).to_i
+  end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/models/sake.rb
+++ b/app/models/sake.rb
@@ -42,6 +42,7 @@
 
 require "elasticsearch/model"
 
+# rubocop:disable Metrics/ClassLength
 class Sake < ApplicationRecord
   has_many :photos, dependent: :destroy
   enum bottle_level: {
@@ -166,6 +167,7 @@ class Sake < ApplicationRecord
   SEALD_NEW_LIMIT = 28.days
   # @type [Date] 設定値以内の日付に購入した開封済の酒を、新着と判定する
   OPENED_NEW_LIMIT = 14.days
+
   # 酒が新しいか
   # @return [Boolean] 未開封または1週間以内に購入ならture、さもなくばfalse
   def new_arrival?
@@ -176,3 +178,4 @@ class Sake < ApplicationRecord
                   end
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/app/models/sake.rb
+++ b/app/models/sake.rb
@@ -179,7 +179,7 @@ class Sake < ApplicationRecord
   # @return [Boolean]
   def new_arrival?
     new_limit = sealed? ? SEALD_NEW_LIMIT : OPENED_NEW_LIMIT
-    created_at >= Time.zone.today.ago(new_limit)
+    created_at.to_date >= Time.zone.today.ago(new_limit)
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/models/sake.rb
+++ b/app/models/sake.rb
@@ -165,8 +165,11 @@ class Sake < ApplicationRecord
 
   # @type [Date] 設定値以内の日付に購入した未開封の酒を、新着と判定する
   SEALD_NEW_LIMIT = 28.days
+  private_constant :SEALD_NEW_LIMIT
+
   # @type [Date] 設定値以内の日付に購入した開封済の酒を、新着と判定する
   OPENED_NEW_LIMIT = 14.days
+  private_constant :OPENED_NEW_LIMIT
 
   # 酒が新しいか
   # @return [Boolean] 未開封または1週間以内に購入ならture、さもなくばfalse

--- a/app/models/sake.rb
+++ b/app/models/sake.rb
@@ -163,23 +163,15 @@ class Sake < ApplicationRecord
     end
   end
 
-  # @type [Date] 設定値以内の日付に購入した未開封の酒を、新着と判定する
-  SEALD_NEW_LIMIT = 28.days
-  private_constant :SEALD_NEW_LIMIT
-
-  # @type [Date] 設定値以内の日付に購入した開封済の酒を、新着と判定する
-  OPENED_NEW_LIMIT = 14.days
-  private_constant :OPENED_NEW_LIMIT
-
   # 酒が新着ならture、さもなくばfalse
   #
   # 下記のいずれかに当てはまる場合は新着と判定する
-  # - 未開封かつSEALD_NEW_LIMITの期間以内に購入した
-  # - 開封済かつOPENED_NEW_LIMITの期間以内に購入した
+  # - 未開封かつ4週間以内に購入した
+  # - 開封済かつ2週間以内に購入した
   # @return [Boolean]
   def new_arrival?
-    new_limit = sealed? ? SEALD_NEW_LIMIT : OPENED_NEW_LIMIT
-    created_at.to_date >= Time.zone.today.ago(new_limit)
+    new_limit = sealed? ? 4.weeks : 2.weeks
+    Time.zone.now.beginning_of_day - created_at.beginning_of_day <= new_limit
   end
 
   # @type [float] 利率

--- a/app/models/sake.rb
+++ b/app/models/sake.rb
@@ -174,19 +174,19 @@ class Sake < ApplicationRecord
     Time.zone.now.beginning_of_day - created_at.beginning_of_day <= new_limit
   end
 
-  # @type [float] 利率
-  INTEREST_RATE = 3.0
-  private_constant :INTEREST_RATE
+  # @type [float] 酒の売値を決めるために、仕入れ値にかける係数
+  SELLING_RATE = 3.0
+  private_constant :SELLING_RATE
 
   # 酒一合当たりの売値を計算する。
   #
-  # 酒一本あたりの価格・内容量と、設定した利率をもとに計算。一の位は切り上げ。
+  # 酒一本あたりの価格・内容量と、設定した係数をもとに計算。十の位以下切り上げ。
   # 売値が計算できない場合はnilを返す。
   # @return [Integer,nil] 酒一合当たりの売値またはnil
   def selling_price
     return nil if price.nil? || price.zero? || size.nil? || size.zero?
 
-    (price.to_f / size * 180 * INTEREST_RATE).ceil(-1)
+    (price.to_f / size * 180 * SELLING_RATE).ceil(-2)
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/packs/entrypoints/sakes/drink_menu.js
+++ b/app/packs/entrypoints/sakes/drink_menu.js
@@ -1,0 +1,1 @@
+// empty entry point

--- a/app/packs/entrypoints/sakes/drink_menu.scss
+++ b/app/packs/entrypoints/sakes/drink_menu.scss
@@ -1,0 +1,19 @@
+@import "../../src/stylesheet/bootstrap_custom";
+@import "~bootstrap/scss/bootstrap";
+@import url("https://fonts.googleapis.com/css2?family=Yuji+Syuku&display=swap");
+
+$accent: #b7282e;
+
+.drink-menu-font {
+  font-family: "Yuji Syuku", serif;
+}
+
+.accent-badge {
+  background-color: $accent;
+  font-weight: normal;
+}
+
+.name-link {
+  overflow-wrap: break-word;
+  word-break: keep-all;
+}

--- a/app/views/sakes/drink_menu.html.erb
+++ b/app/views/sakes/drink_menu.html.erb
@@ -12,8 +12,7 @@
 
   <% @sakes.each do |sake| %>
     <div class="col-auto" style="max-width: 60%;">
-      <%= link_to(sake.name.to_s, sake_path(sake.id),
-                  { class: "text-decoration-none text-dark name-link" }) %>
+      <%= link_to(sake.name, sake_path(sake.id), class: "text-decoration-none text-dark name-link") %>
     </div>
 
     <% if sake.new_arrival? %>

--- a/app/views/sakes/drink_menu.html.erb
+++ b/app/views/sakes/drink_menu.html.erb
@@ -29,7 +29,7 @@
     </div>
 
     <div class="col col-lg-1 text-end text-nowrap">
-      <%= selling_price(sake.price, sake.size) %>
+      <%= price_tag(sake.selling_price) %>
     </div>
 
     <%# 強制改行 %>

--- a/app/views/sakes/drink_menu.html.erb
+++ b/app/views/sakes/drink_menu.html.erb
@@ -1,7 +1,38 @@
-<h1>お品書き</h1>
+<% select_pack_js(%w[common sakes/drink_menu]) %>
+<% select_pack_style(%w[common sakes/drink_menu]) %>
 
-<% @sakes.each do |sake| %>
-  <div class="col-auto">
-    <%= link_to(sake.name.to_s, sake_path(sake.id)) %>
+<h1 class="drink-menu-font display-3">
+  <%= title(t(".title")) %>
+</h1>
+
+<div class="row drink-menu-font fs-4">
+  <div class="col-12 text-end">
+    <%= t(".price_per_go") %>
   </div>
-<% end %>
+
+  <% @sakes.each do |sake| %>
+    <div class="col-auto" style="max-width: 60%;">
+      <%= link_to(sake.name.to_s, sake_path(sake.id),
+                  { class: "text-decoration-none text-dark name-link" }) %>
+    </div>
+
+    <% if sake.new_arrival? %>
+      <div class="col-1">
+        <span class="badge rounded-pill fs-6 accent-badge">
+          <%= t(".new_arrival") %>
+        </span>
+      </div>
+    <% end %>
+
+    <div class="col d-none d-lg-block">
+      <hr class="border border-dark border-1">
+    </div>
+
+    <div class="col col-lg-1 text-end text-nowrap">
+      <%= selling_price(sake.price, sake.size) %>
+    </div>
+
+    <%# 強制改行 %>
+    <div class="w-100 mb-4"></div>
+  <% end %>
+</div>

--- a/config/locales/views/sake.ja.yml
+++ b/config/locales/views/sake.ja.yml
@@ -40,3 +40,8 @@ ja:
     float-button:
       edit: :sakes.index.edit
       new: 新規
+    drink_menu:
+      title: お品書き
+      market_price: 時価
+      price_per_go: 一合あたり
+      new_arrival: 新着

--- a/spec/helpers/sakes_helper_spec.rb
+++ b/spec/helpers/sakes_helper_spec.rb
@@ -109,4 +109,29 @@ RSpec.describe SakesHelper do
       expect(to_shakkan(100)).to eq("0合")
     end
   end
+
+  describe "selling_price" do
+    before do
+      # 利率を1.5にしてテスト
+      stub_const("SakesHelper::INTEREST_RATE", 1.5)
+    end
+
+    context "if first argument is nil" do
+      it "returns market price" do
+        expect(selling_price(nil, 100)).to eq(t("sakes.drink_menu.market_price"))
+      end
+    end
+
+    context "if second argument is nil" do
+      it "returns market price" do
+        expect(selling_price(100, nil)).to eq(t("sakes.drink_menu.market_price"))
+      end
+    end
+
+    context "if both argument are set" do
+      it "returns price per 180[ml]" do
+        expect(selling_price(1234, 720)).to eq("470円")
+      end
+    end
+  end
 end

--- a/spec/helpers/sakes_helper_spec.rb
+++ b/spec/helpers/sakes_helper_spec.rb
@@ -110,27 +110,16 @@ RSpec.describe SakesHelper do
     end
   end
 
-  describe "selling_price" do
-    before do
-      # 利率を1.5にしてテスト
-      stub_const("SakesHelper::INTEREST_RATE", 1.5)
-    end
-
-    context "if first argument is nil" do
-      it "returns market price" do
-        expect(selling_price(nil, 100)).to eq(t("sakes.drink_menu.market_price"))
+  describe "price_tag" do
+    context "if the argument is nil" do
+      it "returns text meaning market price" do
+        expect(price_tag(nil)).to eq(t("sakes.drink_menu.market_price"))
       end
     end
 
-    context "if second argument is nil" do
-      it "returns market price" do
-        expect(selling_price(100, nil)).to eq(t("sakes.drink_menu.market_price"))
-      end
-    end
-
-    context "if both argument are set" do
-      it "returns price per 180[ml]" do
-        expect(selling_price(1234, 720)).to eq("470円")
+    context "if the argument is integer" do
+      it "returns price tag with unit" do
+        expect(price_tag(1234)).to eq("1234円")
       end
     end
   end

--- a/spec/helpers/sakes_helper_spec.rb
+++ b/spec/helpers/sakes_helper_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe SakesHelper do
 
     context "if the argument is integer" do
       it "returns price tag with unit" do
-        expect(price_tag(1234)).to eq("1234円")
+        expect(price_tag(1234)).to eq("1234#{t('activerecord.attributes.sake.price_unit')}")
       end
     end
   end

--- a/spec/models/sake_spec.rb
+++ b/spec/models/sake_spec.rb
@@ -128,4 +128,42 @@ RSpec.describe Sake do
       end
     end
   end
+
+  describe "Sake.new_arrival?" do
+    before do
+      # 2週間以内に購入した未開封の酒を、新着と判定する
+      stub_const("#{described_class}::SEALD_NEW_LIMIT", 14.days)
+
+      # 1週間以内に購入した開封済の酒を、新着と判定する
+      stub_const("#{described_class}::OPENED_NEW_LIMIT", 7.days)
+    end
+
+    context "when sake is seald and created within 2 weeks" do
+      it "returns true" do
+        sealed_new_sake = FactoryBot.build(:sake, bottle_level: "sealed", created_at: Time.zone.today.ago(14.days))
+        expect(sealed_new_sake.new_arrival?).to eq(true)
+      end
+    end
+
+    context "when sake is seald and created more than 2 weeks ago" do
+      it "returns false" do
+        sealed_old_sake = FactoryBot.build(:sake, bottle_level: "sealed", created_at: Time.zone.today.ago(15.days))
+        expect(sealed_old_sake.new_arrival?).to eq(false)
+      end
+    end
+
+    context "when sake is opened and created within 1 week" do
+      it "returns true" do
+        opened_new_sake = FactoryBot.build(:sake, bottle_level: "opened", created_at: Time.zone.today.ago(7.days))
+        expect(opened_new_sake.new_arrival?).to eq(true)
+      end
+    end
+
+    context "when sake is opened and created more than 1 weeks ago" do
+      it "returns false" do
+        opened_old_sake = FactoryBot.build(:sake, bottle_level: "opened", created_at: Time.zone.today.ago(8.days))
+        expect(opened_old_sake.new_arrival?).to eq(false)
+      end
+    end
+  end
 end

--- a/spec/models/sake_spec.rb
+++ b/spec/models/sake_spec.rb
@@ -136,32 +136,34 @@ RSpec.describe Sake do
 
       # 1週間以内に購入した開封済の酒を、新着と判定する
       stub_const("#{described_class}::OPENED_NEW_LIMIT", 7.days)
+
+      travel_to(Time.zone.local(2022, 1, 16, 20, 30))
     end
 
     context "when sake is seald and created within 2 weeks" do
       it "returns true" do
-        sealed_new_sake = FactoryBot.build(:sake, bottle_level: "sealed", created_at: Time.zone.today.ago(14.days))
+        sealed_new_sake = FactoryBot.build(:sake, bottle_level: "sealed", created_at: Time.zone.local(2022, 1, 2, 10, 30))
         expect(sealed_new_sake.new_arrival?).to eq(true)
       end
     end
 
     context "when sake is seald and created more than 2 weeks ago" do
       it "returns false" do
-        sealed_old_sake = FactoryBot.build(:sake, bottle_level: "sealed", created_at: Time.zone.today.ago(15.days))
+        sealed_old_sake = FactoryBot.build(:sake, bottle_level: "sealed", created_at: Time.zone.local(2022, 1, 1, 10, 30))
         expect(sealed_old_sake.new_arrival?).to eq(false)
       end
     end
 
     context "when sake is opened and created within 1 week" do
       it "returns true" do
-        opened_new_sake = FactoryBot.build(:sake, bottle_level: "opened", created_at: Time.zone.today.ago(7.days))
+        opened_new_sake = FactoryBot.build(:sake, bottle_level: "opened", created_at: Time.zone.local(2022, 1, 9, 10, 30))
         expect(opened_new_sake.new_arrival?).to eq(true)
       end
     end
 
     context "when sake is opened and created more than 1 weeks ago" do
       it "returns false" do
-        opened_old_sake = FactoryBot.build(:sake, bottle_level: "opened", created_at: Time.zone.today.ago(8.days))
+        opened_old_sake = FactoryBot.build(:sake, bottle_level: "opened", created_at: Time.zone.local(2022, 1, 8, 10, 30))
         expect(opened_old_sake.new_arrival?).to eq(false)
       end
     end

--- a/spec/models/sake_spec.rb
+++ b/spec/models/sake_spec.rb
@@ -172,25 +172,33 @@ RSpec.describe Sake do
     context "if price is nil" do
       let(:sake) { FactoryBot.build(:sake, price: nil, size: 100) }
 
-      it { expect(sake.selling_price).to eq(nil) }
+      it "returns nil" do
+        expect(sake.selling_price).to eq(nil)
+      end
     end
 
     context "if size is nil" do
       let(:sake) { FactoryBot.build(:sake, price: 100, size: nil) }
 
-      it { expect(sake.selling_price).to eq(nil) }
+      it "returns nil" do
+        expect(sake.selling_price).to eq(nil)
+      end
     end
 
     context "if size is zero" do
       let(:sake) { FactoryBot.build(:sake, price: 100, size: 0) }
 
-      it { expect(sake.selling_price).to eq(nil) }
+      it "returns nil" do
+        expect(sake.selling_price).to eq(nil)
+      end
     end
 
     context "if the sake is 1234 yen and 720ml" do
       let(:sake) { FactoryBot.build(:sake, price: 1234, size: 720) }
 
-      it { expect(sake.selling_price).to eq(470) }
+      it "returns 470" do
+        expect(sake.selling_price).to eq(470)
+      end
     end
   end
 end

--- a/spec/models/sake_spec.rb
+++ b/spec/models/sake_spec.rb
@@ -177,6 +177,14 @@ RSpec.describe Sake do
       end
     end
 
+    context "if price is zero" do
+      let(:sake) { FactoryBot.build(:sake, price: nil, size: 0) }
+
+      it "returns nil" do
+        expect(sake.selling_price).to eq(nil)
+      end
+    end
+
     context "if size is nil" do
       let(:sake) { FactoryBot.build(:sake, price: 100, size: nil) }
 

--- a/spec/models/sake_spec.rb
+++ b/spec/models/sake_spec.rb
@@ -168,4 +168,35 @@ RSpec.describe Sake do
       end
     end
   end
+
+  describe "Sake.selling_price" do
+    before do
+      # 利率を1.5にしてテスト
+      stub_const("#{described_class}::INTEREST_RATE", 1.5)
+    end
+
+    context "if price is nil" do
+      let(:sake) { FactoryBot.build(:sake, price: nil, size: 100) }
+
+      it { expect(sake.selling_price).to eq(nil) }
+    end
+
+    context "if size is nil" do
+      let(:sake) { FactoryBot.build(:sake, price: 100, size: nil) }
+
+      it { expect(sake.selling_price).to eq(nil) }
+    end
+
+    context "if size is zero" do
+      let(:sake) { FactoryBot.build(:sake, price: 100, size: 0) }
+
+      it { expect(sake.selling_price).to eq(nil) }
+    end
+
+    context "if the sake is 1234 yen and 720ml" do
+      let(:sake) { FactoryBot.build(:sake, price: 1234, size: 720) }
+
+      it { expect(sake.selling_price).to eq(470) }
+    end
+  end
 end

--- a/spec/models/sake_spec.rb
+++ b/spec/models/sake_spec.rb
@@ -131,39 +131,33 @@ RSpec.describe Sake do
 
   describe "Sake.new_arrival?" do
     before do
-      # 2週間以内に購入した未開封の酒を、新着と判定する
-      stub_const("#{described_class}::SEALD_NEW_LIMIT", 14.days)
-
-      # 1週間以内に購入した開封済の酒を、新着と判定する
-      stub_const("#{described_class}::OPENED_NEW_LIMIT", 7.days)
-
-      travel_to(Time.zone.local(2022, 1, 16, 20, 30))
+      travel_to(Time.zone.parse("2022-01-30 20:30:00"))
     end
 
-    context "when sake is seald and created within 2 weeks" do
+    context "when sake is seald and created within 4 weeks" do
       it "returns true" do
-        sealed_new_sake = FactoryBot.build(:sake, bottle_level: "sealed", created_at: Time.zone.local(2022, 1, 2, 10, 30))
+        sealed_new_sake = FactoryBot.build(:sake, bottle_level: "sealed", created_at: Time.zone.parse("2022-01-02 10:30:00"))
         expect(sealed_new_sake.new_arrival?).to eq(true)
       end
     end
 
-    context "when sake is seald and created more than 2 weeks ago" do
+    context "when sake is seald and created more than 4 weeks ago" do
       it "returns false" do
-        sealed_old_sake = FactoryBot.build(:sake, bottle_level: "sealed", created_at: Time.zone.local(2022, 1, 1, 10, 30))
+        sealed_old_sake = FactoryBot.build(:sake, bottle_level: "sealed", created_at: Time.zone.parse("2022-01-01 10:30:00"))
         expect(sealed_old_sake.new_arrival?).to eq(false)
       end
     end
 
-    context "when sake is opened and created within 1 week" do
+    context "when sake is opened and created within 2 week" do
       it "returns true" do
-        opened_new_sake = FactoryBot.build(:sake, bottle_level: "opened", created_at: Time.zone.local(2022, 1, 9, 10, 30))
+        opened_new_sake = FactoryBot.build(:sake, bottle_level: "opened", created_at: Time.zone.parse("2022-01-16 10:30:00"))
         expect(opened_new_sake.new_arrival?).to eq(true)
       end
     end
 
-    context "when sake is opened and created more than 1 weeks ago" do
+    context "when sake is opened and created more than 2 weeks ago" do
       it "returns false" do
-        opened_old_sake = FactoryBot.build(:sake, bottle_level: "opened", created_at: Time.zone.local(2022, 1, 8, 10, 30))
+        opened_old_sake = FactoryBot.build(:sake, bottle_level: "opened", created_at: Time.zone.parse("2022-01-15 10:30:00"))
         expect(opened_old_sake.new_arrival?).to eq(false)
       end
     end

--- a/spec/models/sake_spec.rb
+++ b/spec/models/sake_spec.rb
@@ -164,11 +164,6 @@ RSpec.describe Sake do
   end
 
   describe "Sake.selling_price" do
-    before do
-      # 利率を1.5にしてテスト
-      stub_const("#{described_class}::INTEREST_RATE", 1.5)
-    end
-
     context "if price is nil" do
       let(:sake) { FactoryBot.build(:sake, price: nil, size: 100) }
 
@@ -201,11 +196,21 @@ RSpec.describe Sake do
       end
     end
 
-    context "if the sake is 1234 yen and 720ml" do
+    context "if price is 1,234 yen per 720 ml and selling rate is 3" do
       let(:sake) { FactoryBot.build(:sake, price: 1234, size: 720) }
 
-      it "returns 470" do
-        expect(sake.selling_price).to eq(470)
+      it "returns 1000" do
+        stub_const("#{described_class}::SELLING_RATE", 3)
+        expect(sake.selling_price).to eq(1000)
+      end
+    end
+
+    context "if price is 1,234 yen per 720 ml and selling rate is 1.5" do
+      let(:sake) { FactoryBot.build(:sake, price: 1234, size: 720) }
+
+      it "returns 500" do
+        stub_const("#{described_class}::SELLING_RATE", 1.5)
+        expect(sake.selling_price).to eq(500)
       end
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -66,4 +66,7 @@ RSpec.configure do |config|
   config.include(Devise::Test::IntegrationHelpers, type: :request)
   config.include(Devise::Test::IntegrationHelpers, type: :system)
   config.include(SignIn, type: :system)
+
+  # Contains helpers that help you test passage of time.
+  config.include(ActiveSupport::Testing::TimeHelpers)
 end


### PR DESCRIPTION
### やったこと
- お品書きのビューを追加した（テスト未）
- ビューで使う、下記二つのメソッドを追加した（テスト済）
  - 酒一合当たりの値段を表示するための`selling_price`メソッド
  - 酒が新着かどうかを判定する`new_arrival?`メソッド

https://github.com/momocus/sakazuki/wiki/%E3%81%8A%E5%93%81%E6%9B%B8%E3%81%8D

### このあとやること

- **モバイル版のデザインを決める**
- お品書きのビューに対するテスト
- トップページからお品書きページへアクセスできるようリンクを貼る（ハンバーガーメニューに入れるつもり）
  - リンクからアクセスできるかのテスト 

### レビューしてほしいとこ

- ~~お品書きのビューのデザイン~~（モバイル版のデザインをちゃんと決めてなかったから、次のプルリクでやり直し）
- `selling_price`メソッドと`new_arrival?`メソッドのコード
