### PR TITLE
開発環境DockerのDebianバージョンをbullseyeにあげた

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.3-labs
-FROM ruby:3.1.2-slim-buster
+FROM ruby:3.1.2-slim-bullseye
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
@@ -7,10 +7,10 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN <<EOF
   apt-get update -qq
   DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
-    curl=7.64.* build-essential=12.6 gnupg2=2.2.*
+    curl=7.74.* build-essential=12.9 gnupg2=2.2.*
 
   curl -sSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-  echo "deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main" \
+  echo "deb http://apt.postgresql.org/pub/repos/apt bullseye-pgdg main" \
     > /etc/apt/sources.list.d/pgdg.list
 
   curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -14,11 +14,11 @@ RUN <<EOF
   echo "deb http://apt.postgresql.org/pub/repos/apt bullseye-pgdg main" \
     > /etc/apt/sources.list.d/pgdg.list
 
-  curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+  curl -sSL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
   echo "deb https://dl.yarnpkg.com/debian/ stable main" | \
     tee /etc/apt/sources.list.d/yarn.list
 
-  curl -sL https://deb.nodesource.com/setup_18.x | bash -
+  curl -sSL https://deb.nodesource.com/setup_18.x | bash -
 
   apt-get update -qq
   DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -10,8 +10,8 @@ RUN <<EOF
   DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
     curl=7.74.* build-essential=12.9 gnupg2=2.2.*
 
-  curl -sSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-  echo "deb http://apt.postgresql.org/pub/repos/apt bullseye-pgdg main" \
+  curl -sSL https://www.postgresql.org/media/keys/ACCC4CF8.asc -o /usr/share/keyrings/pgdg.asc
+  echo "deb [signed-by=/usr/share/keyrings/pgdg.asc] http://apt.postgresql.org/pub/repos/apt bullseye-pgdg main" \
     > /etc/apt/sources.list.d/pgdg.list
 
   curl -sSL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor \

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -14,9 +14,10 @@ RUN <<EOF
   echo "deb http://apt.postgresql.org/pub/repos/apt bullseye-pgdg main" \
     > /etc/apt/sources.list.d/pgdg.list
 
-  curl -sSL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-  echo "deb https://dl.yarnpkg.com/debian/ stable main" | \
-    tee /etc/apt/sources.list.d/yarn.list
+  curl -sSL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor \
+    > /usr/share/keyrings/yarnkey.gpg
+  echo "deb [signed-by=/usr/share/keyrings/yarnkey.gpg] https://dl.yarnpkg.com/debian stable main" \
+    > /etc/apt/sources.list.d/yarn.list
 
   curl -sSL https://deb.nodesource.com/setup_18.x | bash -
 

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -6,6 +6,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Install build tools, posgresql-client, yarn and node
 RUN <<EOF
   apt-get update -qq
+  apt-get upgrade -y
   DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
     curl=7.74.* build-essential=12.9 gnupg2=2.2.*
 


### PR DESCRIPTION
close #508
close #511

## やったこと

- ベースDockerイメージをbusterからbullseyeにあげた
- apt-keyをやめた
  - keyringsは`/usr/share/keyrings/`まとめた
- 軽度なりファクタ
  - Dockerfileにapt-get upgradeを追加した
  - curlのオプションを揃えた
