### PR TITLE
酒indexのデザインを新しくした！

### DIFF
--- a/app/assets/stylesheets/sakes_index.scss
+++ b/app/assets/stylesheets/sakes_index.scss
@@ -29,3 +29,8 @@
 .dropdown-toggle::after {
   display: none;
 }
+
+.card-footer {
+  background-color: $gray-100;
+  border-top: none;
+}

--- a/app/assets/stylesheets/sakes_index.scss
+++ b/app/assets/stylesheets/sakes_index.scss
@@ -9,6 +9,12 @@
 }
 // stylelint-enable selector-class-pattern
 
+.name-link {
+  @extend .text-primary;
+
+  text-decoration-line: none;
+}
+
 .dropdown-menu {
   a {
     @extend .dropdown-item;

--- a/app/assets/stylesheets/sakes_index.scss
+++ b/app/assets/stylesheets/sakes_index.scss
@@ -1,11 +1,6 @@
 @import "./bootstrap/custom";
 @import "bootstrap/scss/bootstrap";
 
-.name-link {
-  font-size: 1.1em;
-  font-weight: 600;
-}
-
 // Ransackが生成するスタイル
 // stylelint-disable selector-class-pattern
 .btn-group .sort_link {
@@ -14,19 +9,17 @@
 }
 // stylelint-enable selector-class-pattern
 
-.drink-button {
-  @extend .col-auto;
-  @extend .pe-0;
-  @extend .d-flex;
-  @extend .align-items-center;
-
+.dropdown-menu {
   a {
-    @extend .badge;
-    @extend .rounded-pill;
-    @extend .text-decoration-none;
+    @extend .dropdown-item;
 
     i {
-      @extend .me-1;
+      @extend .me-2;
     }
   }
+}
+
+// drink-buttonのトグルボタンの三角を消す
+.dropdown-toggle::after {
+  display: none;
 }

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -28,3 +28,9 @@ collapseElementList.forEach((element) => {
   /* eslint-disable-next-line no-undef */
   new Collapse(element)
 })
+
+const dropdownElementList = document.querySelectorAll(".dropdown-toggle")
+dropdownElementList.forEach((element) => {
+  /* eslint-disable-next-line no-undef */
+  new Dropdown(element)
+})

--- a/app/javascript/taste_graph/taste_graph.ts
+++ b/app/javascript/taste_graph/taste_graph.ts
@@ -191,6 +191,8 @@ export class TasteGraph implements InteractiveGraph {
       elements: { point: { radius: defaultedConfig.pointRadius } },
       // HACK: ダミーの軸を使って高低両方にラベルをつける
       scales: { xAxes: [xAxe, dummyXAxe], yAxes: [yAxe, dummyYAxe] },
+      responsive: true,
+      maintainAspectRatio: false,
     }
     // 各4象限を別々に色付けする
     // https://github.com/chartjs/Chart.js/issues/3535

--- a/app/views/sakes/_drink-button.html.erb
+++ b/app/views/sakes/_drink-button.html.erb
@@ -1,6 +1,6 @@
 <% if sake.sealed? %>
   <li>
-    <%= link_to(tag.i(class: "bi-droplet-half", style: "font-size: 0.95em") + t(".open"),
+    <%= link_to(tag.i(class: "bi-droplet-half", style: "font-size: 0.95em;") + t(".open"),
                 sake_path(sake, params: { sake: { bottle_level: "opened" }, flash_message_type: "open" }),
                 data: { method: :patch, confirm: t(".confirm_open"), testid: "open_button_#{sake.id}" }) %>
   </li>

--- a/app/views/sakes/_drink-button.html.erb
+++ b/app/views/sakes/_drink-button.html.erb
@@ -1,30 +1,23 @@
 <% if sake.sealed? %>
-  <div class="drink-button">
-    <%= link_to(tag.i(class: "bi-droplet-half", style: "font-size: 0.95em;") + t(".open"),
+  <li>
+    <%= link_to(tag.i(class: "bi-droplet-half", style: "font-size: 0.95em") + t(".open"),
                 sake_path(sake, params: { sake: { bottle_level: "opened" }, flash_message_type: "open" }),
-                { method: :patch,
-                  data: { confirm: t(".confirm_open") },
-                  class: "bg-primary",
-                  "data-testid": "open_button_#{sake.id}", }) %>
-  </div>
+                data: { method: :patch, confirm: t(".confirm_open"), testid: "open_button_#{sake.id}" }) %>
+  </li>
 <% end %>
 <% if sake.unimpressed? %>
   <% p = sake.sealed? ? { sake: { bottle_level: "opened" } } : {} %>
   <% testid = sake.sealed? ? "open_and_impress_button_#{sake.id}" : "impress_button_#{sake.id}" %>
-  <div class="drink-button">
+  <li>
     <%= link_to(tag.i(class: "bi-cup-fill", style: "font-size: 1em;") + t(".impress"),
                 edit_sake_path(sake, params: p),
-                { class: "bg-secondary border border-primary text-dark",
-                  "data-testid": testid, }) %>
-  </div>
+                data: { testid: }) %>
+  </li>
 <% end %>
 <% if sake.opened? %>
-  <div class="drink-button">
+  <li>
     <%= link_to(tag.i(class: "bi-droplet", style: "font-size: 0.95em;") + t(".empty"),
                 sake_path(sake, params: { sake: { bottle_level: "empty" }, flash_message_type: "empty" }),
-                { method: :patch,
-                  data: { confirm: t(".confirm_empty") },
-                  class: "bg-light border border-dark text-dark",
-                  "data-testid": "empty_button_#{sake.id}", }) %>
-  </div>
+                data: { method: :patch, confirm: t(".confirm_empty"), testid: "empty_button_#{sake.id}" }) %>
+  </li>
 <% end %>

--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -422,12 +422,14 @@
             </div>
           </div>
 
-          <div class="form-row ">
+          <div class="form-row">
             <%= form.label("#{t('activerecord.attributes.sake.taste_value')}, #{t('activerecord.attributes.sake.aroma_value')}",
                            { class: "col-lg-3 col-7 col-form-label" }) %>
             <%# MEMO: px-0だとchart.jsのグラフが描画されない %>
             <div class="col-lg-9 col-12 px-1">
-              <canvas id="taste_graph"></canvas>
+              <div class="ratio ratio-4x3">
+                <canvas id="taste_graph"></canvas>
+              </div>
               <%= form.number_field(:taste_value,
                                     id: "sake_taste_value",
                                     hidden: true,

--- a/app/views/sakes/_show_review.html.erb
+++ b/app/views/sakes/_show_review.html.erb
@@ -79,10 +79,12 @@
         </div>
       </div>
       <div class="col-lg-6 order-lg-2 col-12 order-1">
-        <canvas id="sake-<%= @sake.id %>"
-          data-taste-value="<%= @sake.taste_value %>"
-          data-aroma-value="<%= @sake.aroma_value %>">
-        </canvas>
+        <div class="ratio ratio-4x3">
+          <canvas id="sake-<%= @sake.id %>"
+            data-taste-value="<%= @sake.taste_value %>"
+            data-aroma-value="<%= @sake.aroma_value %>">
+          </canvas>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -71,8 +71,8 @@
                 <div class="col-auto pe-0">
                   <div class="dropdown" data-testid="sake_buttons_<%= sake.id %>">
                     <% id = "dropdownMenuSake#{sake.id}" %>
-                    <button class="btn btn-outline-light shadow-sm dropdown-toggle py-0 px-1 mx-2"
-                      type="button" id="<%= id %>" data-bs-toggle="dropdown" aria-expanded="false"
+                    <button class="btn dropdown-toggle py-0" type="button"
+                      id="<%= id %>" data-bs-toggle="dropdown" aria-expanded="false"
                       data-testid="dropdown_toggle_<%= sake.id %>">
                       <i class="bi-three-dots-vertical fs-5 text-primary"></i>
                     </button>

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -66,7 +66,7 @@
             <div class="col-12">
               <div class="row align-items-start">
                 <div class="col fs-5">
-                  <%= link_to(sake.name, sake_path(sake)) %>
+                  <%= link_to(sake.name, sake_path(sake), class: "name-link") %>
                 </div>
                 <div class="col-auto pe-0">
                   <div class="dropdown" data-testid="sake_buttons_<%= sake.id %>">
@@ -74,7 +74,7 @@
                     <button class="btn dropdown-toggle py-0" type="button"
                       id="<%= id %>" data-bs-toggle="dropdown" aria-expanded="false"
                       data-testid="dropdown_toggle_<%= sake.id %>">
-                      <i class="bi-three-dots-vertical fs-5"></i>
+                      <i class="bi-three-dots-vertical fs-5 text-primary"></i>
                     </button>
                     <ul class="dropdown-menu dropdown-menu-end fs-6" aria-labelledby="<%= id %>">
                       <li>

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -129,7 +129,7 @@
                 </canvas>
               </div>
             </div>
-            <div class="col-5 mt-3">
+            <div class="col-5 mt-3 align-self-center">
               <% if sake.photos.any? %>
                 <%= cl_image_tag(sake.photos.first.image.thumb.url, { class: "img-fulid img-thumbnail" }) %>
               <% end %>

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -71,8 +71,8 @@
                 <div class="col-auto pe-0">
                   <div class="dropdown" data-testid="sake_buttons_<%= sake.id %>">
                     <% id = "dropdownMenuSake#{sake.id}" %>
-                    <button class="btn dropdown-toggle py-0" type="button"
-                      id="<%= id %>" data-bs-toggle="dropdown" aria-expanded="false"
+                    <button class="btn btn-outline-light shadow-sm dropdown-toggle py-0 px-1 mx-2"
+                      type="button" id="<%= id %>" data-bs-toggle="dropdown" aria-expanded="false"
                       data-testid="dropdown_toggle_<%= sake.id %>">
                       <i class="bi-three-dots-vertical fs-5 text-primary"></i>
                     </button>

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -69,10 +69,11 @@
                   <%= link_to(sake.name, sake_path(sake)) %>
                 </div>
                 <div class="col-auto pe-0">
-                  <div class="dropdown">
+                  <div class="dropdown" data-testid="sake_buttons_<%= sake.id %>">
                     <% id = "dropdownMenuSake#{sake.id}" %>
                     <button class="btn dropdown-toggle py-0" type="button"
-                      id="<%= id %>" data-bs-toggle="dropdown" aria-expanded="false">
+                      id="<%= id %>" data-bs-toggle="dropdown" aria-expanded="false"
+                      data-testid="dropdown_toggle_<%= sake.id %>">
                       <i class="bi-three-dots-vertical fs-5"></i>
                     </button>
                     <ul class="dropdown-menu dropdown-menu-end fs-6" aria-labelledby="<%= id %>">

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -84,7 +84,7 @@
                       <li>
                         <hr class="dropdown-divider">
                       </li>
-                      <%= render("drink-button", sake:) %>
+                      <%= render(partial: "drink-button", locals: { sake: }) %>
                     </ul>
                   </div>
                 </div>
@@ -117,7 +117,7 @@
                         done: t(".#{sake.bottle_level}")) %>
                 </div>
                 <div class="col-12">
-                  <%= render("rating", rating: sake.rating, size_class: "") %>
+                  <%= render(partial: "rating", locals: { rating: sake.rating }) %>
                 </div>
               </div>
             </div>

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -57,52 +57,88 @@
   </div>
 <% end %>
 
-<table class="table table-bordered" caption="Sake List">
-  <tbody>
-    <% @sakes.each do |sake| %>
-      <tr class="row m-0">
-        <td class="col-lg-6 col-12">
-          <div class="row m-0 border-bottom">
-            <div class="col">
-              <%= link_to(sake.name, sake_path(sake), { class: "name-link" }) %>
+<div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-2">
+  <% @sakes.each do |sake| %>
+    <div class="col">
+      <div class="card h-100">
+        <div class="card-body py-2">
+          <div class="row g-2">
+            <div class="col-12">
+              <div class="row align-items-start">
+                <div class="col fs-5">
+                  <%= link_to(sake.name, sake_path(sake)) %>
+                </div>
+                <div class="col-auto pe-0">
+                  <div class="dropdown">
+                    <% id = "dropdownMenuSake#{sake.id}" %>
+                    <button class="btn dropdown-toggle py-0" type="button"
+                      id="<%= id %>" data-bs-toggle="dropdown" aria-expanded="false">
+                      <i class="bi-three-dots-vertical fs-5"></i>
+                    </button>
+                    <ul class="dropdown-menu dropdown-menu-end fs-6" aria-labelledby="<%= id %>">
+                      <li>
+                        <%= link_to(tag.i(class: "bi-pencil-square") + t(".edit"),
+                                    edit_sake_path(sake)) %>
+                      </li>
+                      <li>
+                        <hr class="dropdown-divider">
+                      </li>
+                      <%= render("drink-button", sake:) %>
+                    </ul>
+                  </div>
+                </div>
+                <div class="col-12">
+                  <% if sake.kura.present? %>
+                    <%= short_kura(sake.kura) %> ‒ <%= short_todofuken(sake.todofuken) %>
+                  <% end %>
+                </div>
+              </div>
             </div>
-            <div class="col-auto">
-              <%= link_to(tag.i(class: "bi-pencil-square me-2", style: "font-size: 1.05em;") + t(".edit"),
-                          edit_sake_path(sake),
-                          "data-testid": "sakes-index-edit-link") %>
+            <div class="col-7">
+              <div class="row">
+                <div class="col-12">
+                  <% if sake.tokutei_meisho == "none" %>
+                    <%= t(".tokutei_meisho_none") %>
+                  <% else %>
+                    <%= sake.tokutei_meisho_i18n %>
+                  <% end %>
+                </div>
+                <div class="col-12">
+                  <%= sake.season %>
+                </div>
+              </div>
             </div>
-          </div>
-          <div class="row m-0 mt-2 border-bottom">
-            <div class="col">
-              <%= sake.tokutei_meisho_i18n %>
+            <div class="col-5">
+              <div class="row">
+                <div class="col-12">
+                  <%= t(".time_ago",
+                        count: time_ago_in_words(latest_at(sake), include_seconds: true),
+                        done: t(".#{sake.bottle_level}")) %>
+                </div>
+                <div class="col-12">
+                  <%= render("rating", rating: sake.rating, size_class: "") %>
+                </div>
+              </div>
             </div>
-            <div class="col">
-              <%= sake.todofuken %>
-            </div>
-          </div>
-          <div class="row m-0 mt-2 border-bottom" data-testid="bottle-level-<%= sake.id %>">
-            <div class="col-auto">
-              <%= sake.bottle_level_i18n %>
-            </div>
-            <%= render("drink-button", sake:) %>
-          </div>
-        </td>
-        <td class="col-lg-4 col-8 px-0 py-1">
-          <canvas id="sake-<%= sake.id %>"
+            <div class="col-7 mt-3">
+              <div class="ratio ratio-4x3">
+                <canvas id="sake-<%= sake.id %>"
                   data-taste-value="<%= sake.taste_value %>"
                   data-aroma-value="<%= sake.aroma_value %>">
-          </canvas>
-        </td>
-        <td class="col-lg-2 col-4 p-0" style="text-align: center">
-          <% if sake.photos.any? %>
-            <%= cl_image_tag(sake.photos.first.image.thumb.url,
-                             { class: "img-fulid img-thumbnail" }) %>
-          <% end %>
-        </td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+                </canvas>
+              </div>
+            </div>
+            <div class="col-5 mt-3">
+              <% if sake.photos.any? %>
+                <%= cl_image_tag(sake.photos.first.image.thumb.url, { class: "img-fulid img-thumbnail" }) %>
+              <% end %>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  <% end %>
+</div>
 
 <% if include_empty?(params) %>
   <div class="d-none d-sm-block">

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -95,6 +95,11 @@
                 </div>
               </div>
             </div>
+          </div>
+        </div>
+        <%# HACK: 名前の長さによって揃わない要素を、footerを使って揃える %>
+        <div class="card-footer">
+          <div class="row">
             <div class="col-7">
               <div class="row">
                 <div class="col-12">

--- a/config/locales/views/sake.ja.yml
+++ b/config/locales/views/sake.ja.yml
@@ -4,6 +4,11 @@ ja:
       title: 日本酒リスト
       all_bottles: 空瓶を表示
       edit: 編集
+      tokutei_meisho_none: :sakes.show_abstract.tokutei_meisho_none
+      time_ago: :sakes.show_abstract.time_ago
+      sealed: :sakes.show_abstract.sealed
+      opened: :sakes.show_abstract.opened
+      empty: :sakes.show_abstract.empty
     show:
       delete: 削除
       confirm_delete: 本当に削除しますか？

--- a/spec/system/drink_buttons_spec.rb
+++ b/spec/system/drink_buttons_spec.rb
@@ -18,51 +18,51 @@ RSpec.describe "Drink Buttons" do
 
     describe "sealed bottle" do
       it "has open button with i18n text" do
-        id = "bottle-level-#{sealed_sake.id}"
+        id = "sake_buttons_#{sealed_sake.id}"
         expect(find(:test_id, id)).to have_text(open_text)
       end
 
       it "has impress button with i18n text" do
-        id = "bottle-level-#{sealed_sake.id}"
+        id = "sake_buttons_#{sealed_sake.id}"
         expect(find(:test_id, id)).to have_text(impress_text)
       end
 
       it "does not have empty button with i18n text" do
-        id = "bottle-level-#{sealed_sake.id}"
+        id = "sake_buttons_#{sealed_sake.id}"
         expect(find(:test_id, id)).to have_no_text(empty_text)
       end
     end
 
     describe "opened and unimpressed bottle" do
       it "does not have open button with i18n text" do
-        id = "bottle-level-#{opened_sake.id}"
+        id = "sake_buttons_#{opened_sake.id}"
         expect(find(:test_id, id)).to have_no_text(open_text)
       end
 
       it "has impress button with i18n text" do
-        id = "bottle-level-#{opened_sake.id}"
+        id = "sake_buttons_#{opened_sake.id}"
         expect(find(:test_id, id)).to have_text(impress_text)
       end
 
       it "has empty button with i18n text" do
-        id = "bottle-level-#{opened_sake.id}"
+        id = "sake_buttons_#{opened_sake.id}"
         expect(find(:test_id, id)).to have_text(empty_text)
       end
     end
 
     describe "opened and impressed bottle" do
       it "does not have open button with i18n text" do
-        id = "bottle-level-#{impressed_sake.id}"
+        id = "sake_buttons_#{impressed_sake.id}"
         expect(find(:test_id, id)).to have_no_text(open_text)
       end
 
       it "does not have impress button with i18n text" do
-        id = "bottle-level-#{impressed_sake.id}"
+        id = "sake_buttons_#{impressed_sake.id}"
         expect(find(:test_id, id)).to have_no_text(impress_text)
       end
 
       it "has empty button with i18n text" do
-        id = "bottle-level-#{impressed_sake.id}"
+        id = "sake_buttons_#{impressed_sake.id}"
         expect(find(:test_id, id)).to have_text(empty_text)
       end
     end
@@ -74,17 +74,17 @@ RSpec.describe "Drink Buttons" do
       end
 
       it "does not have open button with i18n text" do
-        id = "bottle-level-#{empty_sake.id}"
+        id = "sake_buttons_#{empty_sake.id}"
         expect(find(:test_id, id)).to have_no_text(open_text)
       end
 
       it "does not have impress button with i18n text" do
-        id = "bottle-level-#{empty_sake.id}"
+        id = "sake_buttons_#{empty_sake.id}"
         expect(find(:test_id, id)).to have_no_text(impress_text)
       end
 
       it "does not have empty button with i18n text" do
-        id = "bottle-level-#{empty_sake.id}"
+        id = "sake_buttons_#{empty_sake.id}"
         expect(find(:test_id, id)).to have_no_text(empty_text)
       end
     end
@@ -97,23 +97,23 @@ RSpec.describe "Drink Buttons" do
 
     describe "clicking impress button of opened bottle" do
       it "redirects to user login page" do
-        id = "impress_button_#{opened_sake.id}"
-        click_link id
-        expect(page).to have_current_path new_user_session_path
+        click_button "dropdown_toggle_#{opened_sake.id}"
+        click_link "impress_button_#{opened_sake.id}"
+        expect(page).to have_current_path(new_user_session_path)
       end
     end
 
     describe "clicking open button of sealed bottle", js: true do
       before do
-        id = "open_button_#{sealed_sake.id}"
+        click_button "dropdown_toggle_#{sealed_sake.id}"
         accept_confirm do
-          click_link id
+          click_link "open_button_#{sealed_sake.id}"
         end
         wait_for_page new_user_session_path
       end
 
       it "redirects to user login page" do
-        expect(page).to have_current_path new_user_session_path
+        expect(page).to have_current_path(new_user_session_path)
       end
 
       it "does not change bottle state after sign in" do
@@ -124,15 +124,15 @@ RSpec.describe "Drink Buttons" do
 
     describe "clicking empty button of impressed bottle", js: true do
       before do
-        id = "empty_button_#{impressed_sake.id}"
+        click_button "dropdown_toggle_#{impressed_sake.id}"
         accept_confirm do
-          click_link id
+          click_link "empty_button_#{impressed_sake.id}"
         end
         wait_for_page new_user_session_path
       end
 
       it "redirects to user login page" do
-        expect(page).to have_current_path new_user_session_path
+        expect(page).to have_current_path(new_user_session_path)
       end
 
       it "does not change bottle state after sign in" do
@@ -149,8 +149,8 @@ RSpec.describe "Drink Buttons" do
 
     describe "clicking impress button of sealed bottle" do
       before do
-        id = "open_and_impress_button_#{sealed_sake.id}"
-        click_link id
+        click_button "dropdown_toggle_#{sealed_sake.id}"
+        click_link "open_and_impress_button_#{sealed_sake.id}"
       end
 
       it "redirects to sake edit page" do
@@ -168,13 +168,13 @@ RSpec.describe "Drink Buttons" do
 
     describe "clicking impress button of opened bottle" do
       before do
-        id = "impress_button_#{opened_sake.id}"
-        click_link id
+        click_button "dropdown_toggle_#{opened_sake.id}"
+        click_link "impress_button_#{opened_sake.id}"
       end
 
       it "redirects to sake edit page" do
         path = edit_sake_path(opened_sake)
-        expect(page).to have_current_path path
+        expect(page).to have_current_path(path)
       end
 
       it "moves to edit page and keep 'opened' state" do
@@ -186,6 +186,7 @@ RSpec.describe "Drink Buttons" do
 
     describe "clicking open button of sealed bottle", js: true do
       before do
+        click_button "dropdown_toggle_#{sealed_sake.id}"
         accept_confirm do
           click_link "open_button_#{sealed_sake.id}"
         end
@@ -214,6 +215,7 @@ RSpec.describe "Drink Buttons" do
 
     describe "clicking empty button of impressed bottle", js: true do
       before do
+        click_button "dropdown_toggle_#{impressed_sake.id}"
         accept_confirm do
           click_link "empty_button_#{impressed_sake.id}"
         end

--- a/spec/system/sign_in_redirect_by_drinkbutton_spec.rb
+++ b/spec/system/sign_in_redirect_by_drinkbutton_spec.rb
@@ -21,9 +21,15 @@ RSpec.describe "Sign-in Redirect by Drink Buttons" do
   end
 
   describe "open button of sealed sake" do
-    it "redirects index page after sign in", js: true do
+    before do
       id = sealed_sake.id
-      accept_confirm do click_link("open_button_#{id}") end
+      click_button "dropdown_toggle_#{id}"
+      accept_confirm do
+        click_link("open_button_#{id}")
+      end
+    end
+
+    it "redirects index page after sign in", js: true do
       wait_for_page new_user_session_path
       signin_process_on_signin_page(user)
       expect(page).to have_current_path(sakes_path)
@@ -31,9 +37,15 @@ RSpec.describe "Sign-in Redirect by Drink Buttons" do
   end
 
   describe "empty button" do
-    it "redirects index page after sign in", js: true do
+    before do
       id = impressed_sake.id
-      accept_confirm do click_link("empty_button_#{id}") end
+      click_button "dropdown_toggle_#{id}"
+      accept_confirm do
+        click_link("empty_button_#{id}")
+      end
+    end
+
+    it "redirects index page after sign in", js: true do
       wait_for_page new_user_session_path
       signin_process_on_signin_page(user)
       expect(page).to have_current_path(sakes_path)

--- a/spec/views/sakes/index.html.erb_spec.rb
+++ b/spec/views/sakes/index.html.erb_spec.rb
@@ -2,26 +2,20 @@ require "rails_helper"
 
 # Capybaraを使うためにsystem specを指定する
 RSpec.describe "sakes/index", type: :system do
-  let(:user) { create(:user) }
   let!(:sake) { create(:sake) }
 
   describe "index page" do
     before do
-      sign_in(user)
       visit sakes_path
     end
 
-    it "has edit button" do
-      id = "sakes-index-edit-link"
-      text = I18n.t("sakes.index.edit")
-      expect(find(:test_id, id)).to have_text(text)
-    end
-
-    it "moves to sake edit page" do
-      id = "sakes-index-edit-link"
-      path = edit_sake_path(sake.id)
-      click_link(id)
-      expect(page).to have_current_path(path, ignore_query: true)
+    context "for a sake" do
+      it "has edit link" do
+        buttons = "sake_buttons_#{sake.id}"
+        text = I18n.t("sakes.index.edit")
+        path = edit_sake_path(sake.id)
+        expect(find(:test_id, buttons)).to have_link(text, href: path)
+      end
     end
   end
 end


### PR DESCRIPTION
after #469
fix #405

ついに新たな酒indexとなったぞ！

## やったこと

- 酒indexを新たなデザインにした
  - カードデザインを採用した
  - 画面サイズによって3列・2列・1列が切り替わる
  - グラフは4x3ですべて固定した
- 各種RSpecを修正した
  - 構造が大きく変わったので、testidの振り方を修正
  - 変更箇所のみリファクタ
