### PR TITLE
メタタグのタイトルに検索内容を含めるようにした

### DIFF
--- a/app/helpers/sakes_helper.rb
+++ b/app/helpers/sakes_helper.rb
@@ -140,4 +140,22 @@ module SakesHelper
   def either_highlight_or_lowlight(value)
     value.blank? || value == "unknown" ? "lowlight-value" : "highlight-value"
   end
+
+  # ヘッダタイトル用に検索ワードつきのタイトルを生成する
+  #
+  # @param search [String, nil] 検索ワード
+  # @return [String] ヘッダタイトル
+  def title_with_search(search)
+    prefix = search.present? ? "#{search} - " : ""
+    "#{prefix}#{t('sakes.index.title')}"
+  end
+
+  # 酒index用に酒の総量つきのタイトルを生成する
+  #
+  # @param include_empty [Boolean] trueなら空き瓶込みでカウントする
+  # @return [String] 酒の総量つきタイトル
+  def title_with_stock(include_empty)
+    stock = to_shakkan(Sake.alcohol_stock(include_empty:))
+    "#{t('sakes.index.title')} - #{stock}"
+  end
 end

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -6,11 +6,10 @@
 <div class="row row-cols-1 g-3">
   <div class="col">
     <h1 class="mb-0" data-testid="total_sake">
-      <% search_text = params.dig(:q, :all_text_cont) %>
-      <% search = search_text.present? ? "#{search_text} - " : "" %>
-      <% stock = to_shakkan(Sake.alcohol_stock(include_empty: include_empty?(params[:q]))) %>
+      <% with_search = title_with_search(params.dig(:q, :all_text_cont)) %>
+      <% with_stock = title_with_stock(include_empty?(params[:q])) %>
       <%# ヘッダタイトルとページタイトル %>
-      <%= title("#{search}#{t('.title')}", "#{t('.title')} - #{stock}") %>
+      <%= title(with_search, with_stock) %>
     </h1>
   </div>
   <div class="col">

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -6,7 +6,10 @@
 <div class="row row-cols-1 g-3">
   <div class="col">
     <h1 class="mb-0" data-testid="total_sake">
-      <%= title("#{t('.title')} - #{to_shakkan(Sake.alcohol_stock(include_empty: include_empty?(params[:q])))}") %>
+      <% search = "#{params.dig(:q, :all_text_cont)} - " || "" %>
+      <% stock = to_shakkan(Sake.alcohol_stock(include_empty: include_empty?(params[:q]))) %>
+      <%# ヘッダタイトルとページタイトル %>
+      <%= title("#{search}#{t('.title')}", "#{t('.title')} - #{stock}") %>
     </h1>
   </div>
   <div class="col">

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -16,7 +16,8 @@
           <%= f.label(:all_text_cont, "search word", class: "form-label visually-hidden") %>
           <%= f.search_field(:all_text_cont,
                              class: "form-control",
-                             value: params.dig(:q, :all_text_cont)) %>
+                             value: params.dig(:q, :all_text_cont),
+                             data: { testid: "text_search" }) %>
           <%= tag.button(tag.i(class: "bi-search"),
                          type: "submit",
                          class: "btn btn-primary",

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -6,7 +6,8 @@
 <div class="row row-cols-1 g-3">
   <div class="col">
     <h1 class="mb-0" data-testid="total_sake">
-      <% search = "#{params.dig(:q, :all_text_cont)} - " || "" %>
+      <% search_text = params.dig(:q, :all_text_cont) %>
+      <% search = search_text.present? ? "#{search_text} - " : "" %>
       <% stock = to_shakkan(Sake.alcohol_stock(include_empty: include_empty?(params[:q]))) %>
       <%# ヘッダタイトルとページタイトル %>
       <%= title("#{search}#{t('.title')}", "#{t('.title')} - #{stock}") %>

--- a/spec/helpers/sakes_helper_spec.rb
+++ b/spec/helpers/sakes_helper_spec.rb
@@ -127,4 +127,40 @@ RSpec.describe SakesHelper do
       end
     end
   end
+
+  describe "title_with_search" do
+    context "without search word" do
+      it "returns only title" do
+        title = I18n.t("sakes.index.title")
+        expect(title_with_search(nil)).to eq(title)
+      end
+    end
+
+    context "with search word" do
+      it "returns title with search word" do
+        searched = "生路井"
+        title = "生路井 - #{I18n.t('sakes.index.title')}"
+        expect(title_with_search(searched)).to eq(title)
+      end
+    end
+  end
+
+  describe "title_with_stock" do
+    before do
+      create(:sake, size: 720, bottle_level: "sealed")
+      create(:sake, size: 1800, bottle_level: "empty")
+    end
+
+    it "returns title with 4合" do
+      include_empty = false
+      title = "#{I18n.t('.sakes.index.title')} - 4合"
+      expect(title_with_stock(include_empty)).to eq(title)
+    end
+
+    it "returns title with 1升4合" do
+      include_empty = true
+      title = "#{I18n.t('.sakes.index.title')} - 1升4合"
+      expect(title_with_stock(include_empty)).to eq(title)
+    end
+  end
 end

--- a/spec/views/sakes/index.html.erb_spec.rb
+++ b/spec/views/sakes/index.html.erb_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "sakes/index", type: :system do
       end
     end
 
-    context "when searching" do
+    context "when searching with some word" do
       before do
         fill_in("text_search", with: "検索中の酒")
         click_button("submit_search")
@@ -41,6 +41,18 @@ RSpec.describe "sakes/index", type: :system do
       it "has title with searching words" do
         title = "検索中の酒 - #{I18n.t('sakes.index.title')} - SAKAZUKI"
         expect(page).to have_title(title)
+      end
+    end
+
+    context "when searching with empty word" do
+      before do
+        fill_in("text_search", with: "")
+        click_button("submit_search")
+      end
+
+      it "does not have title with searching words separator" do
+        title = "- #{I18n.t('sakes.index.title')} - SAKAZUKI"
+        expect(page).not_to have_title(title)
       end
     end
   end

--- a/spec/views/sakes/index.html.erb_spec.rb
+++ b/spec/views/sakes/index.html.erb_spec.rb
@@ -2,19 +2,45 @@ require "rails_helper"
 
 # Capybaraを使うためにsystem specを指定する
 RSpec.describe "sakes/index", type: :system do
-  let!(:sake) { create(:sake) }
+  let!(:sake) { create(:sake, size: 720) }
 
-  describe "index page" do
-    before do
-      visit sakes_path
+  before do
+    visit sakes_path
+  end
+
+  describe "sake" do
+    it "has link to edit" do
+      buttons = "sake_buttons_#{sake.id}"
+      text = I18n.t("sakes.sake.edit")
+      path = edit_sake_path(sake.id)
+      expect(find(:test_id, buttons)).to have_link(text, href: path)
+    end
+  end
+
+  describe "title" do
+    it "has title with total amount of sake" do
+      title = "#{I18n.t('sakes.index.title')} - 4合"
+      expect(page).to have_text(title)
+    end
+  end
+
+  describe "title meta tag" do
+    context "when not searching" do
+      it "has title" do
+        title = "#{I18n.t('sakes.index.title')} - SAKAZUKI"
+        expect(page).to have_title(title)
+      end
     end
 
-    context "for a sake" do
-      it "has edit link" do
-        buttons = "sake_buttons_#{sake.id}"
-        text = I18n.t("sakes.sake.edit")
-        path = edit_sake_path(sake.id)
-        expect(find(:test_id, buttons)).to have_link(text, href: path)
+    context "when searching" do
+      before do
+        fill_in("text_search", with: "検索中の酒")
+        click_button("submit_search")
+      end
+
+      it "has title with searching words" do
+        title = "検索中の酒 - #{I18n.t('sakes.index.title')} - SAKAZUKI"
+        expect(page).to have_title(title)
       end
     end
   end


### PR DESCRIPTION
close #541 

# やったこと

- 酒indexにおけるメタタグのタイトルの変更
  - 酒の総量は含めないようにした
  - 検索中のときは検索ワードを含めるようにした
- 酒indexのH1タイトルとメタタグタイトルのビューテストを追加
