### PR TITLE
小さな画面でページネーションを小さくした

### DIFF
--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,3 +1,3 @@
 <li class="page-item disabled">
-  <%= link_to(sanitize(t("views.pagination.truncate")), "#", { class: "page-link" }) %>
+  <%= link_to(tag.i(class: "bi-three-dots"), "#", class: "page-link") %>
 </li>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,3 +1,5 @@
 <li class="page-item disabled">
-  <%= link_to(tag.i(class: "bi-three-dots"), "#", class: "page-link") %>
+  <span class="page-link">
+    <%= tag.i(class: "bi-three-dots") %>
+  </span>
 </li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,3 +1,3 @@
 <li class="page-item <%= "disabled" if current_page.last? %>">
-  <%= link_to(tag.i(class: "bi-chevron-right"), url, { rel: "next", remote: remote, class: "page-link" }) %>
+  <%= link_to(tag.i(class: "bi-chevron-right"), url, class: "page-link", rel: "next") %>
 </li>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,9 +1,11 @@
 <% if page.current? %>
   <li class="page-item active">
-    <%= tag.a(page, data: { remote: remote }, class: "page-link", rel: page.rel) %>
+    <span class="page-link">
+      <%= page %>
+    </span>
   </li>
 <% else %>
   <li class="page-item">
-    <%= link_to(page, url, { remote: remote, rel: page.rel, class: "page-link" }) %>
+    <%= link_to(page, url,  class: "page-link", rel: page.rel, remote: remote) %>
   </li>
 <% end %>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -6,6 +6,6 @@
   </li>
 <% else %>
   <li class="page-item">
-    <%= link_to(page, url,  class: "page-link", rel: page.rel, remote: remote) %>
+    <%= link_to(page, url, class: "page-link", rel: page.rel, remote: remote) %>
   </li>
 <% end %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,21 +1,6 @@
 <%= paginator.render do %>
-  <%#= 通常サイズ %>
-  <nav class="d-none d-sm-block">
+  <nav>
     <ul class="pagination" style="justify-content: center">
-      <%= prev_page_tag %>
-      <% each_page do |page| %>
-        <% if page.left_outer? || page.right_outer? || page.inside_window? %>
-          <%= page_tag(page) %>
-        <% elsif !page.was_truncated? %>
-          <%= gap_tag %>
-        <% end %>
-      <% end %>
-      <%= next_page_tag %>
-    </ul>
-  </nav>
-  <%#= ミニサイズ %>
-  <nav class="d-sm-none d-block">
-    <ul class="pagination pagination-sm" style="justify-content: center">
       <%= prev_page_tag %>
       <% each_page do |page| %>
         <% if page.left_outer? || page.right_outer? || page.inside_window? %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,6 +1,21 @@
 <%= paginator.render do %>
-  <nav>
+  <%#= 通常サイズ %>
+  <nav class="d-none d-sm-block">
     <ul class="pagination" style="justify-content: center">
+      <%= prev_page_tag %>
+      <% each_page do |page| %>
+        <% if page.left_outer? || page.right_outer? || page.inside_window? %>
+          <%= page_tag(page) %>
+        <% elsif !page.was_truncated? %>
+          <%= gap_tag %>
+        <% end %>
+      <% end %>
+      <%= next_page_tag %>
+    </ul>
+  </nav>
+  <%#= ミニサイズ %>
+  <nav class="d-sm-none d-block">
+    <ul class="pagination pagination-sm" style="justify-content: center">
       <%= prev_page_tag %>
       <% each_page do |page| %>
         <% if page.left_outer? || page.right_outer? || page.inside_window? %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,3 +1,3 @@
 <li class="page-item <%= "disabled" if current_page.first? %>">
-  <%= link_to(tag.i(class: "bi-chevron-left"), url, { rel: "prev", remote: remote, class: "page-link" }) %>
+  <%= link_to(tag.i(class: "bi-chevron-left"), url, class: "page-link", rel: "prev") %>
 </li>

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -101,4 +101,12 @@
   </tbody>
 </table>
 
-<%= paginate(@sakes) if include_empty?(params) %>
+<% if include_empty?(params) %>
+  <div class="d-none d-sm-block">
+    <%= paginate(@sakes) %>
+  </div>
+  <div class="d-sm-none d-block">
+    <%# 小さい画面 %>
+    <%= paginate(@sakes, window: 1) %>
+  </div>
+<% end %>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,5 +1,5 @@
 Kaminari.configure do |config|
   config.default_per_page = 10
   config.window = 2
-  config.outer_window = 2
+  config.outer_window = 1
 end


### PR DESCRIPTION
fix #438

小さくはみ出さないページネーション

## しゃめ

### 大きな画面

![image](https://user-images.githubusercontent.com/849256/158154928-f43b71a2-8061-4dcd-8db6-f1eb19f63cbd.png)

### sm以下の小さな画面

こっちにした
![image](https://user-images.githubusercontent.com/849256/158156557-6ffbdc36-8e18-4fd6-a815-18fbbf53f6ea.png)

こっちは止めた
![image](https://user-images.githubusercontent.com/849256/158154968-0b3410b3-d2ea-43ff-99a8-3e89bc6263b8.png)

## やったこと

- kaminariのページ省略記号をbootstrap-icons化した
- kaminariのクリックできない3dotsや現在ページはtabでも反応させない
- 必要ないaタグのremoteを削除
  - Issue #437 をしたときに復元する
- kaminariによるページネーションで最初・最終のページは1つだけ表示にした
  - 「1 2 … 4 5 6 7 8…」を「1…4 5 6 7 8…」のようにした。
  - 2っていらないじゃんと思った。
- ~~特に小さな画面では小型ページネーションを使う~~
  - ~~上記対策でもiPhone SEのような小型画面でははみ出うるので。~~
- 小さな画面ではページネーションの表示数を減らす
