### PR TITLE
重複したActionsをスキップするようにした

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,9 +1,24 @@
 name: Check
 
-on: push
+on: [push, pull_request]
 
 jobs:
+  # Skip Duplicate Actions
+  check_skip:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v5
+        with:
+          cancel_others: 'true'
+          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
+
   check:
+    needs: check_skip
+    if: needs.check_skip.outputs.should_skip != 'true'
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,12 +12,12 @@ jobs:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@v5
         with:
-          cancel_others: 'true'
-          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
+          cancel_others: "true"
+          do_not_skip: "['pull_request', 'workflow_dispatch', 'schedule']"
 
   check:
     needs: check_skip
-    if: needs.check_skip.outputs.should_skip != 'true'
+    if: needs.check_skip.outputs.should_skip != "true"
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,24 @@
 name: Test
 
-on: push
+on: [push, pull_request]
 
 jobs:
+  # Skip Duplicate Actions
+  check_skip:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v5
+        with:
+          cancel_others: 'true'
+          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
+
   test:
+    needs: check_skip
+    if: needs.check_skip.outputs.should_skip != 'true'
+
     runs-on: ubuntu-latest
 
     services:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,12 +12,12 @@ jobs:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@v5
         with:
-          cancel_others: 'true'
-          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
+          cancel_others: "true"
+          do_not_skip: "['pull_request', 'workflow_dispatch', 'schedule']"
 
   test:
     needs: check_skip
-    if: needs.check_skip.outputs.should_skip != 'true'
+    if: needs.check_skip.outputs.should_skip != "true"
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
close #516

Skip Duplicate Actionsというアクションを使って実現している。
ファイルの変更を見て同じテストやチェックをスキップできる。
PRの表示には重複して起動はするが、内容を見るとスキップされるようになり高速化が期待できる。

監視対象のファイルを細かく設定でき、よりスキップする場合を増やすこともできる。
ただ設定するコストと今後の管理コストの高さから今回は導入していない。

https://github.com/marketplace/actions/skip-duplicate-actions