### PR TITLE
Fix: Rails7環境でSimpleLightboxが動かない不具合を修正

### DIFF
--- a/app/views/sakes/_show_abstract.html.erb
+++ b/app/views/sakes/_show_abstract.html.erb
@@ -85,8 +85,8 @@
   <% if @sake.photos.any? %>
     <div class="col-12 py-1">
       <div class="row g-2 photo-gallery">
-        <% @sake.photos.each_with_index do |photo, i| %>
-          <div class="col-lg-2 col-6">
+        <% @sake.photos.each do |photo| %>
+          <div class="col-lg-2 col-6" data-testid="sake_photo">
             <%= link_to(cl_image_tag(photo.image.thumb.url, class: "img-thumbnail"), photo.image.url) %>
           </div>
         <% end %>

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "lint:markdownlint:fix": "yarn run lint:markdownlint --fix",
     "lint:stylelint": "stylelint '**/*.scss' '**/*.css' --ignore-path .gitignore",
     "lint:stylelint:fix": "yarn run lint:stylelint --fix",
-    "build": "esbuild app/javascript/*.* --bundle --sourcemap --outdir=app/assets/builds",
+    "build": "esbuild app/javascript/*.* --bundle --sourcemap --define:global=window --outdir=app/assets/builds",
     "build:css": "sass ./app/assets/stylesheets/:./app/assets/builds/ --no-source-map --load-path=node_modules"
   },
   "packageManager": "yarn@3.1.1"

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,3 +1,10 @@
 RSpec.configure do |config|
   config.include(FactoryBot::Syntax::Methods)
 end
+
+def sake_with_photos(photo_count: 3)
+  FactoryBot.create(:sake) do |sake|
+    image = Rack::Test::UploadedFile.new(Rails.root.join("spec/system/files/sake_photo1.jpg"))
+    FactoryBot.create_list(:photo, photo_count, sake: sake, image: image)
+  end
+end

--- a/spec/system/sake_show_simple_lightboxes_spec.rb
+++ b/spec/system/sake_show_simple_lightboxes_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe "SakeShowSimpleLightboxes", type: :system do
+  let(:sake) { sake_with_photos(photo_count: 1) }
+
+  before do
+    visit sake_path(sake.id)
+  end
+
+  context "when seeing photo preview" do
+    before do
+      find(:test_id, "sake_photo").click
+    end
+
+    it "has same path", js: true do
+      expect(page).to have_current_path(sake_path(sake.id))
+    end
+  end
+end


### PR DESCRIPTION
fix #434

node_modules/simplelightbox/dist/simple-lightbox.modules.jsにて、globalオブジェクトを前提としている。
globalオブジェクトはnode.jsで定義されるオブジェクトで、ブラウザではwindowオブジェクトとなる。
そのため、esbuildのオプションでglobalという名前でwindowオブジェクトを定義することで回避した。
後々はnode.jsのcommonJS前提が駆逐され、必要なくなるオプションかもしれない。

参考
https://developer.mozilla.org/ja/docs/Glossary/Global_object
https://github.com/evanw/esbuild/issues/73
