### PR TITLE
酒フォームに関するRSPecの名前を揃えた

### DIFF
--- a/spec/system/copy_sakes_spec.rb
+++ b/spec/system/copy_sakes_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "CopySakes", type: :system do
+RSpec.describe "Copy Sakes", type: :system do
   # SakesHelper.with_japanese_eraを使う
   include SakesHelper
 

--- a/spec/system/sake_form_bindume_date_spec.rb
+++ b/spec/system/sake_form_bindume_date_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "SakeFormBindumeDate", type: :system do
+RSpec.describe "Sake Form Bindume Date", type: :system do
   # SakesHelper.with_japanese_eraを使う
   include SakesHelper
 

--- a/spec/system/sake_form_bottle_level_spec.rb
+++ b/spec/system/sake_form_bottle_level_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Edit Sake's Bottle Level" do
+RSpec.describe "Sake Form Bottle Level" do
   let(:user) { create(:user) }
   let(:sealed_sake) { create(:sake, bottle_level: :sealed) }
   let(:opened_sake) { create(:sake, bottle_level: :opened) }

--- a/spec/system/sake_form_bottle_level_spec.rb
+++ b/spec/system/sake_form_bottle_level_spec.rb
@@ -10,199 +10,57 @@ RSpec.describe "Sake Form Bottle Level" do
     sign_in(user)
   end
 
-  context "when usual updating" do
-    describe "updating sake from sealed to opened" do
-      before do
-        visit edit_sake_path(sealed_sake.id)
-        select(I18n.t("enums.sake.bottle_level.opened"), from: "sake_bottle_level")
-        click_button("form-submit")
-      end
-
-      it "updates bottle level to open" do
-        expect { sealed_sake.reload }.to change(sealed_sake, :bottle_level).from("sealed").to("opened")
-      end
-
-      it "does not update created_at" do
-        expect { sealed_sake.reload }.not_to change(sealed_sake, :created_at)
-      end
-
-      it "updates opened_at" do
-        expect { sealed_sake.reload }.to change(sealed_sake, :opened_at)
-      end
-
-      it "does not update emptied_at" do
-        expect { sealed_sake.reload }.not_to change(sealed_sake, :emptied_at)
-      end
-
-      it "updates updated_at" do
-        expect { sealed_sake.reload }.to change(sealed_sake, :updated_at)
-      end
-
-      it "has close date time between updated_at and updated_at" do
-        sealed_sake.reload
-        delta = 1.second        # 差分が1秒以内
-        expect(sealed_sake.opened_at).to be_within(delta).of(sealed_sake.updated_at)
-      end
-    end
-
-    describe "updating sake from sealed to empty" do
-      before do
-        visit edit_sake_path(sealed_sake.id)
-        select(I18n.t("enums.sake.bottle_level.empty"), from: "sake_bottle_level")
-        click_button("form-submit")
-      end
-
-      it "updates bottle level to empty" do
-        expect { sealed_sake.reload }.to change(sealed_sake, :bottle_level).from("sealed").to("empty")
-      end
-
-      it "updates updated_at" do
-        expect { sealed_sake.reload }.to change(sealed_sake, :updated_at)
-      end
-
-      it "updates opened_at" do
-        expect { sealed_sake.reload }.to change(sealed_sake, :opened_at)
-      end
-
-      it "updates emptied_at" do
-        expect { sealed_sake.reload }.to change(sealed_sake, :emptied_at)
-      end
-
-      it "does not update created_at" do
-        expect { sealed_sake.reload }.not_to change(sealed_sake, :created_at)
-      end
-
-      it "has close date time between opened_at and updated_at" do
-        sealed_sake.reload
-        delta = 1.second        # 差分が1秒以内
-        expect(sealed_sake.opened_at).to be_within(delta).of(sealed_sake.updated_at)
-      end
-
-      it "has close date time between emptied_at and updated_at" do
-        sealed_sake.reload
-        delta = 1.second        # 差分が1秒以内
-        expect(sealed_sake.emptied_at).to be_within(delta).of(sealed_sake.updated_at)
-      end
-    end
-
-    describe "updating sake from opened to empty" do
-      before do
-        visit edit_sake_path(opened_sake.id)
-        select(I18n.t("enums.sake.bottle_level.empty"), from: "sake_bottle_level")
-        click_button("form-submit")
-      end
-
-      it "updates bottle level to empty" do
-        expect { opened_sake.reload }.to change(opened_sake, :bottle_level).from("opened").to("empty")
-      end
-
-      it "does not update created_at" do
-        expect { opened_sake.reload }.not_to change(opened_sake, :created_at)
-      end
-
-      it "does not update opened_at" do
-        expect { opened_sake.reload }.not_to change(opened_sake, :opened_at)
-      end
-
-      it "updates emptied_at" do
-        expect { opened_sake.reload }.to change(opened_sake, :emptied_at)
-      end
-
-      it "updates updated_at" do
-        expect { opened_sake.reload }.to change(opened_sake, :updated_at)
-      end
-
-      it "has same date time between updated_at and emptied_at" do
-        opened_sake.reload
-        delta = 1.second        # 差分が1秒以内
-        expect(opened_sake.emptied_at).to be_within(delta).of(opened_sake.updated_at)
-      end
+  describe "updating sake from sealed to opened" do
+    it "updates bottle level to open" do
+      visit edit_sake_path(sealed_sake.id)
+      select(I18n.t("enums.sake.bottle_level.opened"), from: "sake_bottle_level")
+      click_button("form-submit")
+      expect { sealed_sake.reload }.to change(sealed_sake, :bottle_level).from("sealed").to("opened")
     end
   end
 
-  context "when unusual updating" do
-    describe "updating sake from empty to sealed" do
-      before do
-        visit edit_sake_path(empty_sake.id)
-        select(I18n.t("enums.sake.bottle_level.sealed"), from: "sake_bottle_level")
-        click_button("form-submit")
-      end
-
-      it "updates bottle level to sealed" do
-        expect { empty_sake.reload }.to change(empty_sake, :bottle_level).from("empty").to("sealed")
-      end
-
-      it "does not update created_at" do
-        expect { empty_sake.reload }.not_to change(empty_sake, :created_at)
-      end
-
-      it "does not update opened_at" do
-        expect { empty_sake.reload }.not_to change(empty_sake, :opened_at)
-      end
-
-      it "does not update emptied_at" do
-        expect { empty_sake.reload }.not_to change(empty_sake, :emptied_at)
-      end
-
-      it "updates updated_at" do
-        expect { empty_sake.reload }.to change(empty_sake, :updated_at)
-      end
+  describe "updating sake from sealed to empty" do
+    it "updates bottle level to empty" do
+      visit edit_sake_path(sealed_sake.id)
+      select(I18n.t("enums.sake.bottle_level.empty"), from: "sake_bottle_level")
+      click_button("form-submit")
+      expect { sealed_sake.reload }.to change(sealed_sake, :bottle_level).from("sealed").to("empty")
     end
+  end
 
-    describe "updating sake from empty to opened" do
-      before do
-        visit edit_sake_path(empty_sake.id)
-        select(I18n.t("enums.sake.bottle_level.opened"), from: "sake_bottle_level")
-        click_button("form-submit")
-      end
-
-      it "updates bottle level to opened" do
-        expect { empty_sake.reload }.to change(empty_sake, :bottle_level).from("empty").to("opened")
-      end
-
-      it "does not update created_at" do
-        expect { empty_sake.reload }.not_to change(empty_sake, :created_at)
-      end
-
-      it "does not update opened_at" do
-        expect { empty_sake.reload }.not_to change(empty_sake, :opened_at)
-      end
-
-      it "does not update emptied_at" do
-        expect { empty_sake.reload }.not_to change(empty_sake, :emptied_at)
-      end
-
-      it "updates updated_at" do
-        expect { empty_sake.reload }.to change(empty_sake, :updated_at)
-      end
+  describe "updating sake from opened to empty" do
+    it "updates bottle level to empty" do
+      visit edit_sake_path(opened_sake.id)
+      select(I18n.t("enums.sake.bottle_level.empty"), from: "sake_bottle_level")
+      click_button("form-submit")
+      expect { opened_sake.reload }.to change(opened_sake, :bottle_level).from("opened").to("empty")
     end
+  end
 
-    describe "updating sake from opened to sealed" do
-      before do
-        visit edit_sake_path(opened_sake.id)
-        select(I18n.t("enums.sake.bottle_level.sealed"), from: "sake_bottle_level")
-        click_button("form-submit")
-      end
+  describe "updating sake from empty to sealed" do
+    it "updates bottle level to sealed" do
+      visit edit_sake_path(empty_sake.id)
+      select(I18n.t("enums.sake.bottle_level.sealed"), from: "sake_bottle_level")
+      click_button("form-submit")
+      expect { empty_sake.reload }.to change(empty_sake, :bottle_level).from("empty").to("sealed")
+    end
+  end
 
-      it "updates bottle level to sealed" do
-        expect { opened_sake.reload }.to change(opened_sake, :bottle_level).from("opened").to("sealed")
-      end
+  describe "updating sake from empty to opened" do
+    it "updates bottle level to opened" do
+      visit edit_sake_path(empty_sake.id)
+      select(I18n.t("enums.sake.bottle_level.opened"), from: "sake_bottle_level")
+      click_button("form-submit")
+      expect { empty_sake.reload }.to change(empty_sake, :bottle_level).from("empty").to("opened")
+    end
+  end
 
-      it "does not update created_at" do
-        expect { opened_sake.reload }.not_to change(opened_sake, :created_at)
-      end
-
-      it "does not update opened_at" do
-        expect { opened_sake.reload }.not_to change(opened_sake, :opened_at)
-      end
-
-      it "does not update emptied_at" do
-        expect { opened_sake.reload }.not_to change(opened_sake, :emptied_at)
-      end
-
-      it "updates updated_at" do
-        expect { opened_sake.reload }.to change(opened_sake, :updated_at)
-      end
+  describe "updating sake from opened to sealed" do
+    it "updates bottle level to sealed" do
+      visit edit_sake_path(opened_sake.id)
+      select(I18n.t("enums.sake.bottle_level.sealed"), from: "sake_bottle_level")
+      click_button("form-submit")
+      expect { opened_sake.reload }.to change(opened_sake, :bottle_level).from("opened").to("sealed")
     end
   end
 end

--- a/spec/system/sake_form_completion_from_names_spec.rb
+++ b/spec/system/sake_form_completion_from_names_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "SakeFormCompletionFromNames", type: :system do
+RSpec.describe "Sake Form Completion From Names", type: :system do
   let(:user) { create(:user) }
 
   before do

--- a/spec/system/sake_form_datetime_spec.rb
+++ b/spec/system/sake_form_datetime_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "SakeFormDateTime" do
+RSpec.describe "Sake Form Date Time" do
   let(:user) { create(:user) }
 
   before do

--- a/spec/system/sake_form_datetime_spec.rb
+++ b/spec/system/sake_form_datetime_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Sake DateTime" do
+RSpec.describe "SakeFormDateTime" do
   let(:user) { create(:user) }
 
   before do

--- a/spec/system/sake_form_kura_completion_spec.rb
+++ b/spec/system/sake_form_kura_completion_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "KuraCompletion", type: :system do
+RSpec.describe "Sake Form Kura Completion", type: :system do
   let(:user) { create(:user) }
 
   before do

--- a/spec/system/sake_form_photos_spec.rb
+++ b/spec/system/sake_form_photos_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "SakeFormPhotos", type: :system do
+RSpec.describe "Sake Form Photos", type: :system do
   let(:user) { create(:user) }
 
   before do

--- a/spec/system/sake_show_simple_lightboxes_spec.rb
+++ b/spec/system/sake_show_simple_lightboxes_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "SakeShowSimpleLightboxes", type: :system do
+RSpec.describe "Sake Show Simple Lightboxes", type: :system do
   let(:sake) { sake_with_photos(photo_count: 1) }
 
   before do

--- a/spec/system/sign_in_redirect_by_drinkbutton_spec.rb
+++ b/spec/system/sign_in_redirect_by_drinkbutton_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Sign-in Redirect with Drink Buttons" do
+RSpec.describe "Sign-in Redirect by Drink Buttons" do
   let!(:sealed_sake) { create(:sake, bottle_level: "sealed") }
   let!(:impressed_sake) { create(:sake, bottle_level: "opened", taste_value: 1, aroma_value: 2) }
   let(:user) { create(:user) }


### PR DESCRIPTION
酒のedit/newのような酒formに関するスペックは全部`sake_form_***`という名前にしておいた。
そのうちサブディレクトリ掘ってもいいよね。