### PR TITLE
味香りグラフのリセットを今までの別ボタンを止め既存点をクリックに変えた

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,7 +35,7 @@ module.exports = {
       rules: {
         "@typescript-eslint/no-unused-vars": [
           "warn",
-          { argsIgnorePattern: "^_" },
+          { varsIgnorePattern: "^_", argsIgnorePattern: "^_" },
         ],
       },
     },

--- a/app/packs/src/typescript/input_taste_graph.ts
+++ b/app/packs/src/typescript/input_taste_graph.ts
@@ -13,8 +13,7 @@ function updateDomValue(data: GraphP): void {
   aromaInput.setAttribute("value", y)
 }
 
-// DOMにデータがない場合はデータセットをする副作用がある
-function syncAndGetDomValue(): GraphP {
+function getDomValue(): DomValues {
   const tasteInput = document.getElementById(
     "sake_taste_value"
   ) as HTMLInputElement
@@ -32,7 +31,7 @@ function syncAndGetDomValue(): GraphP {
 
 {
   document.addEventListener("DOMContentLoaded", function () {
-    const domData = syncAndGetDomValue() // DOMから味・香りの値を取る、domDataは0~6の二次元データ
+    const domData = getDomValue() // DOMから味・香りの値(0~6)を取る
     const canvas = document.getElementById("taste_graph") as HTMLCanvasElement
     const _graph = new TasteGraph(canvas, domData, {}, true, updateDomValue)
   })

--- a/app/packs/src/typescript/input_taste_graph.ts
+++ b/app/packs/src/typescript/input_taste_graph.ts
@@ -32,18 +32,8 @@ function syncAndGetDomValue(): GraphP {
 
 {
   document.addEventListener("DOMContentLoaded", function () {
-    // DOMから味・香りの値を取る
+    const domData = syncAndGetDomValue() // DOMから味・香りの値を取る、domDataは0~6の二次元データ
     const canvas = document.getElementById("taste_graph") as HTMLCanvasElement
-    const domData = syncAndGetDomValue() // dataは0~6の二次元データ
-
-    // グラフをセットする
-    const graph = new TasteGraph(canvas, domData, {}, true, updateDomValue)
-
-    // グラフのリセットボタンをセットする
-    const button = document.getElementById("graph-reset") as HTMLDivElement
-    button.onclick = () => {
-      graph.update(null)
-      updateDomValue(null)
-    }
+    const _graph = new TasteGraph(canvas, domData, {}, true, updateDomValue)
   })
 }

--- a/app/packs/src/typescript/input_taste_graph.ts
+++ b/app/packs/src/typescript/input_taste_graph.ts
@@ -1,8 +1,8 @@
-import { GraphP, TasteGraph } from "./taste_graph"
+import { DomValues, TasteGraph } from "./taste_graph"
 
-function updateDomValue(data: GraphP): void {
-  const x = data ? data.x.toString() : ""
-  const y = data ? data.y.toString() : ""
+function updateDomValue(data: DomValues): void {
+  const x = isNaN(data.taste) ? "" : data.taste.toString()
+  const y = isNaN(data.arroma) ? "" : data.arroma.toString()
   const tasteInput = document.getElementById(
     "sake_taste_value"
   ) as HTMLInputElement
@@ -20,19 +20,19 @@ function getDomValue(): DomValues {
   const aromaInput = document.getElementById(
     "sake_aroma_value"
   ) as HTMLInputElement
-  if (tasteInput.value && aromaInput.value) {
-    const taste = parseInt(tasteInput.value)
-    const aroma = parseInt(aromaInput.value)
-    if (Number.isInteger(taste) && Number.isInteger(aroma))
-      return { x: taste, y: aroma }
-  }
-  return null // データがない場合
+  if (tasteInput.value && aromaInput.value)
+    return {
+      taste: parseInt(tasteInput.value),
+      arroma: parseInt(aromaInput.value),
+    }
+  // データがない場合
+  return { taste: NaN, arroma: NaN }
 }
 
 {
   document.addEventListener("DOMContentLoaded", function () {
-    const domData = getDomValue() // DOMから味・香りの値(0~6)を取る
+    const { taste, arroma } = getDomValue() // DOMから味・香りの値(0~6)を取る
     const canvas = document.getElementById("taste_graph") as HTMLCanvasElement
-    const _graph = new TasteGraph(canvas, domData, {}, true, updateDomValue)
+    new TasteGraph(canvas, taste, arroma, {}, true, updateDomValue)
   })
 }

--- a/app/packs/src/typescript/input_taste_graph.ts
+++ b/app/packs/src/typescript/input_taste_graph.ts
@@ -2,7 +2,7 @@ import { DomValues, TasteGraph } from "./taste_graph"
 
 function updateDomValue(data: DomValues): void {
   const x = isNaN(data.taste) ? "" : data.taste.toString()
-  const y = isNaN(data.arroma) ? "" : data.arroma.toString()
+  const y = isNaN(data.aroma) ? "" : data.aroma.toString()
   const tasteInput = document.getElementById(
     "sake_taste_value"
   ) as HTMLInputElement
@@ -23,16 +23,16 @@ function getDomValue(): DomValues {
   if (tasteInput.value && aromaInput.value)
     return {
       taste: parseInt(tasteInput.value),
-      arroma: parseInt(aromaInput.value),
+      aroma: parseInt(aromaInput.value),
     }
   // データがない場合
-  return { taste: NaN, arroma: NaN }
+  return { taste: NaN, aroma: NaN }
 }
 
 {
   document.addEventListener("DOMContentLoaded", function () {
-    const { taste, arroma } = getDomValue() // DOMから味・香りの値(0~6)を取る
+    const { taste, aroma } = getDomValue() // DOMから味・香りの値(0~6)を取る
     const canvas = document.getElementById("taste_graph") as HTMLCanvasElement
-    new TasteGraph(canvas, taste, arroma, {}, true, updateDomValue)
+    new TasteGraph(canvas, taste, aroma, {}, true, updateDomValue)
   })
 }

--- a/app/packs/src/typescript/show_taste_graph.ts
+++ b/app/packs/src/typescript/show_taste_graph.ts
@@ -1,17 +1,12 @@
-import { GraphP, TasteGraph } from "./taste_graph"
+import { DomValues, TasteGraph } from "./taste_graph"
 
-function getDomValueFromCanvas(canvas: HTMLCanvasElement): GraphP {
+function getDomValues(canvas: HTMLCanvasElement): DomValues {
   const tasteS = canvas.dataset.tasteValue
   const aromaS = canvas.dataset.aromaValue
-  // not (undefined or empty string)
-  if (tasteS && aromaS) {
-    const taste = parseInt(tasteS)
-    const aroma = parseInt(aromaS)
-    if (Number.isInteger(taste) && Number.isInteger(aroma))
-      return { x: taste, y: aroma }
-  }
-  // データがないなど、Domからデータが取れない場合
-  return null
+  // データがないやparse失敗など、Domからデータが取れない場合はNaN,NaNを返す
+  return tasteS && aromaS
+    ? { taste: parseInt(tasteS), arroma: parseInt(aromaS) }
+    : { taste: NaN, arroma: NaN }
 }
 
 const hasCanvasID = (elem: HTMLCanvasElement): boolean => {
@@ -24,9 +19,10 @@ const hasCanvasID = (elem: HTMLCanvasElement): boolean => {
   document.addEventListener("turbolinks:load", function () {
     const canvases = Array.from(document.getElementsByTagName("canvas"))
     const graphs = canvases.filter(hasCanvasID)
+    const config = { pointRadius: 6, zeroLineWidth: 3 }
     graphs.forEach((canvas) => {
-      const p = getDomValueFromCanvas(canvas)
-      new TasteGraph(canvas, p, { pointRadius: 6, zeroLineWidth: 3 })
+      const { taste, arroma } = getDomValues(canvas)
+      new TasteGraph(canvas, taste, arroma, config)
     })
   })
 }

--- a/app/packs/src/typescript/show_taste_graph.ts
+++ b/app/packs/src/typescript/show_taste_graph.ts
@@ -5,8 +5,8 @@ function getDomValues(canvas: HTMLCanvasElement): DomValues {
   const aromaS = canvas.dataset.aromaValue
   // データがないやparse失敗など、Domからデータが取れない場合はNaN,NaNを返す
   return tasteS && aromaS
-    ? { taste: parseInt(tasteS), arroma: parseInt(aromaS) }
-    : { taste: NaN, arroma: NaN }
+    ? { taste: parseInt(tasteS), aroma: parseInt(aromaS) }
+    : { taste: NaN, aroma: NaN }
 }
 
 const hasCanvasID = (elem: HTMLCanvasElement): boolean => {
@@ -21,8 +21,8 @@ const hasCanvasID = (elem: HTMLCanvasElement): boolean => {
     const graphs = canvases.filter(hasCanvasID)
     const config = { pointRadius: 6, zeroLineWidth: 3 }
     graphs.forEach((canvas) => {
-      const { taste, arroma } = getDomValues(canvas)
-      new TasteGraph(canvas, taste, arroma, config)
+      const { taste, aroma } = getDomValues(canvas)
+      new TasteGraph(canvas, taste, aroma, config)
     })
   })
 }

--- a/app/packs/src/typescript/taste_graph.ts
+++ b/app/packs/src/typescript/taste_graph.ts
@@ -86,9 +86,17 @@ export class TasteGraph implements InteractiveGraph {
     } else return null
   }
 
+  private eqGraphP(p1: GraphP, p2: GraphP) {
+    if (p1 == null && p2 == null) return true
+    else if (p1 == null || p2 == null) return false
+    else if (p1.x == p2.x && p1.y == p2.y) return true
+    else return false
+  }
+
   // JSに渡すときにthis問題を防ぐため、アロー関数で書いておく
   private onClickUpdate = (event: MouseEvent): void => {
-    const data = this.getClickedData(event)
+    let data = this.getClickedData(event)
+    if (this.data != null && this.eqGraphP(data, this.data)) data = null
     this.update(data)
   }
 

--- a/app/packs/src/typescript/taste_graph.ts
+++ b/app/packs/src/typescript/taste_graph.ts
@@ -23,7 +23,7 @@ export type GraphP = Chart.Point | null
  */
 const middle = 3
 
-export function toGraphPoint(documentData: GraphP): GraphP {
+export function fromDomPoint(documentData: GraphP): GraphP {
   return documentData != null
     ? { x: documentData.x - middle, y: documentData.y - middle }
     : null
@@ -44,6 +44,7 @@ interface InteractiveGraph {
 
 export class TasteGraph implements InteractiveGraph {
   public graph: Chart
+  private data: GraphP
 
   /*
    * HACk:
@@ -235,14 +236,15 @@ export class TasteGraph implements InteractiveGraph {
 
   constructor(
     canvas: HTMLCanvasElement,
-    private data: GraphP,
+    domData: GraphP,
     config: { pointRadius?: number; zeroLineWidth?: number },
     private clickable: boolean = false,
     private callbackUpdate: (data: GraphP) => void = (_data) => {
       // do nothing
     }
   ) {
-    const p = this.makeChartData(toGraphPoint(data))
+    this.data = fromDomPoint(domData)
+    const p = this.makeChartData(this.data)
     const chartConfig = this.makeChartConfiguration(p, config)
     this.graph = new Chart(canvas, chartConfig)
   }

--- a/app/packs/src/typescript/taste_graph.ts
+++ b/app/packs/src/typescript/taste_graph.ts
@@ -16,7 +16,7 @@ interface MetaChart extends Chart {
 
 export type GraphP = Chart.Point | null
 
-export type DomValues = { taste: number; arroma: number }
+export type DomValues = { taste: number; aroma: number }
 
 /*
  * HACK:
@@ -25,17 +25,17 @@ export type DomValues = { taste: number; arroma: number }
  */
 const middle = 3
 
-export function fromDom(taste: number, arroma: number): GraphP {
-  // taste/arromaはNaNの可能性がある
-  return isNaN(taste) || isNaN(arroma)
+export function fromDom(taste: number, aroma: number): GraphP {
+  // taste/aromaはNaNの可能性がある
+  return isNaN(taste) || isNaN(aroma)
     ? null
-    : { x: taste - middle, y: arroma - middle }
+    : { x: taste - middle, y: aroma - middle }
 }
 
 export function toDom(p: GraphP): DomValues {
   return p
-    ? { taste: p.x + middle, arroma: p.y + middle }
-    : { taste: NaN, arroma: NaN }
+    ? { taste: p.x + middle, aroma: p.y + middle }
+    : { taste: NaN, aroma: NaN }
 }
 
 export const graphPZero = { x: 0, y: 0 }
@@ -239,14 +239,14 @@ export class TasteGraph implements InteractiveGraph {
   constructor(
     canvas: HTMLCanvasElement,
     taste: number, // NaNがありうる
-    arroma: number, // NaNがありうる
+    aroma: number, // NaNがありうる
     config: { pointRadius?: number; zeroLineWidth?: number },
     private clickable: boolean = false,
     private callbackUpdate: (data: DomValues) => void = (_data) => {
       // do nothing
     }
   ) {
-    this.data = isNaN(taste) || isNaN(arroma) ? null : fromDom(taste, arroma)
+    this.data = isNaN(taste) || isNaN(aroma) ? null : fromDom(taste, aroma)
     const p = this.makeChartData(this.data)
     const chartConfig = this.makeChartConfiguration(p, config)
     this.graph = new Chart(canvas, chartConfig)

--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -346,12 +346,6 @@
           <div class="form-row mt-2">
             <%= form.label("#{t('activerecord.attributes.sake.taste_value')}, #{t('activerecord.attributes.sake.aroma_value')}",
                            { class: "col-lg-3 col-7 col-form-label" }) %>
-            <div class="col-lg-9 col-5">
-              <div class="btn btn-secondary rounded-pill border border-primary" id="graph-reset">
-                <%= t(".reset") %>
-              </div>
-            </div>
-            <div class="col-lg-3"></div>
             <%# MEMO: px-0だとchart.jsのグラフが描画されない %>
             <div class="col-lg-9 col px-1">
               <canvas class="mt-1" id="taste_graph"></canvas>

--- a/config/locales/views/sake.ja.yml
+++ b/config/locales/views/sake.ja.yml
@@ -22,7 +22,6 @@ ja:
     edit:
       title: 編集
     form:
-      reset: リセット
       select_delete_photo: 削除する画像を選択してください
       labelinfo: :sakes.show.labelinfo
       labelinfo_option: オプショナル


### PR DESCRIPTION
close #387 

ださいリセットボタンとおさらば、ratingとの統一感をとるぞ！

## やったこと

- 味香りグラフのリセットボタンを削除した
- 既存点クリックを味香りグラフのリセットにした
- こっそり味香りグラフのバグ修正
  - 動作は問題なかった
- ESLintの設定を変え、TSの`_variable_name`の未使用を許可した
  - 今まで設定済みと勘違いしていた
