### PR TITLE
酒の並び順を瓶状態で並べるようにした

### DIFF
--- a/app/controllers/sakes_controller.rb
+++ b/app/controllers/sakes_controller.rb
@@ -16,14 +16,12 @@ class SakesController < ApplicationController
     # default, not empty bottle
     query.merge!({ bottle_level_not_eq: Sake.bottle_levels["empty"] }) unless include_empty?(query)
 
-    # default, sort by id
-    query.merge!({ s: "id desc" })
-
     # multiple words search
     to_multi_search!(query) if query[:all_text_cont]
 
-    # Ransack search
+    # Ransack search and sort
     @searched = Sake.ransack(query)
+    @searched.sorts = ["bottle_level", "id desc"]
     @sakes = @searched.result.includes(:photos)
 
     # Kaminari pager

--- a/app/controllers/sakes_controller.rb
+++ b/app/controllers/sakes_controller.rb
@@ -20,9 +20,9 @@ class SakesController < ApplicationController
     to_multi_search!(query) if query[:all_text_cont]
 
     # Ransack search and sort
-    @searched = Sake.ransack(query)
-    @searched.sorts = ["bottle_level", "id desc"]
-    @sakes = @searched.result.includes(:photos)
+    @search = Sake.ransack(query)
+    @search.sorts = ["bottle_level", "id desc"]
+    @sakes = @search.result.includes(:photos)
 
     # Kaminari pager
     @sakes = @sakes.page(params[:page]) if include_empty?(query)

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -10,7 +10,7 @@
     </h1>
   </div>
   <div class="col">
-    <%= search_form_for(@searched) do |f| %>
+    <%= search_form_for(@search) do |f| %>
       <div class="row mx-0 align-items-center">
         <div class="col ps-0 input-group">
           <%= f.label(:all_text_cont, "search word", class: "form-label visually-hidden") %>

--- a/spec/system/sake_index_order_spec.rb
+++ b/spec/system/sake_index_order_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe "Sake Index Order" do
+  describe "sakes order in index" do
+    let!(:sealed1) { create(:sake, name: "未開封のお酒1", bottle_level: "sealed") }
+    let!(:opened1) { create(:sake, name: "開封済みのお酒1", bottle_level: "opened") }
+    let!(:empty) { create(:sake, name: "空のお酒", bottle_level: "empty") }
+    let!(:sealed2) { create(:sake, name: "未開封のお酒2", bottle_level: "sealed") }
+    let!(:opened2) { create(:sake, name: "開封済みのお酒2", bottle_level: "opened") }
+
+    before do
+      visit sakes_path
+    end
+
+    context "if not included empty bottle" do
+      it "shows opened sakes before sealed sakes" do
+        regexp = /#{sealed2.name}.*#{sealed1.name}.*#{opened2.name}.*#{opened1.name}/m
+        expect(page.text).to match(regexp)
+      end
+
+      it "does not include empty sake" do
+        regexp = /#{empty.name}}/
+        expect(page.text).not_to match(regexp)
+      end
+    end
+
+    context "if included empty bottle", js: true do
+      before do
+        check("check_empty_bottle") # show empty bottles
+      end
+
+      it "shows sakes sorted by id" do
+        regexp = /#{sealed2.name}.*#{sealed1.name}.*#{opened2.name}.*#{opened1.name}.*#{empty.name}/m
+        expect(page.text).to match(regexp)
+      end
+    end
+  end
+end

--- a/spec/system/sake_index_order_spec.rb
+++ b/spec/system/sake_index_order_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Sake Index Order" do
       end
     end
 
-    context "if included empty bottle", js: true do
+    context "if the 'show empty bottles' checkbox is checked", js: true do
       before do
         check("check_empty_bottle") # show empty bottles
       end

--- a/spec/system/sake_index_order_spec.rb
+++ b/spec/system/sake_index_order_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Sake Index Order" do
       visit sakes_path
     end
 
-    context "if not included empty bottle" do
+    context "if the 'show empty bottles' checkbox is not checked" do
       it "shows opened sakes before sealed sakes" do
         regexp = /#{sealed2.name}.*#{sealed1.name}.*#{opened2.name}.*#{opened1.name}/m
         expect(page.text).to match(regexp)


### PR DESCRIPTION
close #520
after PR #519

### 今まで

- 酒indexで酒はid順にならんでいた

### 問題点

- 開封済み・未開封が混ざった順番でわかりずらい（Issue #492 でも言われていた）

### これから

- 瓶状態でのソートをデフォルトにしてみよう！

### やったこと

- Add: 酒indexでの酒の順番についてのテストを追加
- Update: 酒indexでの酒並び順を変更した
- Refactor: 変数名の命名をRansackのドキュメントに合わせた
