### PR TITLE
ubuntu-latestにFirefoxがないためTest Actionsが終わらない問題の暫定対処

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,9 @@ jobs:
     needs: check_skip
     if: needs.check_skip.outputs.should_skip != 'true'
 
-    runs-on: ubuntu-latest
+    # TODO: Update to ubuntu-latest after install Firefox to Ubuntu 22.04 image
+    #       https://github.com/actions/runner-images/pull/6528
+    runs-on: ubuntu-20.04
 
     services:
       postgres:


### PR DESCRIPTION
fix #527

Test Actionsで使うUbuntuを一時的に20.04で固定した。
Ubuntu 22.04イメージにFirefoxがまだ入っていない。
FirefoxをインストールするPRがすでにあるため、入るまでの暫定対処。
