### PR TITLE
FlashメッセージのRSpecを追加

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -10,26 +10,30 @@
         <span class="navbar-toggler-icon"></span>
       </button>
       <div class="collapse navbar-collapse" id="navbarSupportedContent">
-        <ul class="navbar-nav">
-          <li class="nav-item" data-testid="elasticsearch">
-            <%= link_to("Elasticsearch", elasticsearch_path, class: "nav-link") %>
+        <ul class="navbar-nav" data-testid="navigation_list">
+          <li class="nav-item">
+            <%= link_to("Elasticsearch", elasticsearch_path, class: "nav-link", data: { testid: "elasticsearch" }) %>
           </li>
           <span class="border-bottom border-secondary"></span>
           <% if user_signed_in? %>
             <li class="nav-item" data-testid="user-edit">
-              <%= link_to(current_user.email, edit_user_registration_path, class: "nav-link") %>
+              <%= link_to(current_user.email, edit_user_registration_path, class: "nav-link", data: { testid: "edit_user" }) %>
             </li>
             <% if current_user.admin %>
-              <li class="nav-item" data-testid="invitation">
-                <%= link_to(t(".invitation"), new_user_invitation_path, class: "nav-link") %>
+              <li class="nav-item">
+                <%= link_to(t(".invitation"), new_user_invitation_path, class: "nav-link", data: { testid: "invitation" }) %>
               </li>
             <% end %>
-            <li class="nav-item" data-testid="sign-out">
-              <%= link_to(t(".sign_out"), destroy_user_session_path, method: :delete, class: "nav-link") %>
+            <li class="nav-item">
+              <%= link_to(t(".sign_out"),
+                          destroy_user_session_path,
+                          method: :delete,
+                          class: "nav-link",
+                          data: { testid: "sign_out" }) %>
             </li>
           <% else %>
-            <li class="nav-item" data-testid="sign-in">
-              <%= link_to(t(".sign_in"), new_user_session_path, class: "nav-link") %>
+            <li class="nav-item">
+              <%= link_to(t(".sign_in"), new_user_session_path, class: "nav-link", data: { testid: "sign_in" }) %>
             </li>
           <% end %>
         </ul>

--- a/app/views/sakes/show.html.erb
+++ b/app/views/sakes/show.html.erb
@@ -27,8 +27,8 @@
         <%= link_to(t(".delete"),
                     @sake,
                     method: :delete,
-                    data: { confirm: t(".confirm_delete") },
-                    class: "btn btn-danger") %>
+                    class: "btn btn-danger",
+                    data: { confirm: t(".confirm_delete"), testid: "delete_sake" }) %>
       </div>
     </div>
   </div>

--- a/spec/system/flash_message_spec.rb
+++ b/spec/system/flash_message_spec.rb
@@ -1,0 +1,90 @@
+require "rails_helper"
+
+RSpec.describe "Flash Message" do
+  let(:user) { create(:user) }
+  let(:sake) { create(:sake) }
+
+  context "without login" do
+    # sake
+    describe "asscess new sake page" do
+      it "has flash message" do
+        visit new_sake_path
+        expect(page).to have_selector(:test_id, "flash-message")
+      end
+    end
+
+    describe "asscess edit sake page" do
+      it "has flash message" do
+        visit edit_sake_path(sake.id)
+        expect(page).to have_selector(:test_id, "flash-message")
+      end
+    end
+
+    # invitation
+    describe "asscess invitation page" do
+      it "has flash message" do
+        visit new_user_invitation_path
+        expect(page).to have_selector(:test_id, "flash-message")
+      end
+    end
+
+    # devise
+    describe "login" do
+      it "has flash message" do
+        visit sakes_path
+        sign_in_via_header_button(user)
+        expect(page).to have_selector(:test_id, "flash-message")
+      end
+    end
+  end
+
+  context "with login" do
+    before do
+      sign_in(user)
+    end
+
+    # sake
+    describe "create sake" do
+      it "has flash message" do
+        visit new_sake_path
+        fill_in("sake_name", with: "生道井")
+        click_button("form-submit")
+        expect(page).to have_selector(:test_id, "flash-message")
+      end
+    end
+
+    describe "update sake" do
+      it "has flash message" do
+        visit edit_sake_path(sake.id)
+        fill_in("sake_name", with: "ほしいずみ")
+        click_button("form-submit")
+        expect(page).to have_selector(:test_id, "flash-message")
+      end
+    end
+
+    describe "delete sake", js: true do
+      it "has flash message" do
+        visit sake_path(sake.id)
+        accept_confirm do click_link("delete_sake") end
+        expect(page).to have_selector(:test_id, "flash-message")
+      end
+    end
+
+    describe "copy sake" do
+      it "has flash message" do
+        visit sake_path(sake.id)
+        click_link("copy_sake")
+        expect(page).to have_selector(:test_id, "flash-message")
+      end
+    end
+
+    # devise
+    describe "logout" do
+      it "has flash message" do
+        visit sakes_path
+        click_link("sign_out")
+        expect(page).to have_selector(:test_id, "flash-message")
+      end
+    end
+  end
+end

--- a/spec/views/layouts/_header.html.erb_spec.rb
+++ b/spec/views/layouts/_header.html.erb_spec.rb
@@ -12,23 +12,25 @@ RSpec.describe "layouts/_header", type: :system do
       end
 
       it "does not have sign in link" do
-        expect { find(:test_id, "sign-in") }.to raise_error(Capybara::ElementNotFound)
+        expect { find(:test_id, "sign_in") }.to raise_error(Capybara::ElementNotFound)
       end
 
       it "has elasticsearch link" do
-        expect(find(:test_id, "elasticsearch")).to have_link("Elasticsearch", href: elasticsearch_path)
+        expect(find(:test_id, "navigation_list")).to have_link("Elasticsearch", href: elasticsearch_path)
       end
 
       it "has user edit link" do
-        expect(find(:test_id, "user-edit")).to have_link(user.email, href: edit_user_registration_path)
+        expect(find(:test_id, "navigation_list")).to have_link(user.email, href: edit_user_registration_path)
       end
 
       it "has invitation link" do
-        expect(find(:test_id, "invitation")).to have_link(I18n.t("layouts.header.invitation"), href: new_user_invitation_path)
+        expect(find(:test_id, "navigation_list")).to have_link(I18n.t("layouts.header.invitation"),
+                                                               href: new_user_invitation_path)
       end
 
       it "has sign out link" do
-        expect(find(:test_id, "sign-out")).to have_link(I18n.t("layouts.header.sign_out"), href: destroy_user_session_path)
+        expect(find(:test_id, "navigation_list")).to have_link(I18n.t("layouts.header.sign_out"),
+                                                               href: destroy_user_session_path)
       end
     end
 
@@ -41,15 +43,15 @@ RSpec.describe "layouts/_header", type: :system do
       end
 
       it "does not have sign in link" do
-        expect { find(:test_id, "sign-in") }.to raise_error(Capybara::ElementNotFound)
+        expect { find(:test_id, "sign_in") }.to raise_error(Capybara::ElementNotFound)
       end
 
       it "has elasticsearch link" do
-        expect(find(:test_id, "elasticsearch")).to have_link("Elasticsearch", href: elasticsearch_path)
+        expect(find(:test_id, "navigation_list")).to have_link("Elasticsearch", href: elasticsearch_path)
       end
 
       it "has user edit link" do
-        expect(find(:test_id, "user-edit")).to have_link(user.email, href: edit_user_registration_path)
+        expect(find(:test_id, "navigation_list")).to have_link(user.email, href: edit_user_registration_path)
       end
 
       it "does not have invitation link" do
@@ -57,7 +59,8 @@ RSpec.describe "layouts/_header", type: :system do
       end
 
       it "has sign out link" do
-        expect(find(:test_id, "sign-out")).to have_link(I18n.t("layouts.header.sign_out"), href: destroy_user_session_path)
+        expect(find(:test_id, "navigation_list")).to have_link(I18n.t("layouts.header.sign_out"),
+                                                               href: destroy_user_session_path)
       end
     end
 
@@ -67,15 +70,16 @@ RSpec.describe "layouts/_header", type: :system do
       end
 
       it "has sign in link" do
-        expect(find(:test_id, "sign-in")).to have_link(I18n.t("layouts.header.sign_in"), href: new_user_session_path)
+        expect(find(:test_id, "navigation_list")).to have_link(I18n.t("layouts.header.sign_in"),
+                                                               href: new_user_session_path)
       end
 
       it "has elasticsearch link" do
-        expect(find(:test_id, "elasticsearch")).to have_link("Elasticsearch", href: elasticsearch_path)
+        expect(find(:test_id, "navigation_list")).to have_link("Elasticsearch", href: elasticsearch_path)
       end
 
       it "does not have user edit link" do
-        expect { find(:test_id, "user-edit") }.to raise_error(Capybara::ElementNotFound)
+        expect { find(:test_id, "edit_user") }.to raise_error(Capybara::ElementNotFound)
       end
 
       it "does not have invitation link" do
@@ -83,7 +87,7 @@ RSpec.describe "layouts/_header", type: :system do
       end
 
       it "does not have sign out link" do
-        expect { find(:test_id, "sign-out") }.to raise_error(Capybara::ElementNotFound)
+        expect { find(:test_id, "sign_out") }.to raise_error(Capybara::ElementNotFound)
       end
     end
   end


### PR DESCRIPTION
fix #454

ふらっっっしゅ！！！！

## やったこと

- ナビゲーションバーのViewにおけるtestidの振り方を変えた
  - testidでリンクがクリックできないので、方法を変更
- flashメッセージが表示されるRSpecを書いた

## やってないこと

- deviseの各種メッセージのテスト
  - 例えば、「パスワードリセット」や「アカウントロックメール」やら、、、たくさん
  - メッセージがでないと何をしているかわからないから結構致命的
  - いつか書くべき？
