### PR TITLE
酒indexのデザイン変更前のリファクタ

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,14 +7,6 @@ h1 {
   @extend .mt-2;
 }
 
-.click-transparent {
-  pointer-events: none;
-}
-
-.click-nontransparent {
-  pointer-events: all;
-}
-
 // ------ header ------
 
 .sakazuki-header-logo {
@@ -35,13 +27,15 @@ h1 {
 
 .float-button {
   @extend .fixed-bottom;
-  @extend .click-transparent;
   @extend .mb-lg-4;
   @extend .mb-2;
 
+  // click transparent
+  pointer-events: none;
+
   a,
   button {
-    @extend .click-nontransparent;
+    pointer-events: all;
   }
 }
 

--- a/app/views/sakes/_drink-button.html.erb
+++ b/app/views/sakes/_drink-button.html.erb
@@ -5,12 +5,12 @@
                 { method: :patch,
                   data: { confirm: t(".confirm_open") },
                   class: "bg-primary",
-                  "data-testid": "open-button-#{sake.id}", }) %>
+                  "data-testid": "open_button_#{sake.id}", }) %>
   </div>
 <% end %>
 <% if sake.unimpressed? %>
   <% p = sake.sealed? ? { sake: { bottle_level: "opened" } } : {} %>
-  <% testid = sake.sealed? ? "open-and-impress-button-#{sake.id}" : "impress-button-#{sake.id}" %>
+  <% testid = sake.sealed? ? "open_and_impress_button_#{sake.id}" : "impress_button_#{sake.id}" %>
   <div class="drink-button">
     <%= link_to(tag.i(class: "bi-cup-fill", style: "font-size: 1em;") + t(".impress"),
                 edit_sake_path(sake, params: p),
@@ -25,6 +25,6 @@
                 { method: :patch,
                   data: { confirm: t(".confirm_empty") },
                   class: "bg-light border border-dark text-dark",
-                  "data-testid": "empty-button-#{sake.id}", }) %>
+                  "data-testid": "empty_button_#{sake.id}", }) %>
   </div>
 <% end %>

--- a/app/views/sakes/_rating.html.erb
+++ b/app/views/sakes/_rating.html.erb
@@ -1,13 +1,13 @@
 <% if rating == 0 %>
   <% 5.times do %>
     <%# 未評価 %>
-    <i class="bi-star text-light fs-3"></i>
+    <i class="bi-star text-light"></i>
   <% end %>
 <% else %>
   <% rating.times do %>
-    <i class="bi-star-fill text-primary fs-3"></i>
+    <i class="bi-star-fill text-primary"></i>
   <% end %>
   <% (5 - rating).times do %>
-    <i class="bi-star-fill text-light fs-3"></i>
+    <i class="bi-star-fill text-light"></i>
   <% end %>
 <% end %>

--- a/app/views/sakes/_show_review.html.erb
+++ b/app/views/sakes/_show_review.html.erb
@@ -3,7 +3,7 @@
     <h2 class="fs-3 mb-0"><%= t(".review") %></h2>
   </div>
 
-  <div class="col-12" data-testid="rating">
+  <div class="col-12 fs-3" data-testid="rating">
     <%= render("rating", rating: @sake.rating) %>
   </div>
 

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -5,51 +5,54 @@
 
 <h1><%= title("#{t('.title')} - #{to_shakkan(Sake.alcohol_stock(include_empty: include_empty?(params)))}") %></h1>
 
-<%= search_form_for(@searched, { class: "row my-2 align-items-center" }) do |f| %>
-  <div class="col input-group">
-    <%= f.label(:all_text_cont, "search word", class: "form-label visually-hidden") %>
-    <%= f.search_field(:all_text_cont,
-                       { class: "form-control",
-                         value: params.dig(:q, :all_text_cont), }) %>
-    <%= tag.button(tag.i(class: "bi-search"),
-                   type: "submit",
-                   class: "input-group-text btn btn-primary", "data-testid": "submit_search") %>
-  </div>
-
-  <div class="col-auto">
-    <div class="form-check form-switch">
-      <%= f.check_box(:bottle_level_not_eq,
-                      { class: "form-check-input",
-                        id: "all_bottle_level",
-                        "data-testid": "check_empty_bottle",
-                        onChange: "this.form.submit()", },
-                      bottom_bottle,
-                      Sake.bottle_levels["empty"]) %>
-      <%= f.label(t(".all_bottles"),
-                  { class: "form-check-label",
-                    for: "all_bottle_level", }) %>
+<%= search_form_for(@searched) do |f| %>
+  <div class="row my-2 align-items-center">
+    <div class="col input-group">
+      <%= f.label(:all_text_cont, "search word", class: "form-label visually-hidden") %>
+      <%= f.search_field(:all_text_cont,
+                         class: "form-control",
+                         value: params.dig(:q, :all_text_cont)) %>
+      <%= tag.button(tag.i(class: "bi-search"),
+                     type: "submit",
+                     class: "btn btn-primary",
+                     data: { testid: "submit_search" }) %>
     </div>
-  </div>
 
-  <div class="col-lg mt-lg-0 col-12 mt-2">
-    <div class="btn-group float-lg-end" role="group" aria-label="Sort">
-      <%= sort_link(@searched,
-                    :tokutei_meisho,
-                    t("activerecord.attributes.sake.tokutei_meisho")) %>
-      <%= sort_link(@searched,
-                    :todofuken,
-                    t("activerecord.attributes.sake.todofuken")) %>
-      <%= sort_link(@searched,
-                    :bottle_level,
-                    t("activerecord.attributes.sake.bottle_level")) %>
-      <%= sort_link(@searched,
-                    :taste_value,
-                    t("activerecord.attributes.sake.taste_impression"),
-                    default_order: :desc) %>
-      <%= sort_link(@searched,
-                    :aroma_value,
-                    t("activerecord.attributes.sake.aroma_impression"),
-                    default_order: :desc) %>
+    <div class="col-auto">
+      <div class="form-check form-switch">
+        <%= f.check_box(:bottle_level_not_eq,
+                        { class: "form-check-input",
+                          id: "all_bottle_level",
+                          data: { testid: "check_empty_bottle" },
+                          onChange: "this.form.submit()", },
+                        bottom_bottle,
+                        Sake.bottle_levels["empty"]) %>
+        <%= f.label(t(".all_bottles"),
+                    class: "form-check-label",
+                    for: "all_bottle_level") %>
+      </div>
+    </div>
+
+    <div class="col-lg mt-lg-0 col-12 mt-2">
+      <div class="btn-group float-lg-end" role="group" aria-label="Sort">
+        <%= sort_link(@searched,
+                      :tokutei_meisho,
+                      t("activerecord.attributes.sake.tokutei_meisho")) %>
+        <%= sort_link(@searched,
+                      :todofuken,
+                      t("activerecord.attributes.sake.todofuken")) %>
+        <%= sort_link(@searched,
+                      :bottle_level,
+                      t("activerecord.attributes.sake.bottle_level")) %>
+        <%= sort_link(@searched,
+                      :taste_value,
+                      t("activerecord.attributes.sake.taste_impression"),
+                      default_order: :desc) %>
+        <%= sort_link(@searched,
+                      :aroma_value,
+                      t("activerecord.attributes.sake.aroma_impression"),
+                      default_order: :desc) %>
+      </div>
     </div>
   </div>
 <% end %>

--- a/spec/system/drink_buttons_spec.rb
+++ b/spec/system/drink_buttons_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe "Drink Buttons" do
 
     describe "clicking impress button of opened bottle" do
       it "redirects to user login page" do
-        id = "impress-button-#{opened_sake.id}"
+        id = "impress_button_#{opened_sake.id}"
         click_link id
         expect(page).to have_current_path new_user_session_path
       end
@@ -105,7 +105,7 @@ RSpec.describe "Drink Buttons" do
 
     describe "clicking open button of sealed bottle", js: true do
       before do
-        id = "open-button-#{sealed_sake.id}"
+        id = "open_button_#{sealed_sake.id}"
         accept_confirm do
           click_link id
         end
@@ -124,7 +124,7 @@ RSpec.describe "Drink Buttons" do
 
     describe "clicking empty button of impressed bottle", js: true do
       before do
-        id = "empty-button-#{impressed_sake.id}"
+        id = "empty_button_#{impressed_sake.id}"
         accept_confirm do
           click_link id
         end
@@ -149,7 +149,7 @@ RSpec.describe "Drink Buttons" do
 
     describe "clicking impress button of sealed bottle" do
       before do
-        id = "open-and-impress-button-#{sealed_sake.id}"
+        id = "open_and_impress_button_#{sealed_sake.id}"
         click_link id
       end
 
@@ -168,7 +168,7 @@ RSpec.describe "Drink Buttons" do
 
     describe "clicking impress button of opened bottle" do
       before do
-        id = "impress-button-#{opened_sake.id}"
+        id = "impress_button_#{opened_sake.id}"
         click_link id
       end
 
@@ -187,7 +187,7 @@ RSpec.describe "Drink Buttons" do
     describe "clicking open button of sealed bottle", js: true do
       before do
         accept_confirm do
-          click_link "open-button-#{sealed_sake.id}"
+          click_link "open_button_#{sealed_sake.id}"
         end
         wait_for_alert
       end
@@ -215,7 +215,7 @@ RSpec.describe "Drink Buttons" do
     describe "clicking empty button of impressed bottle", js: true do
       before do
         accept_confirm do
-          click_link "empty-button-#{impressed_sake.id}"
+          click_link "empty_button_#{impressed_sake.id}"
         end
         wait_for_alert
       end

--- a/spec/system/sign_in_redirect_by_drinkbutton_spec.rb
+++ b/spec/system/sign_in_redirect_by_drinkbutton_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Sign-in Redirect by Drink Buttons" do
   describe "impress button" do
     it "redirects edit page after sign in" do
       id = sealed_sake.id
-      click_link("open-and-impress-button-#{id}")
+      click_link("open_and_impress_button_#{id}")
       signin_process_on_signin_page(user)
       # クエリ "?sake[bottle_level]=opened" 部を無視する
       expect(page).to have_current_path(edit_sake_path(id), ignore_query: true)
@@ -23,7 +23,7 @@ RSpec.describe "Sign-in Redirect by Drink Buttons" do
   describe "open button of sealed sake" do
     it "redirects index page after sign in", js: true do
       id = sealed_sake.id
-      accept_confirm do click_link("open-button-#{id}") end
+      accept_confirm do click_link("open_button_#{id}") end
       wait_for_page new_user_session_path
       signin_process_on_signin_page(user)
       expect(page).to have_current_path(sakes_path)
@@ -33,7 +33,7 @@ RSpec.describe "Sign-in Redirect by Drink Buttons" do
   describe "empty button" do
     it "redirects index page after sign in", js: true do
       id = impressed_sake.id
-      accept_confirm do click_link("empty-button-#{id}") end
+      accept_confirm do click_link("empty_button_#{id}") end
       wait_for_page new_user_session_path
       signin_process_on_signin_page(user)
       expect(page).to have_current_path(sakes_path)


### PR DESCRIPTION
Issue #405 やる前の準備

## やったこと

- 酒indexの検索フォームをリファクタ
  - rowの構成見直し
  - data-testidの指定方法を揃えた
  - 必要ないハッシュを削除
- 酒viewのrating内でのフォントサイズ指定を行わないようにした
  - 他の箇所からもratingを呼び出すのに便利
- 必要ない@extendを削除した
  - 1要素を別名保存しても意味ないね
- drink-buttonのtestidをアンダーバー化した
  - 徐々にハイフン繋がりのtestidを駆逐していく