### PR TITLE
パーシャルビューでインスタンス変数を使わない

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,12 +13,12 @@
   </head>
 
   <body>
-    <%= render("layouts/header") %>
+    <%= render(partial: "layouts/header") %>
     <div class="container-xxl">
-      <%= render("layouts/flashes") %>
+      <%= render(partial: "layouts/flashes") %>
       <%= yield %>
     </div>
-    <%= render("layouts/footer") %>
+    <%= render(partial: "layouts/footer") %>
     <% if Rails.env.development? %>
       <div class="py-5 bg-light">
         <%= debug(params) %>

--- a/app/views/sakes/_float-button.html.erb
+++ b/app/views/sakes/_float-button.html.erb
@@ -2,12 +2,12 @@
   <div class="px-xxl-5 px-3 text-end">
     <% if controller.action_name == "show" %>
       <%= link_to(tag.i(class: "bi-pencil-square me-2", style: "font-size: 1.05em;") + t(".edit"),
-                  edit_sake_path(@sake),
+                  edit_sake_path(sake),
                   { class: "float-button-secondary mx-1",
                     style: "font-size: 1.1em;",
-                    "data-testid": "edit-#{@sake.id}", }) %>
+                    "data-testid": "edit-#{sake.id}", }) %>
       <%= link_to(tag.i(class: "bi-front me-2", style: "font-size: 0.95em;") + t(".copy"),
-                  new_sake_path(copied_from: @sake.id),
+                  new_sake_path(copied_from: sake.id),
                   { class: "float-button-primary mx-1",
                     style: "font-size: 1.1em;",
                     "data-testid": "copy_sake", }) %>

--- a/app/views/sakes/_form-abstract.html.erb
+++ b/app/views/sakes/_form-abstract.html.erb
@@ -24,7 +24,7 @@
               <input type="text" id="sake_kura_todofuken_autocompletion"
                 class="form-control" autocomplete="on" list="kura-list"
                 data-testid="sake_kura_todofuken_autocompletion">
-              <%= render("kura-datalist") %>
+              <%= render(partial: "kura-datalist") %>
               <%= form.text_field(:kura, id: "sake_kura", hidden: true, data: { testid: "sake_kura" }) %>
               <%= form.text_field(:todofuken, id: "sake_todofuken", hidden: true, data: { testid: "sake_todofuken" }) %>
             </div>

--- a/app/views/sakes/_form-detail.html.erb
+++ b/app/views/sakes/_form-detail.html.erb
@@ -30,7 +30,7 @@
                                   list: "sakamai-list",
                                   data: { testid: "sake_kakemai" }) %>
             </div>
-            <%= render("sakamai-datalist") %>
+            <%= render(partial: "sakamai-datalist") %>
             <div class="col-12">
               <%= form.label(:kobo, class: "form-label") %>
               <%= form.text_field(:kobo, class: "form-control", data: { testid: "sake_kobo" }) %>

--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -1,7 +1,7 @@
 <% select_js("sakes_form") %>
 <% select_css("sakes_form") %>
 
-<%= render("float-button") %>
+<%= render("float-button", sake:) %>
 
 <%= form_with(model: sake, id: "sake-form") do |form| %>
   <%# error message %>

--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -1,14 +1,14 @@
 <% select_js("sakes_form") %>
 <% select_css("sakes_form") %>
 
-<%= render("float-button", sake:) %>
+<%= render(partial: "float-button", locals: { sake: }) %>
 
 <%= form_with(model: sake, id: "sake-form") do |form| %>
   <%# error message %>
   <% flash.now[:danger] = t(".input_error") if sake.errors.any? %>
   <div class="accordion my-2">
-    <%= render("form-abstract", sake:, form:) %>
-    <%= render("form-detail", sake:, form:) %>
-    <%= render("form-review", sake:, form:) %>
+    <%= render(partial: "form-abstract", locals: { sake:, form: }) %>
+    <%= render(partial: "form-detail", locals: { sake:, form: }) %>
+    <%= render(partial: "form-review", locals: { sake:, form: }) %>
   </div>
 <% end %>

--- a/app/views/sakes/_show_abstract.html.erb
+++ b/app/views/sakes/_show_abstract.html.erb
@@ -5,7 +5,7 @@
         <h1 class="mb-0"><%= title(sake.name) %></h1>
       </div>
       <div class="col-auto order-lg-1 order-2 text-end">
-        <%= render("sns-share-button", sake:) %>
+        <%= render(partial: "sns-share-button", locals: { sake: }) %>
       </div>
       <div class="col-lg-12 order-lg-2 col order-1 fs-3">
         <% if sake.kura.present? %>

--- a/app/views/sakes/_show_abstract.html.erb
+++ b/app/views/sakes/_show_abstract.html.erb
@@ -2,14 +2,14 @@
   <div class="col-12">
     <div class="row align-items-baseline">
       <div class="col-lg col-12">
-        <h1 class="mb-0"><%= title(@sake.name) %></h1>
+        <h1 class="mb-0"><%= title(sake.name) %></h1>
       </div>
       <div class="col-auto order-lg-1 order-2 text-end">
-        <%= render("sns-share-button", sake: @sake) %>
+        <%= render("sns-share-button", sake:) %>
       </div>
       <div class="col-lg-12 order-lg-2 col order-1 fs-3">
-        <% if @sake.kura.present? %>
-          <%= short_kura(@sake.kura) %> ‒ <%= short_todofuken(@sake.todofuken) %>
+        <% if sake.kura.present? %>
+          <%= short_kura(sake.kura) %> ‒ <%= short_todofuken(sake.todofuken) %>
         <% end %>
       </div>
     </div>
@@ -18,25 +18,25 @@
   <div class="col-12">
     <div class="row align-items-baseline">
       <div class="col-12 fs-3">
-        <% if @sake.tokutei_meisho == "none" %>
+        <% if sake.tokutei_meisho == "none" %>
           <%= t(".tokutei_meisho_none") %>
         <% else %>
-          <%= @sake.tokutei_meisho_i18n %>
+          <%= sake.tokutei_meisho_i18n %>
         <% end %>
       </div>
-      <% if @sake.season.present? %>
+      <% if sake.season.present? %>
         <div class="col-auto fs-3">
-          <%= @sake.season %>
+          <%= sake.season %>
         </div>
       <% end %>
-      <div class="col-auto <%= "ps-0" if @sake.season.present? %>">
-        <% if @sake.brew_year.present? %>
-          <%= @sake.brew_year.year %>
+      <div class="col-auto <%= "ps-0" if sake.season.present? %>">
+        <% if sake.brew_year.present? %>
+          <%= sake.brew_year.year %>
           <%= Sake.human_attribute_name(:brew_year) %>
         <% end %>
-        <%= "‒" if @sake.brew_year.present? && @sake.bindume_date.present? %>
-        <% if @sake.bindume_date.present? %>
-          <%= @sake.bindume_date.strftime("%Y/%m") %>
+        <%= "‒" if sake.brew_year.present? && sake.bindume_date.present? %>
+        <% if sake.bindume_date.present? %>
+          <%= sake.bindume_date.strftime("%Y/%m") %>
           <%= t(".made") %>
         <% end %>
       </div>
@@ -47,28 +47,28 @@
     <div class="row">
       <div class="col-12 fs-5">
         <%= t(".time_ago",
-              count: time_ago_in_words(latest_at(@sake), include_seconds: true),
-              done: t(".#{@sake.bottle_level}")) %>
+              count: time_ago_in_words(latest_at(sake), include_seconds: true),
+              done: t(".#{sake.bottle_level}")) %>
       </div>
       <div class="col-auto" data-testid="created-at">
-        <%= l(@sake.created_at.to_date) %>
+        <%= l(sake.created_at.to_date) %>
       </div>
       <div class="col-auto ps-0">
         <%= t(".sealed") %>
       </div>
-      <% if not(@sake.sealed?) %>
+      <% if not(sake.sealed?) %>
         <div class="w-100"></div>
         <div class="col-auto" data-testid="opened-at">
-          <%= l(@sake.opened_at.to_date) %>
+          <%= l(sake.opened_at.to_date) %>
         </div>
         <div class="col-auto ps-0">
           <%= t(".opened") %>
         </div>
       <% end %>
-      <% if @sake.empty? %>
+      <% if sake.empty? %>
         <div class="w-100"></div>
         <div class="col-auto" data-testid="emptied-at">
-          <%= l(@sake.emptied_at.to_date) %>
+          <%= l(sake.emptied_at.to_date) %>
         </div>
         <div class="col-auto ps-0">
           <%= t(".empty") %>
@@ -78,14 +78,14 @@
   </div>
 
   <div class="col-12 fs-5">
-    <%= @sake.size %> ml
-    <%= "‒ #{@sake.price.to_fs(:delimited)} #{t('activerecord.attributes.sake.price_unit')}" if @sake.price.present? %>
+    <%= sake.size %> ml
+    <%= "‒ #{sake.price.to_fs(:delimited)} #{t('activerecord.attributes.sake.price_unit')}" if sake.price.present? %>
   </div>
 
-  <% if @sake.photos.any? %>
+  <% if sake.photos.any? %>
     <div class="col-12 py-1">
       <div class="row g-2 photo-gallery">
-        <% @sake.photos.each do |photo| %>
+        <% sake.photos.each do |photo| %>
           <div class="col-lg-2 col-6" data-testid="sake_photo">
             <%= link_to(cl_image_tag(photo.image.thumb.url, class: "img-thumbnail"), photo.image.url) %>
           </div>

--- a/app/views/sakes/_show_detail.html.erb
+++ b/app/views/sakes/_show_detail.html.erb
@@ -10,8 +10,8 @@
         <%= Sake.human_attribute_name(:genryomai) %>
         <span class="highlight-value">　</span>
       </div>
-      <div class="string-value <%= either_highlight_or_lowlight(@sake.genryomai) %>">
-        <%= empty_to_default(@sake.genryomai, t(".unknown")) %>
+      <div class="string-value <%= either_highlight_or_lowlight(sake.genryomai) %>">
+        <%= empty_to_default(sake.genryomai, t(".unknown")) %>
       </div>
     </div>
     <div class="underline-column">
@@ -19,8 +19,8 @@
         <%= Sake.human_attribute_name(:kakemai) %>
         <span class="highlight-value">　</span>
       </div>
-      <div class="string-value <%= either_highlight_or_lowlight(@sake.kakemai) %>">
-        <%= empty_to_default(@sake.kakemai, t(".unknown")) %>
+      <div class="string-value <%= either_highlight_or_lowlight(sake.kakemai) %>">
+        <%= empty_to_default(sake.kakemai, t(".unknown")) %>
       </div>
     </div>
     <div class="underline-column">
@@ -28,8 +28,8 @@
         <%= Sake.human_attribute_name(:seimai_buai) %>
         <span class="highlight-value">　</span>
       </div>
-      <div class="string-value <%= either_highlight_or_lowlight(@sake.seimai_buai) %>">
-        <%= @sake.seimai_buai.present? ? "#{@sake.seimai_buai} %" : t(".unknown") %>
+      <div class="string-value <%= either_highlight_or_lowlight(sake.seimai_buai) %>">
+        <%= sake.seimai_buai.present? ? "#{sake.seimai_buai} %" : t(".unknown") %>
       </div>
     </div>
     <div class="underline-column">
@@ -37,8 +37,8 @@
         <%= Sake.human_attribute_name(:kobo) %>
         <span class="highlight-value">　</span>
       </div>
-      <div class="string-value <%= either_highlight_or_lowlight(@sake.kobo) %>">
-        <%= empty_to_default(@sake.kobo, t(".unknown")) %>
+      <div class="string-value <%= either_highlight_or_lowlight(sake.kobo) %>">
+        <%= empty_to_default(sake.kobo, t(".unknown")) %>
       </div>
     </div>
   </div>
@@ -52,8 +52,8 @@
         <%= Sake.human_attribute_name(:moto) %>
         <span class="highlight-value">　</span>
       </div>
-      <div class="string-value <%= either_highlight_or_lowlight(@sake.moto) %>">
-        <%= @sake.moto_i18n %>
+      <div class="string-value <%= either_highlight_or_lowlight(sake.moto) %>">
+        <%= sake.moto_i18n %>
       </div>
     </div>
     <div class="underline-column">
@@ -61,8 +61,8 @@
         <%= Sake.human_attribute_name(:shibori) %>
         <span class="highlight-value">　</span>
       </div>
-      <div class="string-value <%= either_highlight_or_lowlight(@sake.shibori) %>">
-        <%= empty_to_default(@sake.shibori, t(".unknown")) %>
+      <div class="string-value <%= either_highlight_or_lowlight(sake.shibori) %>">
+        <%= empty_to_default(sake.shibori, t(".unknown")) %>
       </div>
     </div>
     <div class="underline-column">
@@ -70,8 +70,8 @@
         <%= Sake.human_attribute_name(:roka) %>
         <span class="highlight-value">　</span>
       </div>
-      <div class="string-value <%= either_highlight_or_lowlight(@sake.roka) %>">
-        <%= empty_to_default(@sake.roka, t(".unknown")) %>
+      <div class="string-value <%= either_highlight_or_lowlight(sake.roka) %>">
+        <%= empty_to_default(sake.roka, t(".unknown")) %>
       </div>
     </div>
     <div class="underline-column">
@@ -79,8 +79,8 @@
         <%= Sake.human_attribute_name(:hiire) %>
         <span class="highlight-value">　</span>
       </div>
-      <div class="string-value <%= either_highlight_or_lowlight(@sake.hiire) %>">
-        <%= @sake.hiire_i18n %>
+      <div class="string-value <%= either_highlight_or_lowlight(sake.hiire) %>">
+        <%= sake.hiire_i18n %>
       </div>
     </div>
     <div class="underline-column">
@@ -88,8 +88,8 @@
         <%= Sake.human_attribute_name(:warimizu) %>
         <span class="highlight-value">　</span>
       </div>
-      <div class="string-value <%= either_highlight_or_lowlight(@sake.warimizu) %>">
-        <%= @sake.warimizu_i18n %>
+      <div class="string-value <%= either_highlight_or_lowlight(sake.warimizu) %>">
+        <%= sake.warimizu_i18n %>
       </div>
     </div>
   </div>
@@ -103,11 +103,11 @@
         <%= Sake.human_attribute_name(:alcohol) %>
         <span class="highlight-value">　</span>
       </div>
-      <div class="numeric-value <%= either_highlight_or_lowlight(@sake.alcohol) %>">
-        <%= @sake.alcohol.present? ? @sake.alcohol.truncate : t(".unknown") %>
+      <div class="numeric-value <%= either_highlight_or_lowlight(sake.alcohol) %>">
+        <%= sake.alcohol.present? ? sake.alcohol.truncate : t(".unknown") %>
       </div>
       <div class="numeric-unit">
-        <%= t("activerecord.attributes.sake.alcohol_unit") if @sake.alcohol.present? %>
+        <%= t("activerecord.attributes.sake.alcohol_unit") if sake.alcohol.present? %>
       </div>
     </div>
     <div class="underline-column">
@@ -115,9 +115,9 @@
         <%= Sake.human_attribute_name(:nihonshudo) %>
         <span class="highlight-value">　</span>
       </div>
-      <div class="numeric-value <%= either_highlight_or_lowlight(@sake.nihonshudo) %>">
+      <div class="numeric-value <%= either_highlight_or_lowlight(sake.nihonshudo) %>">
         <%# 正の日本酒度には+記号を常につける %>
-        <%= @sake.nihonshudo.present? ? format("%+.1f", @sake.nihonshudo) : t(".unknown") %>
+        <%= sake.nihonshudo.present? ? format("%+.1f", sake.nihonshudo) : t(".unknown") %>
       </div>
     </div>
     <div class="underline-column">
@@ -125,8 +125,8 @@
         <%= Sake.human_attribute_name(:sando) %>
         <span class="highlight-value">　</span>
       </div>
-      <div class="numeric-value <%= either_highlight_or_lowlight(@sake.sando) %>">
-        <%= empty_to_default(@sake.sando, t(".unknown")) %>
+      <div class="numeric-value <%= either_highlight_or_lowlight(sake.sando) %>">
+        <%= empty_to_default(sake.sando, t(".unknown")) %>
       </div>
     </div>
     <div class="underline-column">
@@ -134,8 +134,8 @@
         <%= Sake.human_attribute_name(:aminosando) %>
         <span class="highlight-value">　</span>
       </div>
-      <div class="numeric-value <%= either_highlight_or_lowlight(@sake.aminosando) %>">
-        <%= empty_to_default(@sake.aminosando, t(".unknown")) %>
+      <div class="numeric-value <%= either_highlight_or_lowlight(sake.aminosando) %>">
+        <%= empty_to_default(sake.aminosando, t(".unknown")) %>
       </div>
     </div>
   </div>

--- a/app/views/sakes/_show_review.html.erb
+++ b/app/views/sakes/_show_review.html.erb
@@ -4,7 +4,7 @@
   </div>
 
   <div class="col-12 fs-3" data-testid="rating">
-    <%= render("rating", rating: sake.rating) %>
+    <%= render(partial: "rating", locals: { rating: sake.rating }) %>
   </div>
 
   <div class="col-12 mb-2">

--- a/app/views/sakes/_show_review.html.erb
+++ b/app/views/sakes/_show_review.html.erb
@@ -4,7 +4,7 @@
   </div>
 
   <div class="col-12 fs-3" data-testid="rating">
-    <%= render("rating", rating: @sake.rating) %>
+    <%= render("rating", rating: sake.rating) %>
   </div>
 
   <div class="col-12 mb-2">
@@ -16,7 +16,7 @@
           </div>
           <div class="text">
             <div>
-              <%= empty_to_default(@sake.color, "　") %>
+              <%= empty_to_default(sake.color, "　") %>
             </div>
           </div>
         </div>
@@ -28,7 +28,7 @@
           </div>
           <div class="text">
             <div>
-              <%= empty_to_default(@sake.nigori, "　") %>
+              <%= empty_to_default(sake.nigori, "　") %>
             </div>
           </div>
         </div>
@@ -47,7 +47,7 @@
               </div>
               <div class="text">
                 <div>
-                  <%= empty_to_default(@sake.aroma_impression, "　") %>
+                  <%= empty_to_default(sake.aroma_impression, "　") %>
                 </div>
               </div>
             </div>
@@ -59,7 +59,7 @@
               </div>
               <div class="text">
                 <div>
-                  <%= empty_to_default(@sake.taste_impression, "　") %>
+                  <%= empty_to_default(sake.taste_impression, "　") %>
                 </div>
               </div>
             </div>
@@ -71,7 +71,7 @@
               </div>
               <div class="text">
                 <div>
-                  <%= empty_to_default(@sake.awa, t(".no_awa")) %>
+                  <%= empty_to_default(sake.awa, t(".no_awa")) %>
                 </div>
               </div>
             </div>
@@ -80,9 +80,9 @@
       </div>
       <div class="col-lg-6 order-lg-2 col-12 order-1">
         <div class="ratio ratio-4x3">
-          <canvas id="sake-<%= @sake.id %>"
-            data-taste-value="<%= @sake.taste_value %>"
-            data-aroma-value="<%= @sake.aroma_value %>">
+          <canvas id="sake-<%= sake.id %>"
+            data-taste-value="<%= sake.taste_value %>"
+            data-aroma-value="<%= sake.aroma_value %>">
           </canvas>
         </div>
       </div>
@@ -96,7 +96,7 @@
       </div>
       <div class="text">
         <div>
-          <%= empty_to_default(@sake.note, "　") %>
+          <%= empty_to_default(sake.note, "　") %>
         </div>
       </div>
     </div>

--- a/app/views/sakes/edit.html.erb
+++ b/app/views/sakes/edit.html.erb
@@ -1,3 +1,3 @@
 <h1 data-testid="<%= edit_sake_path(@sake) %>"><%= title(t(".title")) %></h1>
 
-<%= render("form", sake: @sake) %>
+<%= render(partial: "form", locals: { sake: @sake }) %>

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -1,7 +1,7 @@
 <% select_js("sakes_index") %>
 <% select_css("sakes_index") %>
 
-<%= render("float-button", sake: @sake) %>
+<%= render(partial: "float-button", locals: { sake: @sake }) %>
 
 <div class="row row-cols-1 g-3">
   <div class="col">

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -1,7 +1,7 @@
 <% select_js("sakes_index") %>
 <% select_css("sakes_index") %>
 
-<%= render("float-button") %>
+<%= render("float-button", sake: @sake) %>
 
 <div class="row row-cols-1 g-3">
   <div class="col">

--- a/app/views/sakes/menu.html.erb
+++ b/app/views/sakes/menu.html.erb
@@ -8,8 +8,8 @@
   <div class="col-12">
     <div class="row row-cols-1 row-cols-md-2 g-5">
       <% @sakes.each_slice(2) do |sake1, sake2| %>
-        <%= render("menu_one_drink", sake: sake1) %>
-        <%= render("menu_one_drink", sake: sake2) if sake2.present? %>
+        <%= render(partial: "menu_one_drink", locals: { sake: sake1 }) %>
+        <%= render(partial: "menu_one_drink", locals: { sake: sake2 }) if sake2.present? %>
       <% end %>
     </div>
   </div>

--- a/app/views/sakes/new.html.erb
+++ b/app/views/sakes/new.html.erb
@@ -1,3 +1,3 @@
 <h1><%= title(t(".title")) %></h1>
 
-<%= render("form", sake: @sake) %>
+<%= render(partial: "form", locals: { sake: @sake }) %>

--- a/app/views/sakes/show.html.erb
+++ b/app/views/sakes/show.html.erb
@@ -6,7 +6,7 @@
   <% set_meta_tags(og: { image: { _: @sake.photos.first.image.large_twitter_card.url, width: 600, height: 300 } }) %>
 <% end %>
 
-<%= render("float-button") %>
+<%= render("float-button", sake: @sake) %>
 
 <div class="row gy-5">
   <div class="col-12">

--- a/app/views/sakes/show.html.erb
+++ b/app/views/sakes/show.html.erb
@@ -6,19 +6,19 @@
   <% set_meta_tags(og: { image: { _: @sake.photos.first.image.large_twitter_card.url, width: 600, height: 300 } }) %>
 <% end %>
 
-<%= render("float-button", sake: @sake) %>
+<%= render(partial: "float-button", locals: { sake: @sake }) %>
 
 <div class="row gy-5">
   <div class="col-12">
-    <%= render("show_abstract", sake: @sake) %>
+    <%= render(partial: "show_abstract", locals: { sake: @sake }) %>
   </div>
 
   <div class="col-12">
-    <%= render("show_detail", sake: @sake) %>
+    <%= render(partial: "show_detail", locals: { sake: @sake }) %>
   </div>
 
   <div class="col-12">
-    <%= render("show_review", sake: @sake) %>
+    <%= render(partial: "show_review", locals: { sake: @sake }) %>
   </div>
 
   <div class="col-12">


### PR DESCRIPTION
パーシャルビューでインスタンス変数を使うのはよくない！

## 今までの問題

- パーシャルビューでインスタンス変数を使っていた
  - `@sake`を使える前提で書いている
  - これだと、render呼び出しによってはインスタンス変数が存在しないというエラーになる

## これから

- 必要な変数はrenderの呼び出しからしっかり渡す！
  - render呼び出し時に引数のハッシュキーを省略できなくなる
    - 明示的でわかりやすい
  - `render(partial: "PARTIAL_VIEW_NAME", locales: { VAR_NAME1: VALUE1, VAR_NAME2: VALUE2, ... })`

## やったこと

- パーシャルビューの呼び出し方法を変更
- ~~パーシャルビューの名前をハイフン区切りで揃えた~~
  - 別Issueにした