### PR TITLE
BY不明の酒を編集してもちゃんとBY不明のままにした

### DIFF
--- a/app/controllers/sakes_controller.rb
+++ b/app/controllers/sakes_controller.rb
@@ -38,6 +38,7 @@ class SakesController < ApplicationController
   def new
     @sake = Sake.new
     @sake.size = 720
+    @sake.brew_year = to_by(Time.current)
   end
 
   # GET /sakes/1/edit

--- a/app/helpers/sakes_helper.rb
+++ b/app/helpers/sakes_helper.rb
@@ -25,7 +25,7 @@ module SakesHelper
   # @param id [String] HTMLのid
   # @param name [String] HTMLのname
   # @param begin_year [Integer] 開始年
-  # @param selected_year [Integer] 初期選択年
+  # @param selected_year [Integer, nil] 初期選択年
   # @param include_blank [Boolean] trueなら選択肢に空が含まれる
   # @param args [Object] select_tagにそのまま渡されるoptions
   # @return [String] 年のHTMLセレクタ
@@ -34,7 +34,7 @@ module SakesHelper
       [with_japanese_era(Date.new(year)), year]
     }
     options += [[t("sakes.new.unknown"), nil]] if include_blank
-    select_tag(id, options_for_select(options, selected: selected_year), class: "form-select", name: name, **args)
+    select_tag(id, options_for_select(options, selected: selected_year || ""), class: "form-select", name: name, **args)
   end
 
   # どの瓶状態（bottle_level）にもマッチしない値

--- a/app/helpers/sakes_helper.rb
+++ b/app/helpers/sakes_helper.rb
@@ -21,18 +21,27 @@ module SakesHelper
     Date.new(by_year, 7)
   end
 
-  # 和暦付きの年のHTMLセレクタを生成する
-  # @param latest_year [Integer] 選択肢の最新年
-  # @param selected [Integer, nil] 初期選択年
-  # @param include_nil [String, nil] 選択肢nilを含めるかどうか、Stringならnil選択肢を含みStringを表示テキストとして使う
-  # @param args [Object] tag.selectにそのまま渡されるoptions
-  # @return [String] 年のHTMLセレクタ
-  def select_year_with_japanese_era(latest_year:, selected: latest_year, include_nil: nil, **args)
-    years = year_range(latest_year)
-    opts = years.index_by { |year| with_japanese_era(Date.new(year)) }
-    opts[include_nil] = nil if include_nil
-    options = options_for_select(opts, selected: selected || "") # HACK: ""で空値の不明を選択する
-    tag.select(options, **args)
+  # 過去何年を酒情報に入力可能にするかの値
+  # @return [Integer] 年数
+  def start_year_limit
+    30
+  end
+
+  # 現在日時から入力可能なBY年のレンジを作成する
+  # @return [Range<Date>] BYレンジ
+  def by_range
+    this_by_year = to_by(Time.current).year
+    years = (this_by_year - start_year_limit)..this_by_year
+    years.map { |year| Date.new(year, 7, 1) }
+  end
+
+  # 日付を和暦付き文字列に変換する
+  #
+  # 7/1の月日を持つBYのDateオブジェクトを渡しても、正しく和暦をつけることができる。
+  # @param date [Date] 日付
+  # @return [String] "2021 / 令和3年"のような文字列
+  def with_japanese_era(date)
+    "#{date.year} / #{date.to_era('%O%-E年')}"
   end
 
   # どの瓶状態（bottle_level）にもマッチしない値
@@ -120,25 +129,6 @@ module SakesHelper
   end
 
   private
-
-  # 日付を和暦付き文字列に変換する
-  # @param date [Date] 日付
-  # @return [String] "2021 / 令和3年"のような文字列
-  def with_japanese_era(date)
-    "#{date.year} / #{date.to_era('%O%-E年')}"
-  end
-
-  # 過去何年を酒情報に入力可能にするかの値
-  # @type [Integer]
-  START_YEAR_LIMIT = 30
-  private_constant :START_YEAR_LIMIT
-
-  # 酒情報に入力可能な年範囲を作成する
-  # @param begin_year [Integer] 開始年
-  # @return [Range<Integer>] 年範囲
-  def year_range(begin_year)
-    (begin_year - START_YEAR_LIMIT)..begin_year
-  end
 
   private_constant :UNITS
 end

--- a/app/helpers/sakes_helper.rb
+++ b/app/helpers/sakes_helper.rb
@@ -22,19 +22,17 @@ module SakesHelper
   end
 
   # 和暦付きの年のHTMLセレクタを生成する
-  # @param id [String] HTMLのid
-  # @param name [String] HTMLのname
   # @param latest_year [Integer] 選択肢の最新年
   # @param selected [Integer, nil] 初期選択年
   # @param include_blank [Boolean] trueなら選択肢に空が含まれる
-  # @param args [Object] select_tagにそのまま渡されるoptions
+  # @param args [Object] tag.selectにそのまま渡されるoptions
   # @return [String] 年のHTMLセレクタ
-  def year_select_with_japanese_era(id:, name:, latest_year:, selected: latest_year, include_blank: false, **args)
+  def year_select_with_japanese_era(latest_year:, selected: latest_year, include_blank: false, **args)
     years = year_range(latest_year)
     options = years.map { |year| [with_japanese_era(Date.new(year)), year] }
     options += [[t("sakes.new.unknown"), nil]] if include_blank
     options = options_for_select(options, selected: selected || "") # HACK: ""で空値の不明を選択する
-    select_tag(id, options, class: "form-select", name: name, **args)
+    tag.select(options, **args)
   end
 
   # どの瓶状態（bottle_level）にもマッチしない値

--- a/app/helpers/sakes_helper.rb
+++ b/app/helpers/sakes_helper.rb
@@ -27,7 +27,7 @@ module SakesHelper
   # @param include_nil [String, nil] 選択肢nilを含めるかどうか、Stringならnil選択肢を含みStringを表示テキストとして使う
   # @param args [Object] tag.selectにそのまま渡されるoptions
   # @return [String] 年のHTMLセレクタ
-  def year_select_with_japanese_era(latest_year:, selected: latest_year, include_nil: nil, **args)
+  def select_year_with_japanese_era(latest_year:, selected: latest_year, include_nil: nil, **args)
     years = year_range(latest_year)
     options = years.map { |year| [with_japanese_era(Date.new(year)), year] }
     options += [[include_nil, nil]] if include_nil

--- a/app/helpers/sakes_helper.rb
+++ b/app/helpers/sakes_helper.rb
@@ -28,10 +28,10 @@ module SakesHelper
   end
 
   # 現在日時から入力可能なBY年のレンジを作成する
-  # @return [Range<Date>] BYレンジ
+  # @return [Range<Date>] 1年間隔で30年分のBYオブジェクトのレンジ
   def by_range
-    this_by_year = to_by(Time.current).year
-    years = (this_by_year - start_year_limit)..this_by_year
+    this_by = to_by(Time.current).year
+    years = (this_by - start_year_limit)..this_by
     years.map { |year| Date.new(year, 7, 1) }
   end
 

--- a/app/helpers/sakes_helper.rb
+++ b/app/helpers/sakes_helper.rb
@@ -24,13 +24,13 @@ module SakesHelper
   # 和暦付きの年のHTMLセレクタを生成する
   # @param latest_year [Integer] 選択肢の最新年
   # @param selected [Integer, nil] 初期選択年
-  # @param include_blank [Boolean] trueなら選択肢に空が含まれる
+  # @param include_nil [String, nil] 選択肢nilを含めるかどうか、Stringならnil選択肢を含みStringを表示テキストとして使う
   # @param args [Object] tag.selectにそのまま渡されるoptions
   # @return [String] 年のHTMLセレクタ
-  def year_select_with_japanese_era(latest_year:, selected: latest_year, include_blank: false, **args)
+  def year_select_with_japanese_era(latest_year:, selected: latest_year, include_nil: nil, **args)
     years = year_range(latest_year)
     options = years.map { |year| [with_japanese_era(Date.new(year)), year] }
-    options += [[t("sakes.new.unknown"), nil]] if include_blank
+    options += [[include_nil, nil]] if include_nil
     options = options_for_select(options, selected: selected || "") # HACK: ""で空値の不明を選択する
     tag.select(options, **args)
   end

--- a/app/helpers/sakes_helper.rb
+++ b/app/helpers/sakes_helper.rb
@@ -29,9 +29,9 @@ module SakesHelper
   # @return [String] 年のHTMLセレクタ
   def select_year_with_japanese_era(latest_year:, selected: latest_year, include_nil: nil, **args)
     years = year_range(latest_year)
-    options = years.map { |year| [with_japanese_era(Date.new(year)), year] }
-    options += [[include_nil, nil]] if include_nil
-    options = options_for_select(options, selected: selected || "") # HACK: ""で空値の不明を選択する
+    opts = years.index_by { |year| with_japanese_era(Date.new(year)) }
+    opts[include_nil] = nil if include_nil
+    options = options_for_select(opts, selected: selected || "") # HACK: ""で空値の不明を選択する
     tag.select(options, **args)
   end
 

--- a/app/helpers/sakes_helper.rb
+++ b/app/helpers/sakes_helper.rb
@@ -54,6 +54,7 @@ module SakesHelper
 
   # @type [Array<String>]
   UNITS = %w[合 升 斗 石].freeze
+  private_constant :UNITS
 
   # 酒の量[ml]を尺貫法の体積にした文字列で返す
   #
@@ -127,8 +128,4 @@ module SakesHelper
   def either_highlight_or_lowlight(value)
     value.blank? || value == "unknown" ? "lowlight-value" : "highlight-value"
   end
-
-  private
-
-  private_constant :UNITS
 end

--- a/app/helpers/sakes_helper.rb
+++ b/app/helpers/sakes_helper.rb
@@ -123,12 +123,6 @@ module SakesHelper
 
   private
 
-  # 過去何年を酒情報に入力可能にするかの値
-  # @return [Integer] 年数
-  def start_year_limit
-    30
-  end
-
   # 日付を和暦付き文字列に変換する
   # @param date [Date] 日付
   # @return [String] "2021 / 令和3年"のような文字列
@@ -136,11 +130,16 @@ module SakesHelper
     "#{date.year} / #{date.to_era('%O%-E年')}"
   end
 
+  # 過去何年を酒情報に入力可能にするかの値
+  # @type [Integer]
+  START_YEAR_LIMIT = 30
+  private_constant :START_YEAR_LIMIT
+
   # 酒情報に入力可能な年範囲を作成する
   # @param begin_year [Integer] 開始年
   # @return [Range<Integer>] 年範囲
   def year_range(begin_year)
-    (begin_year - start_year_limit)..begin_year
+    (begin_year - START_YEAR_LIMIT)..begin_year
   end
 
   private_constant :UNITS

--- a/app/helpers/sakes_helper.rb
+++ b/app/helpers/sakes_helper.rb
@@ -29,7 +29,7 @@ module SakesHelper
   # @param include_blank [Boolean] trueなら選択肢に空が含まれる
   # @param args [Object] select_tagにそのまま渡されるoptions
   # @return [String] 年のHTMLセレクタ
-  def year_select_with_japanese_era(id, name, begin_year, selected_year: begin_year, include_blank: false, **args)
+  def year_select_with_japanese_era(id:, name:, begin_year:, selected_year: begin_year, include_blank: false, **args)
     options = year_range(begin_year).map { |year|
       [with_japanese_era(Date.new(year)), year]
     }

--- a/app/helpers/sakes_helper.rb
+++ b/app/helpers/sakes_helper.rb
@@ -24,17 +24,17 @@ module SakesHelper
   # 和暦付きの年のHTMLセレクタを生成する
   # @param id [String] HTMLのid
   # @param name [String] HTMLのname
-  # @param begin_year [Integer] 開始年
-  # @param selected_year [Integer, nil] 初期選択年
+  # @param latest_year [Integer] 選択肢の最新年
+  # @param selected [Integer, nil] 初期選択年
   # @param include_blank [Boolean] trueなら選択肢に空が含まれる
   # @param args [Object] select_tagにそのまま渡されるoptions
   # @return [String] 年のHTMLセレクタ
-  def year_select_with_japanese_era(id:, name:, begin_year:, selected_year: begin_year, include_blank: false, **args)
-    options = year_range(begin_year).map { |year|
+  def year_select_with_japanese_era(id:, name:, latest_year:, selected: latest_year, include_blank: false, **args)
+    options = year_range(latest_year).map { |year|
       [with_japanese_era(Date.new(year)), year]
     }
     options += [[t("sakes.new.unknown"), nil]] if include_blank
-    select_tag(id, options_for_select(options, selected: selected_year || ""), class: "form-select", name: name, **args)
+    select_tag(id, options_for_select(options, selected: selected || ""), class: "form-select", name: name, **args)
   end
 
   # どの瓶状態（bottle_level）にもマッチしない値

--- a/app/helpers/sakes_helper.rb
+++ b/app/helpers/sakes_helper.rb
@@ -27,13 +27,14 @@ module SakesHelper
   # @param begin_year [Integer] 開始年
   # @param selected_year [Integer] 初期選択年
   # @param include_blank [Boolean] trueなら選択肢に空が含まれる
+  # @param args [Object] select_tagにそのまま渡されるoptions
   # @return [String] 年のHTMLセレクタ
-  def year_select_with_japanese_era(id, name, begin_year, selected_year: begin_year, include_blank: false)
+  def year_select_with_japanese_era(id, name, begin_year, selected_year: begin_year, include_blank: false, **args)
     options = year_range(begin_year).map { |year|
       [with_japanese_era(Date.new(year)), year]
     }
     options += [[t("sakes.new.unknown"), nil]] if include_blank
-    select_tag(id, options_for_select(options, selected: selected_year), { class: "form-select", name: name })
+    select_tag(id, options_for_select(options, selected: selected_year), class: "form-select", name: name, **args)
   end
 
   # どの瓶状態（bottle_level）にもマッチしない値

--- a/app/helpers/sakes_helper.rb
+++ b/app/helpers/sakes_helper.rb
@@ -30,11 +30,11 @@ module SakesHelper
   # @param args [Object] select_tagにそのまま渡されるoptions
   # @return [String] 年のHTMLセレクタ
   def year_select_with_japanese_era(id:, name:, latest_year:, selected: latest_year, include_blank: false, **args)
-    options = year_range(latest_year).map { |year|
-      [with_japanese_era(Date.new(year)), year]
-    }
+    years = year_range(latest_year)
+    options = years.map { |year| [with_japanese_era(Date.new(year)), year] }
     options += [[t("sakes.new.unknown"), nil]] if include_blank
-    select_tag(id, options_for_select(options, selected: selected || ""), class: "form-select", name: name, **args)
+    options = options_for_select(options, selected: selected || "") # HACK: ""で空値の不明を選択する
+    select_tag(id, options, class: "form-select", name: name, **args)
   end
 
   # どの瓶状態（bottle_level）にもマッチしない値

--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -139,7 +139,7 @@
               <% current_by = to_by(Date.current).year %>
               <%= year_select_with_japanese_era(latest_year: current_by,
                                                 selected: @sake.brew_year&.year,
-                                                include_blank: true,
+                                                include_nil: t(".unknown"),
                                                 id: "sake_brew_year_1i",
                                                 name: "sake[brew_year(1i)]",
                                                 class: "form-select",

--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -118,9 +118,9 @@
             <%#       Railsデフォルトでは年月が縦並びになってしまう。%>
             <%#       そのため、2つフォームを設置してTSで同期する。 %>
             <div class="two-column-form">
-              <%= year_select_with_japanese_era(id = "bindume_year",
-                                                name = "sake[bindume_date(1i)]",
-                                                begin_year = Date.current.year,
+              <%= year_select_with_japanese_era(id: "bindume_year",
+                                                name: "sake[bindume_date(1i)]",
+                                                begin_year: Date.current.year,
                                                 selected_year: @sake.bindume_date&.year || Date.current.year,
                                                 data: { testid: "select_bindume_year" }) %>
             </div>
@@ -136,9 +136,9 @@
             <%= form.label(:brew_year, { class: "form-label" }) %>
             <div class="two-column-form">
               <% current_by = to_by(Date.current).year %>
-              <%= year_select_with_japanese_era(id = "sake_brew_year_1i",
-                                                name = "sake[brew_year(1i)]",
-                                                begin_year = current_by,
+              <%= year_select_with_japanese_era(id: "sake_brew_year_1i",
+                                                name: "sake[brew_year(1i)]",
+                                                begin_year: current_by,
                                                 selected_year: @sake.brew_year&.year,
                                                 include_blank: true,
                                                 data: { testid: "select_by" }) %>

--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -120,8 +120,8 @@
             <div class="two-column-form">
               <%= year_select_with_japanese_era(id: "bindume_year",
                                                 name: "sake[bindume_date(1i)]",
-                                                begin_year: Date.current.year,
-                                                selected_year: @sake.bindume_date&.year || Date.current.year,
+                                                latest_year: Date.current.year,
+                                                selected: @sake.bindume_date&.year || Date.current.year,
                                                 data: { testid: "select_bindume_year" }) %>
             </div>
             <div class="two-column-form">
@@ -138,8 +138,8 @@
               <% current_by = to_by(Date.current).year %>
               <%= year_select_with_japanese_era(id: "sake_brew_year_1i",
                                                 name: "sake[brew_year(1i)]",
-                                                begin_year: current_by,
-                                                selected_year: @sake.brew_year&.year,
+                                                latest_year: current_by,
+                                                selected: @sake.brew_year&.year,
                                                 include_blank: true,
                                                 data: { testid: "select_by" }) %>
               <%# 使わない月日はBY始まりの7/1とする. See to_by %>

--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -121,12 +121,14 @@
               <%= year_select_with_japanese_era(id = "bindume_year",
                                                 name = "sake[bindume_date(1i)]",
                                                 begin_year = Date.current.year,
-                                                selected_year: @sake.bindume_date&.year || Date.current.year) %>
+                                                selected_year: @sake.bindume_date&.year || Date.current.year,
+                                                data: { testid: "select_bindume_year" }) %>
             </div>
             <div class="two-column-form">
               <%= form.date_select(:bindume_date,
                                    { discard_day: true, discard_year: true },
-                                   { class: "form-select", id: "bindume_month" }) %>
+                                   class: "form-select",
+                                   data: { testid: "select_bindume_month" }) %>
             </div>
           </div>
 
@@ -138,7 +140,8 @@
                                                 name = "sake[brew_year(1i)]",
                                                 begin_year = current_by,
                                                 selected_year: @sake.brew_year&.year || current_by,
-                                                include_blank: true) %>
+                                                include_blank: true,
+                                                data: { testid: "select_by" }) %>
               <%# 使わない月日はBY始まりの7/1とする. See to_by %>
               <input type="hidden" id="sake_<%= :brew_year %>_2i" name="sake[<%= :brew_year %>(2i)]" value="7">
               <input type="hidden" id="sake_<%= :brew_year %>_3i" name="sake[<%= :brew_year %>(3i)]" value="1">

--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -118,7 +118,7 @@
             <%#       Railsデフォルトでは年月が縦並びになってしまう。%>
             <%#       そのため、2つフォームを設置してTSで同期する。 %>
             <div class="two-column-form">
-              <%= year_select_with_japanese_era(latest_year: Date.current.year,
+              <%= select_year_with_japanese_era(latest_year: Date.current.year,
                                                 selected: @sake.bindume_date&.year || Date.current.year,
                                                 id: "bindume_year",
                                                 name: "sake[bindume_date(1i)]",
@@ -137,7 +137,7 @@
             <%= form.label(:brew_year, { class: "form-label" }) %>
             <div class="two-column-form">
               <% current_by = to_by(Date.current).year %>
-              <%= year_select_with_japanese_era(latest_year: current_by,
+              <%= select_year_with_japanese_era(latest_year: current_by,
                                                 selected: @sake.brew_year&.year,
                                                 include_nil: t(".unknown"),
                                                 id: "sake_brew_year_1i",

--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -136,8 +136,7 @@
           <div class="form-row">
             <%= form.label(:brew_year, { class: "form-label" }) %>
             <div class="two-column-form">
-              <% current_by = to_by(Date.current).year %>
-              <%= select_year_with_japanese_era(latest_year: current_by,
+              <%= select_year_with_japanese_era(latest_year: to_by(Time.current).year,
                                                 selected: @sake.brew_year&.year,
                                                 include_nil: t(".unknown"),
                                                 id: "sake_brew_year_1i",

--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -118,12 +118,14 @@
             <%#       Railsデフォルトでは年月が縦並びになってしまう。%>
             <%#       そのため、2つフォームを設置してTSで同期する。 %>
             <div class="two-column-form">
-              <%= select_year_with_japanese_era(latest_year: Date.current.year,
-                                                selected: @sake.bindume_date&.year || Date.current.year,
-                                                id: "bindume_year",
-                                                name: "sake[bindume_date(1i)]",
-                                                class: "form-select",
-                                                data: { testid: "select_bindume_year" }) %>
+              <%= form.date_select("dummy_bindume",
+                                   { discard_month: true,
+                                     start_year: Time.current.year - start_year_limit,
+                                     end_year: Time.current.year,
+                                     year_format: ->(year) { with_japanese_era(Date.new(year, 1, 1)) }, },
+                                   id: "bindume_year",
+                                   class: "form-select",
+                                   data: { testid: "select_bindume_year" }) %>
             </div>
             <div class="two-column-form">
               <%= form.date_select(:bindume_date,
@@ -136,14 +138,20 @@
           <div class="form-row">
             <%= form.label(:brew_year, { class: "form-label" }) %>
             <div class="two-column-form">
-              <%= select_year_with_japanese_era(latest_year: to_by(Time.current).year,
-                                                selected: @sake.brew_year&.year,
-                                                include_nil: t(".unknown"),
-                                                id: "sake_brew_year_1i",
-                                                name: "sake[brew_year(1i)]",
-                                                class: "form-select",
-                                                data: { testid: "select_by" }) %>
-              <%# 使わない月日はBY始まりの7/1とする. See to_by %>
+              <%# HACK: 不明を最後に表示するため、form.date_selectを使わない %>
+              <%= form.select(:brew_year,
+                              nil,
+                              {},
+                              id: "sake_brew_year_1i",
+                              name: "sake[brew_year(1i)]",
+                              class: "form-select",
+                              data: { testid: "select_by" }) do %>
+                <% by_range.each do |by| %>
+                  <%= tag.option(with_japanese_era(by), value: by.year, selected: by.year == @sake.brew_year&.year) %>
+                <% end %>
+                <%= tag.option(t(".unknown"), value: "", selected: @sake.brew_year.nil?) %>
+              <% end %>
+              <%# 使わない月日はBY始まりの7/1とする. SEE: SakesHelper.to_by %>
               <input type="hidden" id="sake_<%= :brew_year %>_2i" name="sake[<%= :brew_year %>(2i)]" value="7">
               <input type="hidden" id="sake_<%= :brew_year %>_3i" name="sake[<%= :brew_year %>(3i)]" value="1">
             </div>

--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -118,10 +118,11 @@
             <%#       Railsデフォルトでは年月が縦並びになってしまう。%>
             <%#       そのため、2つフォームを設置してTSで同期する。 %>
             <div class="two-column-form">
-              <%= year_select_with_japanese_era(id: "bindume_year",
-                                                name: "sake[bindume_date(1i)]",
-                                                latest_year: Date.current.year,
+              <%= year_select_with_japanese_era(latest_year: Date.current.year,
                                                 selected: @sake.bindume_date&.year || Date.current.year,
+                                                id: "bindume_year",
+                                                name: "sake[bindume_date(1i)]",
+                                                class: "form-select",
                                                 data: { testid: "select_bindume_year" }) %>
             </div>
             <div class="two-column-form">
@@ -136,11 +137,12 @@
             <%= form.label(:brew_year, { class: "form-label" }) %>
             <div class="two-column-form">
               <% current_by = to_by(Date.current).year %>
-              <%= year_select_with_japanese_era(id: "sake_brew_year_1i",
-                                                name: "sake[brew_year(1i)]",
-                                                latest_year: current_by,
+              <%= year_select_with_japanese_era(latest_year: current_by,
                                                 selected: @sake.brew_year&.year,
                                                 include_blank: true,
+                                                id: "sake_brew_year_1i",
+                                                name: "sake[brew_year(1i)]",
+                                                class: "form-select",
                                                 data: { testid: "select_by" }) %>
               <%# 使わない月日はBY始まりの7/1とする. See to_by %>
               <input type="hidden" id="sake_<%= :brew_year %>_2i" name="sake[<%= :brew_year %>(2i)]" value="7">

--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -139,7 +139,7 @@
               <%= year_select_with_japanese_era(id = "sake_brew_year_1i",
                                                 name = "sake[brew_year(1i)]",
                                                 begin_year = current_by,
-                                                selected_year: @sake.brew_year&.year || current_by,
+                                                selected_year: @sake.brew_year&.year,
                                                 include_blank: true,
                                                 data: { testid: "select_by" }) %>
               <%# 使わない月日はBY始まりの7/1とする. See to_by %>

--- a/config/locales/views/sake.ja.yml
+++ b/config/locales/views/sake.ja.yml
@@ -32,10 +32,10 @@ ja:
       confirm_empty: 飲みきった？
     new:
       title: 新規登録
-      unknown: 不明
     edit:
       title: 編集
     form:
+      unknown: 不明
       select_delete_photo: 削除する画像を選択してください
       labelinfo: ラベル
       labelinfo_option: オプショナル

--- a/spec/helpers/sakes_helper_spec.rb
+++ b/spec/helpers/sakes_helper_spec.rb
@@ -78,6 +78,18 @@ RSpec.describe SakesHelper do
     end
   end
 
+  describe "select_year_with_japanese_era" do
+    # rubocop:disable Layout/LineLength
+    it "returns select tag" do
+      expect(select_year_with_japanese_era(latest_year: 2022)).to eq("<select><option value=\"1992\">1992 / 平成4年</option>\n<option value=\"1993\">1993 / 平成5年</option>\n<option value=\"1994\">1994 / 平成6年</option>\n<option value=\"1995\">1995 / 平成7年</option>\n<option value=\"1996\">1996 / 平成8年</option>\n<option value=\"1997\">1997 / 平成9年</option>\n<option value=\"1998\">1998 / 平成10年</option>\n<option value=\"1999\">1999 / 平成11年</option>\n<option value=\"2000\">2000 / 平成12年</option>\n<option value=\"2001\">2001 / 平成13年</option>\n<option value=\"2002\">2002 / 平成14年</option>\n<option value=\"2003\">2003 / 平成15年</option>\n<option value=\"2004\">2004 / 平成16年</option>\n<option value=\"2005\">2005 / 平成17年</option>\n<option value=\"2006\">2006 / 平成18年</option>\n<option value=\"2007\">2007 / 平成19年</option>\n<option value=\"2008\">2008 / 平成20年</option>\n<option value=\"2009\">2009 / 平成21年</option>\n<option value=\"2010\">2010 / 平成22年</option>\n<option value=\"2011\">2011 / 平成23年</option>\n<option value=\"2012\">2012 / 平成24年</option>\n<option value=\"2013\">2013 / 平成25年</option>\n<option value=\"2014\">2014 / 平成26年</option>\n<option value=\"2015\">2015 / 平成27年</option>\n<option value=\"2016\">2016 / 平成28年</option>\n<option value=\"2017\">2017 / 平成29年</option>\n<option value=\"2018\">2018 / 平成30年</option>\n<option value=\"2019\">2019 / 平成31年</option>\n<option value=\"2020\">2020 / 令和2年</option>\n<option value=\"2021\">2021 / 令和3年</option>\n<option selected=\"selected\" value=\"2022\">2022 / 令和4年</option></select>")
+    end
+
+    it "returns select tag with nil selection" do
+      expect(select_year_with_japanese_era(latest_year: 2022, selected: nil, include_nil: "不明")).to eq("<select><option value=\"1992\">1992 / 平成4年</option>\n<option value=\"1993\">1993 / 平成5年</option>\n<option value=\"1994\">1994 / 平成6年</option>\n<option value=\"1995\">1995 / 平成7年</option>\n<option value=\"1996\">1996 / 平成8年</option>\n<option value=\"1997\">1997 / 平成9年</option>\n<option value=\"1998\">1998 / 平成10年</option>\n<option value=\"1999\">1999 / 平成11年</option>\n<option value=\"2000\">2000 / 平成12年</option>\n<option value=\"2001\">2001 / 平成13年</option>\n<option value=\"2002\">2002 / 平成14年</option>\n<option value=\"2003\">2003 / 平成15年</option>\n<option value=\"2004\">2004 / 平成16年</option>\n<option value=\"2005\">2005 / 平成17年</option>\n<option value=\"2006\">2006 / 平成18年</option>\n<option value=\"2007\">2007 / 平成19年</option>\n<option value=\"2008\">2008 / 平成20年</option>\n<option value=\"2009\">2009 / 平成21年</option>\n<option value=\"2010\">2010 / 平成22年</option>\n<option value=\"2011\">2011 / 平成23年</option>\n<option value=\"2012\">2012 / 平成24年</option>\n<option value=\"2013\">2013 / 平成25年</option>\n<option value=\"2014\">2014 / 平成26年</option>\n<option value=\"2015\">2015 / 平成27年</option>\n<option value=\"2016\">2016 / 平成28年</option>\n<option value=\"2017\">2017 / 平成29年</option>\n<option value=\"2018\">2018 / 平成30年</option>\n<option value=\"2019\">2019 / 平成31年</option>\n<option value=\"2020\">2020 / 令和2年</option>\n<option value=\"2021\">2021 / 令和3年</option>\n<option value=\"2022\">2022 / 令和4年</option>\n<option selected=\"selected\" value=\"\">不明</option></select>")
+    end
+    # rubocop:enable Layout/LineLength
+  end
+
   describe "bottom_bottle" do
     it "must always return -1" do
       expect(bottom_bottle).to eq(-1)

--- a/spec/helpers/sakes_helper_spec.rb
+++ b/spec/helpers/sakes_helper_spec.rb
@@ -32,24 +32,6 @@ RSpec.describe SakesHelper do
     end
   end
 
-  describe "year_range" do
-    it "generates a range ending with 2021" do
-      expect(year_range(2021).last).to eq(2021)
-    end
-
-    it "generates a range starting with 1991, (2021 - 30)" do
-      expect(year_range(2021).first).to eq(1991)
-    end
-
-    it "generates a range ending with 2030" do
-      expect(year_range(2030).last).to eq(2030)
-    end
-
-    it "generates a range starting with 2000, (2030 - 30)" do
-      expect(year_range(2030).first).to eq(2000)
-    end
-  end
-
   describe "to_by" do
     let(:date) { Date.current }
 
@@ -78,16 +60,36 @@ RSpec.describe SakesHelper do
     end
   end
 
-  describe "select_year_with_japanese_era" do
-    # rubocop:disable Layout/LineLength
-    it "returns select tag" do
-      expect(select_year_with_japanese_era(latest_year: 2022)).to eq("<select><option value=\"1992\">1992 / 平成4年</option>\n<option value=\"1993\">1993 / 平成5年</option>\n<option value=\"1994\">1994 / 平成6年</option>\n<option value=\"1995\">1995 / 平成7年</option>\n<option value=\"1996\">1996 / 平成8年</option>\n<option value=\"1997\">1997 / 平成9年</option>\n<option value=\"1998\">1998 / 平成10年</option>\n<option value=\"1999\">1999 / 平成11年</option>\n<option value=\"2000\">2000 / 平成12年</option>\n<option value=\"2001\">2001 / 平成13年</option>\n<option value=\"2002\">2002 / 平成14年</option>\n<option value=\"2003\">2003 / 平成15年</option>\n<option value=\"2004\">2004 / 平成16年</option>\n<option value=\"2005\">2005 / 平成17年</option>\n<option value=\"2006\">2006 / 平成18年</option>\n<option value=\"2007\">2007 / 平成19年</option>\n<option value=\"2008\">2008 / 平成20年</option>\n<option value=\"2009\">2009 / 平成21年</option>\n<option value=\"2010\">2010 / 平成22年</option>\n<option value=\"2011\">2011 / 平成23年</option>\n<option value=\"2012\">2012 / 平成24年</option>\n<option value=\"2013\">2013 / 平成25年</option>\n<option value=\"2014\">2014 / 平成26年</option>\n<option value=\"2015\">2015 / 平成27年</option>\n<option value=\"2016\">2016 / 平成28年</option>\n<option value=\"2017\">2017 / 平成29年</option>\n<option value=\"2018\">2018 / 平成30年</option>\n<option value=\"2019\">2019 / 平成31年</option>\n<option value=\"2020\">2020 / 令和2年</option>\n<option value=\"2021\">2021 / 令和3年</option>\n<option selected=\"selected\" value=\"2022\">2022 / 令和4年</option></select>")
+  describe "by_range" do
+    it "generates a range ending with current" do
+      expect(by_range.last).to eq(to_by(Time.current))
     end
 
-    it "returns select tag with nil selection" do
-      expect(select_year_with_japanese_era(latest_year: 2022, selected: nil, include_nil: "不明")).to eq("<select><option value=\"1992\">1992 / 平成4年</option>\n<option value=\"1993\">1993 / 平成5年</option>\n<option value=\"1994\">1994 / 平成6年</option>\n<option value=\"1995\">1995 / 平成7年</option>\n<option value=\"1996\">1996 / 平成8年</option>\n<option value=\"1997\">1997 / 平成9年</option>\n<option value=\"1998\">1998 / 平成10年</option>\n<option value=\"1999\">1999 / 平成11年</option>\n<option value=\"2000\">2000 / 平成12年</option>\n<option value=\"2001\">2001 / 平成13年</option>\n<option value=\"2002\">2002 / 平成14年</option>\n<option value=\"2003\">2003 / 平成15年</option>\n<option value=\"2004\">2004 / 平成16年</option>\n<option value=\"2005\">2005 / 平成17年</option>\n<option value=\"2006\">2006 / 平成18年</option>\n<option value=\"2007\">2007 / 平成19年</option>\n<option value=\"2008\">2008 / 平成20年</option>\n<option value=\"2009\">2009 / 平成21年</option>\n<option value=\"2010\">2010 / 平成22年</option>\n<option value=\"2011\">2011 / 平成23年</option>\n<option value=\"2012\">2012 / 平成24年</option>\n<option value=\"2013\">2013 / 平成25年</option>\n<option value=\"2014\">2014 / 平成26年</option>\n<option value=\"2015\">2015 / 平成27年</option>\n<option value=\"2016\">2016 / 平成28年</option>\n<option value=\"2017\">2017 / 平成29年</option>\n<option value=\"2018\">2018 / 平成30年</option>\n<option value=\"2019\">2019 / 平成31年</option>\n<option value=\"2020\">2020 / 令和2年</option>\n<option value=\"2021\">2021 / 令和3年</option>\n<option value=\"2022\">2022 / 令和4年</option>\n<option selected=\"selected\" value=\"\">不明</option></select>")
+    it "generates a range starting with 30 years ago" do
+      expect(by_range.first).to eq(to_by(Time.current) - 30.years)
     end
-    # rubocop:enable Layout/LineLength
+  end
+
+  describe "with_japanese_era" do
+    context "for normal year" do
+      it "returns formated year including 令和" do
+        expect(with_japanese_era(Date.new(2019, 5, 1))).to eq("2019 / 令和1年")
+      end
+
+      it "returns formated year including 平成" do
+        expect(with_japanese_era(Date.new(2019, 4, 30))).to eq("2019 / 平成31年")
+      end
+    end
+
+    context "for brew year" do
+      it "returns formated year including 令和" do
+        expect(with_japanese_era(to_by(Date.new(2019, 7, 1)))).to eq("2019 / 令和1年")
+      end
+
+      it "returns formated year including 平成" do
+        expect(with_japanese_era(to_by(Date.new(2019, 6, 30)))).to eq("2018 / 平成30年")
+      end
+    end
   end
 
   describe "bottom_bottle" do

--- a/spec/helpers/sakes_helper_spec.rb
+++ b/spec/helpers/sakes_helper_spec.rb
@@ -80,16 +80,6 @@ RSpec.describe SakesHelper do
         expect(with_japanese_era(Date.new(2019, 4, 30))).to eq("2019 / 平成31年")
       end
     end
-
-    context "for brew year" do
-      it "returns formated year including 令和" do
-        expect(with_japanese_era(to_by(Date.new(2019, 7, 1)))).to eq("2019 / 令和1年")
-      end
-
-      it "returns formated year including 平成" do
-        expect(with_japanese_era(to_by(Date.new(2019, 6, 30)))).to eq("2018 / 平成30年")
-      end
-    end
   end
 
   describe "bottom_bottle" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -66,4 +66,7 @@ RSpec.configure do |config|
   config.include(Devise::Test::IntegrationHelpers, type: :request)
   config.include(Devise::Test::IntegrationHelpers, type: :system)
   config.include(SignIn, type: :system)
+
+  # Contains helpers that help you test passage of time.
+  config.include(ActiveSupport::Testing::TimeHelpers)
 end

--- a/spec/system/sake_form_date_select_spec.rb
+++ b/spec/system/sake_form_date_select_spec.rb
@@ -1,0 +1,97 @@
+require "rails_helper"
+
+RSpec.describe "Sake Form Date Select", type: :system do
+  # HACK: sakes_helperのprivate methodであるwith_japanese_eraを使う
+  include SakesHelper
+
+  let(:user) { FactoryBot.create(:user) }
+
+  before do
+    sign_in(user)
+  end
+
+  context "when new sake" do
+    before do
+      visit new_sake_path
+    end
+
+    describe "selector of bindume date" do
+      it "selects this year" do
+        year = with_japanese_era(Time.current)
+        expect(page).to have_select("select_bindume_year", selected: year)
+      end
+
+      it "selects this month" do
+        month = I18n.l(Time.current, format: "%b")
+        expect(page).to have_select("select_bindume_month", selected: month)
+      end
+    end
+  end
+
+  context "when new sake before 7/1" do
+    describe "selector of BY" do
+      it "selects this BY" do
+        datetime = Time.zone.parse("2022-06-30 20:30:00")
+        travel_to(datetime)
+
+        visit new_sake_path
+        by = with_japanese_era(to_by(Time.current))
+        expect(page).to have_select("select_by", selected: by)
+      end
+    end
+  end
+
+  context "when new sake after 7/1" do
+    describe "selector of BY" do
+      it "selects this BY" do
+        datetime = Time.zone.parse("2022-07-1 10:30:00")
+        travel_to(datetime)
+
+        visit new_sake_path
+        by = with_japanese_era(to_by(Time.current))
+        expect(page).to have_select("select_by", selected: by)
+      end
+    end
+  end
+
+  context "when edit sake having bindume date and BY" do
+    let(:sake) { FactoryBot.create(:sake, bindume_date: Date.new(2022, 2, 1), brew_year: Date.new(2021, 7, 1)) }
+
+    before do
+      visit edit_sake_path(sake.id)
+    end
+
+    describe "selector of bindume date" do
+      it "selects the year of sake" do
+        year = with_japanese_era(sake.bindume_date)
+        expect(page).to have_select("select_bindume_year", selected: year)
+      end
+
+      it "selects the month of sake" do
+        month = I18n.l(sake.bindume_date, format: "%b")
+        expect(page).to have_select("select_bindume_month", selected: month)
+      end
+    end
+
+    describe "selector of BY" do
+      it "selects the BY of sake" do
+        by = with_japanese_era(sake.brew_year)
+        expect(page).to have_select("select_by", selected: by)
+      end
+    end
+  end
+
+  context "when edit sake not having BY" do
+    let(:sake) { FactoryBot.create(:sake, brew_year: nil) }
+
+    before do
+      visit edit_sake_path(sake.id)
+    end
+
+    describe "selector of BY" do
+      it "selects nil" do
+        expect(page).to have_select("select_by", selected: I18n.t("sakes.new.unknown"))
+      end
+    end
+  end
+end

--- a/spec/system/sake_form_date_select_spec.rb
+++ b/spec/system/sake_form_date_select_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "Sake Form Date Select", type: :system do
-  # HACK: sakes_helperのprivate methodであるwith_japanese_eraを使う
+  # SakesHelper.with_japanese_eraを使う
   include SakesHelper
 
   let(:user) { FactoryBot.create(:user) }

--- a/spec/system/sake_form_date_select_spec.rb
+++ b/spec/system/sake_form_date_select_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Sake Form Date Select", type: :system do
 
   context "when new sake before 7/1" do
     describe "selector of BY" do
-      it "selects this BY" do
+      it "selects this BY, not same with this year" do
         datetime = Time.zone.parse("2022-06-30 20:30:00")
         travel_to(datetime)
 
@@ -43,7 +43,7 @@ RSpec.describe "Sake Form Date Select", type: :system do
 
   context "when new sake after 7/1" do
     describe "selector of BY" do
-      it "selects this BY" do
+      it "selects this BY, same with this year" do
         datetime = Time.zone.parse("2022-07-1 10:30:00")
         travel_to(datetime)
 

--- a/spec/system/sake_form_date_select_spec.rb
+++ b/spec/system/sake_form_date_select_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe "Sake Form Date Select", type: :system do
 
     describe "selector of BY" do
       it "selects nil" do
-        expect(page).to have_select("select_by", selected: I18n.t("sakes.new.unknown"))
+        expect(page).to have_select("select_by", selected: I18n.t("sakes.form.unknown"))
       end
     end
   end


### PR DESCRIPTION
fix #403

見つからないPR 403

## やったこと

- 酒formの瓶詰め日、BYをRSpecで記述した
- BYを勝手に変えるバグを修正した
  - BYはnil値を許可するため、nilのとき新規酒なのかnil BYの酒なのか判定を間違えていた
- ~~日本元号つきselect関数を大幅にリファクタした~~
  - ~~これからは普通のformのようにclassやdata-testidを付加できるぞ！~~
- 自前select関数を使うのをやめ、Railsのselect/date_selectをなるべく使うようにした
