### PR TITLE
ハンバーガーメニューに表示するリンクのテスト

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -11,25 +11,25 @@
       </button>
       <div class="collapse navbar-collapse" id="navbarSupportedContent">
         <ul class="navbar-nav">
-          <li class="nav-item">
+          <li class="nav-item" data-testid="elasticsearch">
             <%= link_to("Elasticsearch", elasticsearch_path, class: "nav-link") %>
           </li>
           <span class="border-bottom border-secondary"></span>
           <% if user_signed_in? %>
-            <li class="nav-item">
+            <li class="nav-item" data-testid="user-edit">
               <%= link_to(current_user.email, edit_user_registration_path, class: "nav-link") %>
             </li>
             <% if current_user.admin %>
-              <li class="nav-item">
-                <%= link_to(t(".invitation"), new_user_invitation_path, class: "nav-link", "data-testid": "invitation-link") %>
+              <li class="nav-item" data-testid="invitation">
+                <%= link_to(t(".invitation"), new_user_invitation_path, class: "nav-link") %>
               </li>
             <% end %>
-            <li class="nav-item">
+            <li class="nav-item" data-testid="sign-out">
               <%= link_to(t(".sign_out"), destroy_user_session_path, method: :delete, class: "nav-link") %>
             </li>
           <% else %>
-            <li class="nav-item">
-              <%= link_to(t(".sign_in"), new_user_session_path, class: "nav-link", "data-testid": "sign-in") %>
+            <li class="nav-item" data-testid="sign-in">
+              <%= link_to(t(".sign_in"), new_user_session_path, class: "nav-link") %>
             </li>
           <% end %>
         </ul>

--- a/spec/support/sign_in.rb
+++ b/spec/support/sign_in.rb
@@ -2,7 +2,7 @@ module SignIn
   # ヘッダーのSign inボタンをクリックし、サインインする
   # @param user [Object] ファクトリーボットで作ったuserオブジェクト
   def sign_in_via_header_button(user)
-    click_link("sign-in")
+    click_link(I18n.t("layouts.header.sign_in"))
     signin_process_on_signin_page(user)
   end
 

--- a/spec/views/layouts/_header.html.erb_spec.rb
+++ b/spec/views/layouts/_header.html.erb_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 # Capybaraを使うためにsystem specを指定する
 RSpec.describe "layouts/_header", type: :system do
-  describe "header link" do
+  describe "header links" do
     context "with signed in admin user" do
       let(:user) { FactoryBot.create(:user, admin: true) }
 

--- a/spec/views/layouts/_header.html.erb_spec.rb
+++ b/spec/views/layouts/_header.html.erb_spec.rb
@@ -1,0 +1,90 @@
+require "rails_helper"
+
+# Capybaraを使うためにsystem specを指定する
+RSpec.describe "layouts/_header", type: :system do
+  describe "header link" do
+    context "with signed in admin user" do
+      let(:user) { FactoryBot.create(:user, admin: true) }
+
+      before do
+        sign_in(user)
+        visit root_path
+      end
+
+      it "does not have sign in link" do
+        expect { find(:test_id, "sign-in") }.to raise_error(Capybara::ElementNotFound)
+      end
+
+      it "has elasticsearch link" do
+        expect(find(:test_id, "elasticsearch")).to have_link("Elasticsearch", href: elasticsearch_path)
+      end
+
+      it "has user edit link" do
+        expect(find(:test_id, "user-edit")).to have_link(user.email, href: edit_user_registration_path)
+      end
+
+      it "has invitation link" do
+        expect(find(:test_id, "invitation")).to have_link(I18n.t("layouts.header.invitation"), href: new_user_invitation_path)
+      end
+
+      it "has sign out link" do
+        expect(find(:test_id, "sign-out")).to have_link(I18n.t("layouts.header.sign_out"), href: destroy_user_session_path)
+      end
+    end
+
+    context "with signed in non admin user" do
+      let(:user) { FactoryBot.create(:user, admin: false) }
+
+      before do
+        sign_in(user)
+        visit root_path
+      end
+
+      it "does not have sign in link" do
+        expect { find(:test_id, "sign-in") }.to raise_error(Capybara::ElementNotFound)
+      end
+
+      it "has elasticsearch link" do
+        expect(find(:test_id, "elasticsearch")).to have_link("Elasticsearch", href: elasticsearch_path)
+      end
+
+      it "has user edit link" do
+        expect(find(:test_id, "user-edit")).to have_link(user.email, href: edit_user_registration_path)
+      end
+
+      it "does not have invitation link" do
+        expect { find(:test_id, "invitation") }.to raise_error(Capybara::ElementNotFound)
+      end
+
+      it "has sign out link" do
+        expect(find(:test_id, "sign-out")).to have_link(I18n.t("layouts.header.sign_out"), href: destroy_user_session_path)
+      end
+    end
+
+    context "with not signed in user" do
+      before do
+        visit root_path
+      end
+
+      it "has sign in link" do
+        expect(find(:test_id, "sign-in")).to have_link(I18n.t("layouts.header.sign_in"), href: new_user_session_path)
+      end
+
+      it "has elasticsearch link" do
+        expect(find(:test_id, "elasticsearch")).to have_link("Elasticsearch", href: elasticsearch_path)
+      end
+
+      it "does not have user edit link" do
+        expect { find(:test_id, "user-edit") }.to raise_error(Capybara::ElementNotFound)
+      end
+
+      it "does not have invitation link" do
+        expect { find(:test_id, "invitation") }.to raise_error(Capybara::ElementNotFound)
+      end
+
+      it "does not have sign out link" do
+        expect { find(:test_id, "sign-out") }.to raise_error(Capybara::ElementNotFound)
+      end
+    end
+  end
+end


### PR DESCRIPTION
ハンバーガーメニューに表示するリンクのテストを追加した（Fix #411）

どのユーザーにどのリンクを表示するかの表

|  link \ user               | non signed in | signed in & non admin | signed in & admin |
| --------------- | ------------- | --------------------- | ----------------- |
| sign in         | o             | x                     | x                 |
| sign out        | x             | o                     | o                 |
| elasticsearch   | o             | o                     | o                 |
| user edit       | x             | o                     | o                 |
| user invitation | x             | x                     | o                 |

o: 表示  x: 非表示