### PR TITLE
Update: elasticsearch をruby3対応バージョンに上げた

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Install build tools, posgresql-client, yarn and node
 RUN apt-get update -qq && \
     DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
-    curl=7.64.* build-essential=12.6 gnupg2=2.2.* imagemagick=8:6.9.* \
-    git=1:2.20.* && \
+    curl=7.64.* build-essential=12.6 gnupg2=2.2.* imagemagick=8:6.9.* && \
     apt-get clean && \
     rm -rf /var/cache/apt/archives/* && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \

--- a/Gemfile
+++ b/Gemfile
@@ -56,9 +56,9 @@ gem "era_ja"
 # ElasticSearch
 # Do not update, because released gems have not adapted to Ruby 3 yet.
 gem "bonsai-elasticsearch-rails"
-gem "elasticsearch", ">= 7.13", "< 7.14"
-gem "elasticsearch-model", github: "indirect/elasticsearch-rails"
-gem "elasticsearch-rails", ">= 7.1", "< 7.2"
+gem "elasticsearch", ">=7.2"
+gem "elasticsearch-model", ">=7.2"
+gem "elasticsearch-rails", ">=7.2"
 
 group :development, :test do
   gem "annotate"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,3 @@
-GIT
-  remote: https://github.com/indirect/elasticsearch-rails.git
-  revision: 20efbf2ca6a4d310b3e11638334d85017d923ffe
-  specs:
-    elasticsearch-model (7.1.0)
-      activesupport (> 3)
-      elasticsearch (~> 7)
-      hashie
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -147,7 +138,11 @@ GEM
       elasticsearch-transport (= 7.13.3)
     elasticsearch-api (7.13.3)
       multi_json
-    elasticsearch-rails (7.1.1)
+    elasticsearch-model (7.2.1)
+      activesupport (> 3)
+      elasticsearch (~> 7)
+      hashie
+    elasticsearch-rails (7.2.1)
     elasticsearch-transport (7.13.3)
       faraday (~> 1)
       multi_json
@@ -190,7 +185,7 @@ GEM
     ffi (1.15.5)
     globalid (0.5.2)
       activesupport (>= 5.0)
-    hashie (4.1.0)
+    hashie (5.0.0)
     html_tokenizer (0.0.7)
     http-accept (1.7.0)
     http-cookie (1.0.4)
@@ -441,9 +436,9 @@ DEPENDENCIES
   devise-i18n
   devise_invitable
   dotenv-rails
-  elasticsearch (>= 7.13, < 7.14)
-  elasticsearch-model!
-  elasticsearch-rails (>= 7.1, < 7.2)
+  elasticsearch (>= 7.2)
+  elasticsearch-model (>= 7.2)
+  elasticsearch-rails (>= 7.2)
   enum_help
   era_ja
   erb_lint


### PR DESCRIPTION
Close #226

elasticsearch-railsのruby3対応バージョンがやっとリリースされたぞ！