### PR TITLE
drink_buttonの開封・空の操作時のメッセージに酒名をつけた

### DIFF
--- a/app/views/sakes/_drink_button.html.erb
+++ b/app/views/sakes/_drink_button.html.erb
@@ -2,7 +2,9 @@
   <li>
     <%= link_to(tag.i(class: "bi-droplet-half", style: "font-size: 0.95em;") + t(".open"),
                 sake_path(sake, params: { sake: { bottle_level: "opened" }, flash_message_type: "open" }),
-                data: { method: :patch, confirm: t(".confirm_open"), testid: "open_button_#{sake.id}" }) %>
+                data: { method: :patch,
+                        confirm: t(".confirm_open", name: sake.name),
+                        testid: "open_button_#{sake.id}", }) %>
   </li>
 <% end %>
 <% if sake.unimpressed? %>
@@ -18,6 +20,8 @@
   <li>
     <%= link_to(tag.i(class: "bi-droplet", style: "font-size: 0.95em;") + t(".empty"),
                 sake_path(sake, params: { sake: { bottle_level: "empty" }, flash_message_type: "empty" }),
-                data: { method: :patch, confirm: t(".confirm_empty"), testid: "empty_button_#{sake.id}" }) %>
+                data: { method: :patch,
+                        confirm: t(".confirm_empty", name: sake.name),
+                        testid: "empty_button_#{sake.id}", }) %>
   </li>
 <% end %>

--- a/config/locales/views/sake.ja.yml
+++ b/config/locales/views/sake.ja.yml
@@ -33,9 +33,9 @@ ja:
     drink_button:
       open: 開封する
       impress: 評価する
-      confirm_open: 栓を開けます？
+      confirm_open: "%{name} の栓を開ける？"
       empty: 空にする
-      confirm_empty: 飲みきった？
+      confirm_empty: "%{name} を飲みきった？"
     new:
       title: 新規登録
     edit:


### PR DESCRIPTION
close #495

after PR #543

### やったこと

- drink-buttonのメッセージ変更
  - 「栓を開けます？」→「ほしいずみ 特別純米 無濾過生原酒 の栓を開ける？」
  - 「飲みきった？」→「ほしいずみ 特別純米 無濾過生原酒 を飲みきった？」
