### PR TITLE
Apple Silicon 向けビルド済み nokogiri がインストールされるようにする

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,6 +245,8 @@ GEM
     nokogiri (1.13.9)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
+    nokogiri (1.13.9-arm64-darwin)
+      racc (~> 1.4)
     orm_adapter (0.5.0)
     parallel (1.21.0)
     parallel_tests (3.7.3)
@@ -402,6 +404,7 @@ GEM
     zeitwerk (2.5.4)
 
 PLATFORMS
+  arm64-darwin
   ruby
 
 DEPENDENCIES


### PR DESCRIPTION
Closes #513

## 変更点

今回は Apple Silicon (ARM系）の Mac でも sakazuki の Docker を実行できるように、
```
bundle lock --add-platform arm64-darwin
```
で platform を Gemfile.lock に追加しました。
これにともなって、arm64-darwin であれば事前にネイティブビルド済みの nokogiri がインストールされるようになったようです。

## 検証方法

- M1 Mac + macOS 12 でのみ検証しました。
   **_x86_64 の Linux や Windows では検証していませんので、ご確認ください。_** 
- `docker compose build` ⇨ `docker compose run` 

次のように Rails サーバーが無事立ち上がりました。

 ```
sakazuki-web-1  | => Booting Puma
sakazuki-web-1  | => Rails 7.0.2.2 application starting in development 
sakazuki-web-1  | => Run `bin/rails server --help` for more startup options
sakazuki-web-1  | Puma starting in single mode...
sakazuki-web-1  | * Puma version: 5.6.4 (ruby 3.1.1-p18) ("Birdie's Version")
sakazuki-web-1  | *  Min threads: 5
sakazuki-web-1  | *  Max threads: 5
sakazuki-web-1  | *  Environment: development
sakazuki-web-1  | *          PID: 1
sakazuki-web-1  | * Listening on http://0.0.0.0:3000
sakazuki-web-1  | Use Ctrl-C to stop
```

## platform について

[Nokogiri のリリースノート](https://github.com/sparklemotion/nokogiri/blob/main/CHANGELOG.md#faster-more-reliable-installation-native-gem-for-arm64-linux) によると、

> Faster, more reliable installation: Native Gem for ARM64 Linux
>
> This version of Nokogiri ships experimental native gem support for the aarch64-linux platform, which should support AWS Graviton and other ARM Linux platforms. We don't yet have CI running for this platform, and so we're interested in hearing back from y'all whether this is working, and what problems you're seeing. Please send us feedback here: https://github.com/sparklemotion/nokogiri/discussions/2359

- CPU アーキ（x86_64, ARM...）
- OS (Darwin=Mac, Linux, ...）

などの組み合わせからなる platform をあらかじめ Gemfile.lock で指定しておくと、該当する platform では、あらかじめネイティブビルド済みの nokogiri （や他の gem）をインストールしてくれるようです。
これにより、Docker ビルド時間の短縮や、不要なパッケージの削減などができるそうです。

[こちらの Qiita 記事](https://qiita.com/mziyut/items/d75222fee131457aaa37) によると、`arm64-linux` などもあるようです。
これを指定すると、AWS などでは x86-84 系よりもコストの安い ARM 系マシンが使えてお得なようです。
