### PR TITLE
Fix #399

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,6 +1,6 @@
 name: Check
 
-on: [push, pull_request]
+on: push
 
 jobs:
   check:


### PR DESCRIPTION
Closes #399 

`push` だけにしました。

`push` だと`master` ブランチにマージされたときにも実行されます。
メリットとして、複数のPRをマージしたときのセマンティックコンフリクトを検出できます