### PR TITLE
Fix: #475 debug gemのバージョンを1.5.0に上げた

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,7 +121,7 @@ GEM
     crass (1.0.6)
     cssbundling-rails (1.1.0)
       railties (>= 6.0.0)
-    debug (1.4.0)
+    debug (1.5.0)
       irb (>= 1.3.6)
       reline (>= 0.2.7)
     debug_inspector (1.1.0)


### PR DESCRIPTION
Fix: #475

debug gemのバージョンを1.5.0に上げることで、macOS上のdocker環境でrails s や rails db:createで落ちる問題を解消。