### PR TITLE
Update: Twitterカード用画像をテキスト優先で切り抜くようにした

### DIFF
--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -6,13 +6,19 @@ class ImageUploader < CarrierWave::Uploader::Base
     storage :file
   end
 
+  process(ocr: "adv_ocr:ja") if Rails.env.production?
+
   version :thumb do
     # HACK: 1:1でスマホで２つ並んでも潰れないサイズ
-    process resize_to_fill: [600, 600]
+    process(resize_to_fill: [600, 600])
   end
 
   version :large_twitter_card do
-    process resize_to_fill: [600, 300]
+    if Rails.env.production?
+      cloudinary_transformation(crop: :thumb, width: 600, height: 300, sign_url: true, gravity: :ocr_text)
+    else
+      process(resize_to_fill: [600, 300])
+    end
   end
 
   def store_dir


### PR DESCRIPTION
fix #172

本当にこれでいいのかは怪しい。

## 動いている例

- うまくいっているやつ
  - 「しぼりたて」がきれいに認識されてるようだ
  - https://github.com/momocus/sakazuki/issues/172#issuecomment-1082011589
- うまくいってないやつ
  - フォントがおしゃれだとダメ
  - https://github.com/momocus/sakazuki/issues/172#issuecomment-1077351333

## 制限

- 無料枠なので月50回まで
- 1ヶ月に50本は消費しないだろという目論見
- 最悪ケースは、画像変換方式が変化してから過去ログを一気に見た場合。そのときはそのときで考えよう。

## 悩み点

- 日本語指定を`adv_ocr:ja`で指定できるとあるけど、どこにつけるの？
- ドキュメントでは`upload`関数につけろというけど、CarrierWaveが`upload`をラップしているため直接指定できない
- `process`に指定したけど本当にこれでいいの？

## 参考

- Cloudinaryドキュメント - 画像変換
  - https://cloudinary.com/documentation/image_transformations
- Cloudinaryドキュメント - OCRテキストの検出と抽出
  - https://cloudinary.com/documentation/ocr_text_detection_and_extraction_addon