### PR TITLE
RSpecを並列実行できるようにした

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,6 +68,8 @@ group :development, :test do
   gem "dotenv-rails"
   gem "factory_bot_rails"
   gem "letter_opener_web"
+  # parallel test
+  gem "parallel_tests"
   # useful repl pry
   gem "pry"
   gem "pry-byebug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -254,6 +254,8 @@ GEM
       racc (~> 1.4)
     orm_adapter (0.5.0)
     parallel (1.21.0)
+    parallel_tests (3.7.3)
+      parallel
     parser (3.0.2.0)
       ast (~> 2.4.1)
     pg (1.2.3)
@@ -451,6 +453,7 @@ DEPENDENCIES
   kaminari-i18n
   letter_opener_web
   meta-tags
+  parallel_tests
   pg
   pry
   pry-byebug

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ User.create!(
 - DB の作成
   - `bundle exec rails db:create`
   - `bundle exec rails db:migrate`
+  - `bundle exec rake parallel:setup`、並列テストを使う場合
 - 管理者ユーザの作成
   - `bundle exec rails db:seed`
 - サーバの起動
@@ -146,6 +147,8 @@ Creating sakazuki_es_1 ... done
 Creating sakazuki_web_run ... done
 Created database 'sakazuki_development'
 Created database 'sakazuki_test'
+$ docker-compose run --rm web bundle exec rake parallel:setup
+...
 $ docker-compose run --rm web bundle exec rails db:migrate
 Creating sakazuki_web_run ... done
 ...

--- a/config/database.yml
+++ b/config/database.yml
@@ -58,7 +58,7 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: sakazuki_test
+  database: sakazuki_test<%= ENV["TEST_ENV_NUMBER"] %>
   username: <%= ENV["POSTGRES_USERNAME"] %>
   password: <%= ENV["POSTGRES_PASSWORD"] %>
 


### PR DESCRIPTION
fix #391

なんでもいいから`bundle exec parallel_rspec`だ！

手元では 55s → 35s くらい、6割くらいに削減できそう。

## 使い方

- 初回のみテストDBを複数個にするため`rake parallel:setup`をする
- `rspec`の代わりに`bundle exec parallel_rspec`を使う

## 止め方

- `rake parallel:drop`でコピーされたDBを削除できる
- `bundle exec rails db:create`でテストDBを1個だけ復元する

## やったこと

- parallel_tests gemを追加
- parallel_rspec向けに設定を更新
- README.mdを更新

## やらなかったこと

- Github ActionsでのRSpecは並列化しなかった
  - トラブルがあったときわかりくくなりそうな気がする。ピュアなテストにしておく。
