### PR TITLE
Turboを導入した

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem "cssbundling-rails"
 gem "jbuilder"
 
 # Use Redis adapter to run Action Cable in production
-# gem "redis", "~> 4.0"
+gem "redis"
 
 # Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]
 # gem "kredis"

--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem "puma"
 gem "jsbundling-rails"
 
 # Hotwire's SPA-like page accelerator [https://turbo.hotwired.dev]
-# gem "turbo-rails"
+gem "turbo-rails"
 
 # Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]
 # gem "stimulus-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -344,6 +344,7 @@ GEM
     rb-fsevent (0.11.1)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redis (4.6.0)
     regexp_parser (2.2.1)
     reline (0.3.1)
       io-console (~> 0.5)
@@ -484,6 +485,7 @@ DEPENDENCIES
   rails (= 7.0.2.2)
   rails-i18n
   ransack
+  redis
   rspec-rails
   rubocop
   rubocop-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -414,6 +414,9 @@ GEM
     strscan (3.0.1)
     thor (1.2.1)
     timeout (0.2.0)
+    turbo-rails (1.0.1)
+      actionpack (>= 6.0.0)
+      railties (>= 6.0.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unf (0.1.4)
@@ -489,6 +492,7 @@ DEPENDENCIES
   selenium-webdriver
   simplecov
   spring
+  turbo-rails
   tzinfo-data
   web-console
   webdrivers

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -57,7 +57,7 @@ module ApplicationHelper
   # @param name [String] 読み込む.scssファイル名、複数記述できる
   def select_css(*name)
     content_for(:css) do
-      stylesheet_link_tag(*name)
+      stylesheet_link_tag(*name, "data-turbo-track": "reload")
     end
   end
 

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,4 +1,5 @@
 // Entry point for the build script in your package.json
+import "@hotwired/turbo-rails"
 import Rails from "@rails/ujs"
 Rails.start()
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,7 +6,7 @@
     <%= csp_meta_tag %>
     <%= display_meta_tags(default_meta_tags) %>
     <%= adsense_tags %>
-    <%= stylesheet_link_tag("application") %>
+    <%= stylesheet_link_tag("application", "data-turbo-track": "reload") %>
     <%= yield(:css) if content_for?(:css) %>
     <%= javascript_include_tag("application", "data-turbo-track": "reload", defer: true) %>
     <%= yield(:js) if content_for?(:js) %>

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,5 +1,6 @@
 development:
-  adapter: async
+  adapter: redis
+  url: redis://localhost:6379/1
 
 test:
   adapter: test

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "sakazuki",
   "private": true,
   "dependencies": {
+    "@hotwired/turbo-rails": "^7.1.1",
     "@rails/ujs": "7.0.2-2",
     "bootstrap": ">=5.1.3 <6",
     "bootstrap-icons": ">=1.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -294,6 +294,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@hotwired/turbo-rails@npm:^7.1.1":
+  version: 7.1.1
+  resolution: "@hotwired/turbo-rails@npm:7.1.1"
+  dependencies:
+    "@hotwired/turbo": ^7.1.0
+    "@rails/actioncable": ^7.0
+  checksum: 606c0595659a4027e8f555acf5391031a5a6ebfe2ee57710d3b4de76bca3b75c3b79c2558d76cedc02ef8f90c04906aa505f365b675c305ca69e7ca8c7f1d22a
+  languageName: node
+  linkType: hard
+
+"@hotwired/turbo@npm:^7.1.0":
+  version: 7.1.0
+  resolution: "@hotwired/turbo@npm:7.1.0"
+  checksum: 4f71ebf2ff6a396d4031d048fa4d4dba6039aed9ad68436e6df4527e975acd8427c7d2f9b3e7f61f3e9c1af987193adf4e2b640c4033d4afd3e1f914ed05ba9f
+  languageName: node
+  linkType: hard
+
 "@humanwhocodes/config-array@npm:^0.5.0":
   version: 0.5.0
   resolution: "@humanwhocodes/config-array@npm:0.5.0"
@@ -356,6 +373,13 @@ __metadata:
     mkdirp: ^1.0.4
     rimraf: ^3.0.2
   checksum: c96381d4a37448ea280951e46233f7e541058cf57a57d4094dd4bdcaae43fa5872b5f2eb6bfb004591a68e29c5877abe3cdc210cb3588cbf20ab2877f31a7de7
+  languageName: node
+  linkType: hard
+
+"@rails/actioncable@npm:^7.0":
+  version: 7.0.2
+  resolution: "@rails/actioncable@npm:7.0.2"
+  checksum: 0064aa1b43c4099c62b0ec57534f756b22283a751571449e9b2285cef6593cefdd8f3edd692dc7840047ceba8f39e269f5a3e4a083f761ff87f686a6c366c7e8
   languageName: node
   linkType: hard
 
@@ -3560,6 +3584,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "sakazuki@workspace:."
   dependencies:
+    "@hotwired/turbo-rails": ^7.1.1
     "@rails/ujs": 7.0.2-2
     "@types/chart.js": ">=2.9.34 <3"
     "@typescript-eslint/eslint-plugin": ">=4.32.0"


### PR DESCRIPTION
fix #437

おめでとう、TurbolinksはTurboに進化した

## やったこと

- turboのインストール
- turboの設定を追加

## 必要なかったこと

- デフォルトでturboがオンなので、以前のTurbolinksのような`data-remote: true`は必要ない
  - 不具合が起きたら`data-remote: false`でリンクのTurboをオフにできる
