### PR TITLE
酒フォームにてフラッシュメッセージでなくフォーム直下にエラー内容を表示するようにした

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,17 +15,6 @@ h1 {
   pointer-events: all;
 }
 
-// Ruby on Railsが生成するエラー用スタイルなので、アンダーバーのままにする
-// stylelint-disable selector-class-pattern
-.field_with_errors {
-  display: contents;
-
-  input {
-    @extend .is-invalid;
-  }
-}
-// stylelint-enable selector-class-pattern
-
 // ------ header ------
 
 .sakazuki-header-logo {

--- a/app/views/layouts/_flashes.html.erb
+++ b/app/views/layouts/_flashes.html.erb
@@ -2,7 +2,7 @@
   <%# timedoutのときだけdeviseが意味のない0メッセージを生成するため飛ばす %>
   <% next if message_type == "timedout" %>
   <div class="alert alert-<%= bootstrap_alert(message_type) %> alert-dismissible fade show shadow-sm"
-    data-testid="flash-message">
+    data-testid="flash_message">
     <%= sanitize(message, tags: %w[a]) %>
     <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
   </div>

--- a/app/views/sakes/_float-button.html.erb
+++ b/app/views/sakes/_float-button.html.erb
@@ -24,7 +24,7 @@
                      form: "sake-form",
                      class: "float-button-primary mx-1",
                      style: "font-size: 1.1em;",
-                     "data-testid": "form-submit") do %>
+                     "data-testid": "form_submit") do %>
         <%= tag.i(class: "bi-check-circle me-2") + t("submit", scope: "sakes.form.#{controller.action_name}") %>
       <% end %>
     <% end %>

--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -6,11 +6,7 @@
 <%= form_with(model: sake, id: "sake-form") do |form| %>
 
   <%# error message %>
-  <% if sake.errors.any? %>
-    <% sake.errors.full_messages.each do |message| %>
-      <% flash.now[:danger] = message %>
-    <% end %>
-  <% end %>
+  <% flash.now[:danger] = t(".input_error") if sake.errors.any? %>
 
   <%# 表示義務ありのラベル情報 %>
   <div class="accordion my-2" id="accordionLabelInfo">
@@ -92,7 +88,15 @@
             <%= form.label(:alcohol, { class: "form-label" }) %>
             <div class="short-form">
               <%= form.number_field(:alcohol,
-                                    step: "any", class: "form-control", data: { testid: "sake_alcohol" }) %>
+                                    step: "any",
+                                    class: "form-control",
+                                    aria: { describedby: "sakeAlcoholValidationFeedback" },
+                                    data: { testid: "sake_alcohol" }) %>
+              <% sake.errors.full_messages_for(:alcohol).each do |message| %>
+                <div id="sakeAlcoholValidationFeedback" class="invalid-feedback">
+                  <%= message %>
+                </div>
+              <% end %>
             </div>
           </div>
 
@@ -112,7 +116,14 @@
             <%= form.label(:seimai_buai, { class: "form-label" }) %>
             <div class="short-form">
               <%= form.number_field(:seimai_buai,
-                                    class: "form-control", data: { testid: "sake_seimai_buai" }) %>
+                                    class: "form-control",
+                                    aria: { describedby: "sakeSeimaiBuaiValidationFeedback" },
+                                    data: { testid: "sake_seimai_buai" }) %>
+              <% sake.errors.full_messages_for(:seimai_buai).each do |message| %>
+                <div id="sakeSeimaiBuaiValidationFeedback" class="invalid-feedback">
+                  <%= message %>
+                </div>
+              <% end %>
             </div>
           </div>
 
@@ -168,14 +179,31 @@
           <div class="form-row">
             <%= form.label(:size, { class: "form-label" }) %>
             <div class="short-form">
-              <%= form.number_field(:size, required: true, class: "form-control", data: { testid: "sake_size" }) %>
+              <%= form.number_field(:size,
+                                    required: true,
+                                    class: "form-control",
+                                    aria: { describedby: "sakeSizeValidationFeedback" },
+                                    data: { testid: "sake_size" }) %>
+              <% sake.errors.full_messages_for(:size).each do |message| %>
+                <div id="sakeSizeValidationFeedback" class="invalid-feedback">
+                  <%= message %>
+                </div>
+              <% end %>
             </div>
           </div>
 
           <div class="form-row">
             <%= form.label(:price, { class: "form-label" }) %>
             <div class="short-form">
-              <%= form.number_field(:price, class: "form-control", data: { testid: "sake_price" }) %>
+              <%= form.number_field(:price,
+                                    class: "form-control",
+                                    aria: { describedby: "sakePriceValidationFeedback" },
+                                    data: { testid: "sake_price" }) %>
+              <% sake.errors.full_messages_for(:price).each do |message| %>
+                <div id="sakePriceValidationFeedback" class="invalid-feedback">
+                  <%= message %>
+                </div>
+              <% end %>
             </div>
           </div>
 
@@ -338,7 +366,15 @@
             <%= form.label(:sando, { class: "form-label" }) %>
             <div class="short-form">
               <%= form.number_field(:sando,
-                                    step: "any", class: "form-control", data: { testid: "sake_sando" }) %>
+                                    step: "any",
+                                    class: "form-control",
+                                    aria: { describedby: "sakeSandoValidationFeedback" },
+                                    data: { testid: "sake_sando" }) %>
+              <% sake.errors.full_messages_for(:sando).each do |message| %>
+                <div id="sakeSandoValidationFeedback" class="invalid-feedback">
+                  <%= message %>
+                </div>
+              <% end %>
             </div>
           </div>
 
@@ -346,7 +382,15 @@
             <%= form.label(:aminosando, { class: "form-label" }) %>
             <div class="short-form">
               <%= form.number_field(:aminosando,
-                                    step: "any", class: "form-control", data: { testid: "sake_aminosando" }) %>
+                                    step: "any",
+                                    class: "form-control",
+                                    aria: { describedby: "sakeAminosandoValidationFeedback" },
+                                    data: { testid: "sake_aminosando" }) %>
+              <% sake.errors.full_messages_for(:aminosando).each do |message| %>
+                <div id="sakeAminosandoValidationFeedback" class="invalid-feedback">
+                  <%= message %>
+                </div>
+              <% end %>
             </div>
           </div>
         </div>

--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -32,7 +32,9 @@
             <div class="col">
               <%= form.text_field(:name,
                                   class: "form-control",
-                                  autocomplete: "off", data: { testid: "sake_name" }) %>
+                                  autocomplete: "off",
+                                  required: true,
+                                  data: { testid: "sake_name" }) %>
             </div>
           </div>
 
@@ -166,7 +168,7 @@
           <div class="form-row">
             <%= form.label(:size, { class: "form-label" }) %>
             <div class="short-form">
-              <%= form.number_field(:size, class: "form-control", data: { testid: "sake_size" }) %>
+              <%= form.number_field(:size, required: true, class: "form-control", data: { testid: "sake_size" }) %>
             </div>
           </div>
 

--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -93,7 +93,7 @@
                                     aria: { describedby: "sakeAlcoholValidationFeedback" },
                                     data: { testid: "sake_alcohol" }) %>
               <% sake.errors.full_messages_for(:alcohol).each do |message| %>
-                <div id="sakeAlcoholValidationFeedback" class="invalid-feedback">
+                <div id="sakeAlcoholValidationFeedback" class="invalid-feedback" data-testid="sake_alcohol_feedback">
                   <%= message %>
                 </div>
               <% end %>
@@ -120,7 +120,7 @@
                                     aria: { describedby: "sakeSeimaiBuaiValidationFeedback" },
                                     data: { testid: "sake_seimai_buai" }) %>
               <% sake.errors.full_messages_for(:seimai_buai).each do |message| %>
-                <div id="sakeSeimaiBuaiValidationFeedback" class="invalid-feedback">
+                <div id="sakeSeimaiBuaiValidationFeedback" class="invalid-feedback" data-testid="sake_seimai_buai_feedback">
                   <%= message %>
                 </div>
               <% end %>
@@ -185,7 +185,7 @@
                                     aria: { describedby: "sakeSizeValidationFeedback" },
                                     data: { testid: "sake_size" }) %>
               <% sake.errors.full_messages_for(:size).each do |message| %>
-                <div id="sakeSizeValidationFeedback" class="invalid-feedback">
+                <div id="sakeSizeValidationFeedback" class="invalid-feedback" data-testid="sake_size_feedback">
                   <%= message %>
                 </div>
               <% end %>
@@ -200,7 +200,7 @@
                                     aria: { describedby: "sakePriceValidationFeedback" },
                                     data: { testid: "sake_price" }) %>
               <% sake.errors.full_messages_for(:price).each do |message| %>
-                <div id="sakePriceValidationFeedback" class="invalid-feedback">
+                <div id="sakePriceValidationFeedback" class="invalid-feedback" data-testid="sake_price_feedback">
                   <%= message %>
                 </div>
               <% end %>
@@ -371,7 +371,7 @@
                                     aria: { describedby: "sakeSandoValidationFeedback" },
                                     data: { testid: "sake_sando" }) %>
               <% sake.errors.full_messages_for(:sando).each do |message| %>
-                <div id="sakeSandoValidationFeedback" class="invalid-feedback">
+                <div id="sakeSandoValidationFeedback" class="invalid-feedback" data-testid="sake_sando_feedback">
                   <%= message %>
                 </div>
               <% end %>
@@ -387,7 +387,7 @@
                                     aria: { describedby: "sakeAminosandoValidationFeedback" },
                                     data: { testid: "sake_aminosando" }) %>
               <% sake.errors.full_messages_for(:aminosando).each do |message| %>
-                <div id="sakeAminosandoValidationFeedback" class="invalid-feedback">
+                <div id="sakeAminosandoValidationFeedback" class="invalid-feedback" data-testid="sake_aminosando_feedback">
                   <%= message %>
                 </div>
               <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,6 +31,17 @@ module Sakazuki
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
 
+    # Rails error forms using Bootstrap is-invalid style
+    config.action_view.field_error_proc = lambda { |html_tag, _instance|
+      doc = Nokogiri::HTML::DocumentFragment.parse(html_tag)
+      element = doc.children[0]
+      form_fields = %w[textarea input select]
+      return html_tag unless form_fields.include?(element.name)
+
+      element[:class] = "#{element[:class]} is-invalid"
+      ActiveSupport::SafeBuffer.new(doc.to_html)
+    }
+
     # For Japanese
     config.i18n.load_path +=
       Dir[Rails.root.join("config/locales/**/*.ja.{rb,yml}")]

--- a/config/locales/views/sake.ja.yml
+++ b/config/locales/views/sake.ja.yml
@@ -50,6 +50,7 @@ ja:
         submit: 更新
       update:
         submit: :sakes.form.edit.submit
+      input_error: 入力内容に問題があります
     float-button:
       edit: :sakes.index.edit
       copy: 複製

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -41,7 +41,7 @@ end
 #
 # ユーザーが現在いるページにリダイレクトされたとき、何らかのアラートが表示されるまで待つ。
 def wait_for_alert
-  find(:test_id, "flash-message")
+  find(:test_id, "flash_message")
 end
 
 # 酒のshowページのパスから、そのページで表示している酒オブジェクトを取得する

--- a/spec/system/copy_sakes_spec.rb
+++ b/spec/system/copy_sakes_spec.rb
@@ -48,11 +48,11 @@ RSpec.describe "Copy Sakes", type: :system do
     describe "flash message" do
       it "has copy message" do
         text = I18n.t("sakes.new.copy", name: sake.name)
-        expect(find(:test_id, "flash-message")).to have_text(text)
+        expect(find(:test_id, "flash_message")).to have_text(text)
       end
 
       it "has link to copied sake on name" do
-        expect(find(:test_id, "flash-message")).to have_link(sake.name, href: sake_path(sake.id))
+        expect(find(:test_id, "flash_message")).to have_link(sake.name, href: sake_path(sake.id))
       end
     end
   end

--- a/spec/system/drink_buttons_spec.rb
+++ b/spec/system/drink_buttons_spec.rb
@@ -198,11 +198,11 @@ RSpec.describe "Drink Buttons" do
 
       it "has success flash message" do
         text = I18n.t("sakes.update.success_open", name: sealed_sake.name)
-        expect(find(:test_id, "flash-message")).to have_text(text)
+        expect(find(:test_id, "flash_message")).to have_text(text)
       end
 
       it "has flash message containing link to updated sake" do
-        expect(find(:test_id, "flash-message")).to have_link(sealed_sake.name, href: sake_path(sealed_sake.id))
+        expect(find(:test_id, "flash_message")).to have_link(sealed_sake.name, href: sake_path(sealed_sake.id))
       end
 
       it "updates sake to opened" do
@@ -226,11 +226,11 @@ RSpec.describe "Drink Buttons" do
 
       it "has success flash message" do
         text = I18n.t("sakes.update.success_empty", name: impressed_sake.name)
-        expect(find(:test_id, "flash-message")).to have_text(text)
+        expect(find(:test_id, "flash_message")).to have_text(text)
       end
 
       it "has flash message containing link to updated sake" do
-        expect(find(:test_id, "flash-message")).to have_link(impressed_sake.name, href: sake_path(impressed_sake.id))
+        expect(find(:test_id, "flash_message")).to have_link(impressed_sake.name, href: sake_path(impressed_sake.id))
       end
 
       it "updates sake to empty" do

--- a/spec/system/edit_sake_spec.rb
+++ b/spec/system/edit_sake_spec.rb
@@ -19,12 +19,12 @@ RSpec.describe "Edit Sake" do
     it "has success flash message" do
       sake.reload
       text = I18n.t("sakes.update.success", name: sake.name)
-      expect(find(:test_id, "flash-message")).to have_text(text)
+      expect(find(:test_id, "flash_message")).to have_text(text)
     end
 
     it "has link to the updated sake" do
       sake.reload
-      expect(find(:test_id, "flash-message")).to have_link(sake.name, href: sake_path(sake.id))
+      expect(find(:test_id, "flash_message")).to have_link(sake.name, href: sake_path(sake.id))
     end
 
     it "updates also updated_at" do

--- a/spec/system/edit_sake_spec.rb
+++ b/spec/system/edit_sake_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Edit Sake" do
       sign_in(user)
       visit edit_sake_path(sake.id)
       fill_in("sake_name", with: "ほしいずみ")
-      click_button("form-submit")
+      click_button("form_submit")
     end
 
     it "redirect to sake page" do

--- a/spec/system/flash_message_spec.rb
+++ b/spec/system/flash_message_spec.rb
@@ -9,14 +9,14 @@ RSpec.describe "Flash Message" do
     describe "asscess new sake page" do
       it "has flash message" do
         visit new_sake_path
-        expect(page).to have_selector(:test_id, "flash-message")
+        expect(page).to have_selector(:test_id, "flash_message")
       end
     end
 
     describe "asscess edit sake page" do
       it "has flash message" do
         visit edit_sake_path(sake.id)
-        expect(page).to have_selector(:test_id, "flash-message")
+        expect(page).to have_selector(:test_id, "flash_message")
       end
     end
 
@@ -24,7 +24,7 @@ RSpec.describe "Flash Message" do
     describe "asscess invitation page" do
       it "has flash message" do
         visit new_user_invitation_path
-        expect(page).to have_selector(:test_id, "flash-message")
+        expect(page).to have_selector(:test_id, "flash_message")
       end
     end
 
@@ -33,7 +33,7 @@ RSpec.describe "Flash Message" do
       it "has flash message" do
         visit sakes_path
         sign_in_via_header_button(user)
-        expect(page).to have_selector(:test_id, "flash-message")
+        expect(page).to have_selector(:test_id, "flash_message")
       end
     end
   end
@@ -49,7 +49,7 @@ RSpec.describe "Flash Message" do
         visit new_sake_path
         fill_in("sake_name", with: "生道井")
         click_button("form_submit")
-        expect(page).to have_selector(:test_id, "flash-message")
+        expect(page).to have_selector(:test_id, "flash_message")
       end
     end
 
@@ -58,7 +58,7 @@ RSpec.describe "Flash Message" do
         visit edit_sake_path(sake.id)
         fill_in("sake_name", with: "ほしいずみ")
         click_button("form_submit")
-        expect(page).to have_selector(:test_id, "flash-message")
+        expect(page).to have_selector(:test_id, "flash_message")
       end
     end
 
@@ -66,7 +66,7 @@ RSpec.describe "Flash Message" do
       it "has flash message" do
         visit sake_path(sake.id)
         accept_confirm do click_link("delete_sake") end
-        expect(page).to have_selector(:test_id, "flash-message")
+        expect(page).to have_selector(:test_id, "flash_message")
       end
     end
 
@@ -74,7 +74,7 @@ RSpec.describe "Flash Message" do
       it "has flash message" do
         visit sake_path(sake.id)
         click_link("copy_sake")
-        expect(page).to have_selector(:test_id, "flash-message")
+        expect(page).to have_selector(:test_id, "flash_message")
       end
     end
 
@@ -83,7 +83,7 @@ RSpec.describe "Flash Message" do
       it "has flash message" do
         visit sakes_path
         click_link("sign_out")
-        expect(page).to have_selector(:test_id, "flash-message")
+        expect(page).to have_selector(:test_id, "flash_message")
       end
     end
   end

--- a/spec/system/flash_message_spec.rb
+++ b/spec/system/flash_message_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "Flash Message" do
       it "has flash message" do
         visit new_sake_path
         fill_in("sake_name", with: "生道井")
-        click_button("form-submit")
+        click_button("form_submit")
         expect(page).to have_selector(:test_id, "flash-message")
       end
     end
@@ -57,7 +57,7 @@ RSpec.describe "Flash Message" do
       it "has flash message" do
         visit edit_sake_path(sake.id)
         fill_in("sake_name", with: "ほしいずみ")
-        click_button("form-submit")
+        click_button("form_submit")
         expect(page).to have_selector(:test_id, "flash-message")
       end
     end

--- a/spec/system/new_sake_spec.rb
+++ b/spec/system/new_sake_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "New Sake" do
 
     it "has success flash message" do
       text = I18n.t("sakes.create.success", name: sake_name)
-      expect(find(:test_id, "flash-message")).to have_text(text)
+      expect(find(:test_id, "flash_message")).to have_text(text)
     end
 
     it "has specified sake name" do
@@ -28,7 +28,7 @@ RSpec.describe "New Sake" do
 
     it "has flash message containing link to created sake" do
       # 酒のIDが不明なため、フラッシュメッセージのリンク先が現在のパスと同じことを確認する
-      expect(find(:test_id, "flash-message")).to have_link(sake_name, href: current_path)
+      expect(find(:test_id, "flash_message")).to have_link(sake_name, href: current_path)
     end
   end
 end

--- a/spec/system/new_sake_spec.rb
+++ b/spec/system/new_sake_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "New Sake" do
       sign_in(user)
       visit new_sake_path
       fill_in("sake_name", with: sake_name)
-      click_button("form-submit")
+      click_button("form_submit")
     end
 
     it "has success flash message" do

--- a/spec/system/sake_form_bindume_date_spec.rb
+++ b/spec/system/sake_form_bindume_date_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Sake Form Bindume Date", type: :system do
       before do
         year = with_japanese_era(Time.current)
         select(year, from: "sake_bindume_year")
-        click_button("form-submit")
+        click_button("form_submit")
       end
 
       it "makes a sake whoes bindume year is current year" do
@@ -32,7 +32,7 @@ RSpec.describe "Sake Form Bindume Date", type: :system do
       before do
         year = with_japanese_era(ago)
         select(year, from: "sake_bindume_year")
-        click_button("form-submit")
+        click_button("form_submit")
       end
 
       it "makes a sake whoes bindume year is 10 years ago" do
@@ -47,7 +47,7 @@ RSpec.describe "Sake Form Bindume Date", type: :system do
       before do
         month = I18n.l(Time.zone.parse("2022-01-01 10:30:00"), format: "%b")
         select(month, from: "sake_bindume_month")
-        click_button("form-submit")
+        click_button("form_submit")
       end
 
       it "makes a sake whoes bindume month is January" do
@@ -60,7 +60,7 @@ RSpec.describe "Sake Form Bindume Date", type: :system do
       before do
         month = I18n.l(Time.zone.parse("2022-12-01 10:30:00"), format: "%b")
         select(month, from: "sake_bindume_month")
-        click_button("form-submit")
+        click_button("form_submit")
       end
 
       it "makes a sake whoes bindume month is December" do

--- a/spec/system/sake_form_bottle_level_spec.rb
+++ b/spec/system/sake_form_bottle_level_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Sake Form Bottle Level" do
     it "updates bottle level to open" do
       visit edit_sake_path(sealed_sake.id)
       select(I18n.t("enums.sake.bottle_level.opened"), from: "sake_bottle_level")
-      click_button("form-submit")
+      click_button("form_submit")
       expect { sealed_sake.reload }.to change(sealed_sake, :bottle_level).from("sealed").to("opened")
     end
   end
@@ -23,7 +23,7 @@ RSpec.describe "Sake Form Bottle Level" do
     it "updates bottle level to empty" do
       visit edit_sake_path(sealed_sake.id)
       select(I18n.t("enums.sake.bottle_level.empty"), from: "sake_bottle_level")
-      click_button("form-submit")
+      click_button("form_submit")
       expect { sealed_sake.reload }.to change(sealed_sake, :bottle_level).from("sealed").to("empty")
     end
   end
@@ -32,7 +32,7 @@ RSpec.describe "Sake Form Bottle Level" do
     it "updates bottle level to empty" do
       visit edit_sake_path(opened_sake.id)
       select(I18n.t("enums.sake.bottle_level.empty"), from: "sake_bottle_level")
-      click_button("form-submit")
+      click_button("form_submit")
       expect { opened_sake.reload }.to change(opened_sake, :bottle_level).from("opened").to("empty")
     end
   end
@@ -41,7 +41,7 @@ RSpec.describe "Sake Form Bottle Level" do
     it "updates bottle level to sealed" do
       visit edit_sake_path(empty_sake.id)
       select(I18n.t("enums.sake.bottle_level.sealed"), from: "sake_bottle_level")
-      click_button("form-submit")
+      click_button("form_submit")
       expect { empty_sake.reload }.to change(empty_sake, :bottle_level).from("empty").to("sealed")
     end
   end
@@ -50,7 +50,7 @@ RSpec.describe "Sake Form Bottle Level" do
     it "updates bottle level to opened" do
       visit edit_sake_path(empty_sake.id)
       select(I18n.t("enums.sake.bottle_level.opened"), from: "sake_bottle_level")
-      click_button("form-submit")
+      click_button("form_submit")
       expect { empty_sake.reload }.to change(empty_sake, :bottle_level).from("empty").to("opened")
     end
   end
@@ -59,7 +59,7 @@ RSpec.describe "Sake Form Bottle Level" do
     it "updates bottle level to sealed" do
       visit edit_sake_path(opened_sake.id)
       select(I18n.t("enums.sake.bottle_level.sealed"), from: "sake_bottle_level")
-      click_button("form-submit")
+      click_button("form_submit")
       expect { opened_sake.reload }.to change(opened_sake, :bottle_level).from("opened").to("sealed")
     end
   end

--- a/spec/system/sake_form_datetime_spec.rb
+++ b/spec/system/sake_form_datetime_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Sake Form Date Time" do
 
     context "for sealed sake" do
       it "creates the sake whoes created_at is close to now" do
-        click_button("form-submit")
+        click_button("form_submit")
         created_at = sake_from_show_path(page.current_path).created_at
         now = Time.current
         expect(created_at).to be_within(delta).of(now)
@@ -27,7 +27,7 @@ RSpec.describe "Sake Form Date Time" do
     context "for opened sake" do
       before do
         select(I18n.t("enums.sake.bottle_level.opened"), from: "sake_bottle_level")
-        click_button("form-submit")
+        click_button("form_submit")
       end
 
       it "creates the sake whoes created_at is close to now" do
@@ -46,7 +46,7 @@ RSpec.describe "Sake Form Date Time" do
     context "for emptied sake" do
       before do
         select(I18n.t("enums.sake.bottle_level.empty"), from: "sake_bottle_level")
-        click_button("form-submit")
+        click_button("form_submit")
       end
 
       it "creates the sake whoes created_at is close to now" do
@@ -76,7 +76,7 @@ RSpec.describe "Sake Form Date Time" do
     before do
       visit edit_sake_path(sake.id)
       select(I18n.t("enums.sake.bottle_level.opened"), from: "sake_bottle_level")
-      click_button("form-submit")
+      click_button("form_submit")
     end
 
     it "does not change created_at" do

--- a/spec/system/sake_form_photos_spec.rb
+++ b/spec/system/sake_form_photos_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Sake Form Photos", type: :system do
       before do
         photo1 = Rails.root.join("spec/system/files/sake_photo1.jpg")
         attach_file("sake_photos", photo1)
-        click_button("form-submit")
+        click_button("form_submit")
       end
 
       it "makes a sake having one photo" do
@@ -28,7 +28,7 @@ RSpec.describe "Sake Form Photos", type: :system do
         photo1 = Rails.root.join("spec/system/files/sake_photo1.jpg")
         photo2 = Rails.root.join("spec/system/files/sake_photo2.jpg")
         attach_file("sake_photos", [photo1, photo2])
-        click_button("form-submit")
+        click_button("form_submit")
       end
 
       it "makes a sake having two photos" do
@@ -39,7 +39,7 @@ RSpec.describe "Sake Form Photos", type: :system do
 
     context "without photos" do
       before do
-        click_button("form-submit")
+        click_button("form_submit")
       end
 
       it "makes a sake not having any photos" do

--- a/spec/system/sake_form_validation_spec.rb
+++ b/spec/system/sake_form_validation_spec.rb
@@ -31,12 +31,18 @@ RSpec.describe "Sake Form Validation" do
     end
   end
 
-  # describe "name" do
-  #   context "with empty string" do
-  #     it "" do
-  #     end
-  #   end
-  # end
+  describe "name", js: true do
+    context "with empty string" do
+      before do
+        fill_in("sake_name", with: "")
+        click_button("form_submit")
+      end
+
+      it "do not move page" do
+        expect(page).to have_current_path(new_sake_path)
+      end
+    end
+  end
 
   describe "alcohol" do
     context "with minus value" do

--- a/spec/system/sake_form_validation_spec.rb
+++ b/spec/system/sake_form_validation_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe "Sake Form Validation" do
         expect(find(:test_id, "sake_alcohol").first(:xpath, "..")).to have_css(".is-invalid")
       end
 
-      it "is with error message" do
+      it "has error message" do
         expect(page).to have_selector(:test_id, "sake_alcohol_feedback")
       end
     end
@@ -70,7 +70,7 @@ RSpec.describe "Sake Form Validation" do
         expect(find(:test_id, "sake_alcohol").first(:xpath, "..")).to have_css(".is-invalid")
       end
 
-      it "is with error message" do
+      it "has error message" do
         expect(page).to have_selector(:test_id, "sake_alcohol_feedback")
       end
     end
@@ -87,7 +87,7 @@ RSpec.describe "Sake Form Validation" do
         expect(find(:test_id, "sake_seimai_buai").first(:xpath, "..")).to have_css(".is-invalid")
       end
 
-      it "is with error message" do
+      it "has error message" do
         expect(page).to have_selector(:test_id, "sake_seimai_buai_feedback")
       end
     end
@@ -102,7 +102,7 @@ RSpec.describe "Sake Form Validation" do
         expect(find(:test_id, "sake_seimai_buai").first(:xpath, "..")).to have_css(".is-invalid")
       end
 
-      it "is with error message" do
+      it "has error message" do
         expect(page).to have_selector(:test_id, "sake_seimai_buai_feedback")
       end
     end
@@ -119,7 +119,7 @@ RSpec.describe "Sake Form Validation" do
         expect(find(:test_id, "sake_size").first(:xpath, "..")).to have_css(".is-invalid")
       end
 
-      it "is with error message" do
+      it "has error message" do
         expect(page).to have_selector(:test_id, "sake_size_feedback")
       end
     end
@@ -136,7 +136,7 @@ RSpec.describe "Sake Form Validation" do
         expect(find(:test_id, "sake_price").first(:xpath, "..")).to have_css(".is-invalid")
       end
 
-      it "is with error message" do
+      it "has error message" do
         expect(page).to have_selector(:test_id, "sake_price_feedback")
       end
     end
@@ -153,7 +153,7 @@ RSpec.describe "Sake Form Validation" do
         expect(find(:test_id, "sake_sando").first(:xpath, "..")).to have_css(".is-invalid")
       end
 
-      it "is with error message" do
+      it "has error message" do
         expect(page).to have_selector(:test_id, "sake_sando_feedback")
       end
     end
@@ -170,7 +170,7 @@ RSpec.describe "Sake Form Validation" do
         expect(find(:test_id, "sake_aminosando").first(:xpath, "..")).to have_css(".is-invalid")
       end
 
-      it "is with error message" do
+      it "has error message" do
         expect(page).to have_selector(:test_id, "sake_aminosando_feedback")
       end
     end

--- a/spec/system/sake_form_validation_spec.rb
+++ b/spec/system/sake_form_validation_spec.rb
@@ -1,0 +1,172 @@
+require "rails_helper"
+
+RSpec.describe "Sake Form Validation" do
+  let(:user) { create(:user) }
+
+  before do
+    sign_in(user)
+    visit new_sake_path
+    fill_in("sake_name", with: "生道井")
+  end
+
+  describe "flash message" do
+    context "with invalid value" do
+      before do
+        fill_in("sake_alcohol", with: "-10")
+        click_button("form_submit")
+      end
+
+      it "has flash message" do
+        expect(page).to have_selector(:test_id, "flash_message")
+      end
+
+      it "has error flash message" do
+        expect(page).to have_css(".alert-danger")
+      end
+
+      it "has error message" do
+        text = I18n.t("sakes.form.input_error")
+        expect(find(:test_id, "flash_message")).to have_text(text)
+      end
+    end
+  end
+
+  # describe "name" do
+  #   context "with empty string" do
+  #     it "" do
+  #     end
+  #   end
+  # end
+
+  describe "alcohol" do
+    context "with minus value" do
+      before do
+        fill_in("sake_alcohol", with: "-1")
+        click_button("form_submit")
+      end
+
+      it "has style for invalid" do
+        expect(find(:test_id, "sake_alcohol").first(:xpath, "..")).to have_css(".is-invalid")
+      end
+
+      it "is with error message" do
+        expect(page).to have_selector(:test_id, "sake_alcohol_feedback")
+      end
+    end
+
+    context "with value over 100" do
+      before do
+        fill_in("sake_alcohol", with: "101")
+        click_button("form_submit")
+      end
+
+      it "has style for invalid" do
+        expect(find(:test_id, "sake_alcohol").first(:xpath, "..")).to have_css(".is-invalid")
+      end
+
+      it "is with error message" do
+        expect(page).to have_selector(:test_id, "sake_alcohol_feedback")
+      end
+    end
+  end
+
+  describe "seimai_buai" do
+    context "with minus value" do
+      before do
+        fill_in("sake_seimai_buai", with: "-1")
+        click_button("form_submit")
+      end
+
+      it "has style for invalid" do
+        expect(find(:test_id, "sake_seimai_buai").first(:xpath, "..")).to have_css(".is-invalid")
+      end
+
+      it "is with error message" do
+        expect(page).to have_selector(:test_id, "sake_seimai_buai_feedback")
+      end
+    end
+
+    context "with value over 100" do
+      before do
+        fill_in("sake_seimai_buai", with: "101")
+        click_button("form_submit")
+      end
+
+      it "has style for invalid" do
+        expect(find(:test_id, "sake_seimai_buai").first(:xpath, "..")).to have_css(".is-invalid")
+      end
+
+      it "is with error message" do
+        expect(page).to have_selector(:test_id, "sake_seimai_buai_feedback")
+      end
+    end
+  end
+
+  describe "size" do
+    context "with minus value" do
+      before do
+        fill_in("sake_size", with: "-1")
+        click_button("form_submit")
+      end
+
+      it "has style for invalid" do
+        expect(find(:test_id, "sake_size").first(:xpath, "..")).to have_css(".is-invalid")
+      end
+
+      it "is with error message" do
+        expect(page).to have_selector(:test_id, "sake_size_feedback")
+      end
+    end
+  end
+
+  describe "price" do
+    context "with minus value" do
+      before do
+        fill_in("sake_price", with: "-1")
+        click_button("form_submit")
+      end
+
+      it "has style for invalid" do
+        expect(find(:test_id, "sake_price").first(:xpath, "..")).to have_css(".is-invalid")
+      end
+
+      it "is with error message" do
+        expect(page).to have_selector(:test_id, "sake_price_feedback")
+      end
+    end
+  end
+
+  describe "sando" do
+    context "with minus value" do
+      before do
+        fill_in("sake_sando", with: "-1.0")
+        click_button("form_submit")
+      end
+
+      it "has style for invalid" do
+        expect(find(:test_id, "sake_sando").first(:xpath, "..")).to have_css(".is-invalid")
+      end
+
+      it "is with error message" do
+        expect(page).to have_selector(:test_id, "sake_sando_feedback")
+      end
+    end
+  end
+
+  describe "aminosando" do
+    context "with minus value" do
+      before do
+        fill_in("sake_aminosando", with: "-1.0")
+        click_button("form_submit")
+      end
+
+      it "has style for invalid" do
+        expect(find(:test_id, "sake_aminosando").first(:xpath, "..")).to have_css(".is-invalid")
+      end
+
+      it "is with error message" do
+        expect(page).to have_selector(:test_id, "sake_aminosando_feedback")
+      end
+    end
+  end
+end

--- a/spec/system/sake_form_validation_spec.rb
+++ b/spec/system/sake_form_validation_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "Sake Form Validation" do
   end
 
   describe "alcohol" do
-    context "with minus value" do
+    context "with negative value" do
       before do
         fill_in("sake_alcohol", with: "-1")
         click_button("form_submit")
@@ -77,7 +77,7 @@ RSpec.describe "Sake Form Validation" do
   end
 
   describe "seimai_buai" do
-    context "with minus value" do
+    context "with negative value" do
       before do
         fill_in("sake_seimai_buai", with: "-1")
         click_button("form_submit")
@@ -109,7 +109,7 @@ RSpec.describe "Sake Form Validation" do
   end
 
   describe "size" do
-    context "with minus value" do
+    context "with negative value" do
       before do
         fill_in("sake_size", with: "-1")
         click_button("form_submit")
@@ -126,7 +126,7 @@ RSpec.describe "Sake Form Validation" do
   end
 
   describe "price" do
-    context "with minus value" do
+    context "with negative value" do
       before do
         fill_in("sake_price", with: "-1")
         click_button("form_submit")
@@ -143,7 +143,7 @@ RSpec.describe "Sake Form Validation" do
   end
 
   describe "sando" do
-    context "with minus value" do
+    context "with negative value" do
       before do
         fill_in("sake_sando", with: "-1.0")
         click_button("form_submit")
@@ -160,7 +160,7 @@ RSpec.describe "Sake Form Validation" do
   end
 
   describe "aminosando" do
-    context "with minus value" do
+    context "with negative value" do
       before do
         fill_in("sake_aminosando", with: "-1.0")
         click_button("form_submit")


### PR DESCRIPTION
close #463 

フラッシュメッセージを改変するのはやめだ。
Bootstrapに従うんだ！

## 動作の様子

### 空欄禁止の名前とサイズ

サブミットボタンを押しても、画面遷移は行われない。
ブラウザが判定してメッセージを出す。

![image](https://user-images.githubusercontent.com/849256/162611105-d38e4491-a8a5-4e4f-9515-00fd380a4f1f.png)

### 他の入力エラー

フォーム直下にエラーメッセージが表示される。

![image](https://user-images.githubusercontent.com/849256/162611158-52d1f5d1-75c3-40c1-b41c-27cd97050814.png)

## やったこと

- HTML5のinput required属性を使って酒フォームの入力必須値を設定した
- 入力フォームエラーが起きたとき、フォーム直下にBootstrapのvalidationスタイルでエラー内容を表示する
  - configを変更して、Railsの`field_with_errors`スタイル付加されたdivタグを作らないようにした
  - 代わりに、Bootstrapの`is-invalid`をスタイルに追加する
- あとからだけど、テストも追加した！

## やってないこと

- Deviseの複数エラーの対応はまだ → Issue #102
- Devコンソールを使わないと起こせないバリデーションエラーはエラー内容表示をしない
  - 例えば香りの値の入力制限をわざわざ消してから"-1"にセットする、など