### PR TITLE
酒のDate型カラムをRailsの命名規則に合わせた

### DIFF
--- a/app/controllers/sakes_controller.rb
+++ b/app/controllers/sakes_controller.rb
@@ -138,7 +138,7 @@ class SakesController < ApplicationController
   # @param key [Symbol] 酒カラム
   # @return [Boolean] コピー対象のキーならtrue
   def copy_key?(key)
-    %w[alcohol aminosando bindume_date brew_year genryomai hiire kakemai kobo
+    %w[alcohol aminosando bindume_on brew_year genryomai hiire kakemai kobo
        kura moto name nihonshudo price roka sando season seimai_buai shibori
        size todofuken tokutei_meisho warimizu].include?(key)
   end
@@ -179,7 +179,7 @@ class SakesController < ApplicationController
   # Only allow a list of trusted parameters through.
   def sake_params
     params.require(:sake)
-          .permit(:name, :kura, :bindume_date, :brew_year,
+          .permit(:name, :kura, :bindume_on, :brew_year,
                   :todofuken, :taste_value, :aroma_value,
                   :nihonshudo, :sando, :aroma_impression,
                   :color, :taste_impression, :nigori, :awa,

--- a/app/controllers/sakes_controller.rb
+++ b/app/controllers/sakes_controller.rb
@@ -43,7 +43,7 @@ class SakesController < ApplicationController
       attr = copy_attributes(copied)
       @sake = Sake.new(attr)
     else
-      @sake = Sake.new(size: 720, brew_year: to_by(Time.current))
+      @sake = Sake.new(size: 720, brewery_year: to_by(Time.current))
     end
   end
 
@@ -138,7 +138,7 @@ class SakesController < ApplicationController
   # @param key [Symbol] 酒カラム
   # @return [Boolean] コピー対象のキーならtrue
   def copy_key?(key)
-    %w[alcohol aminosando bindume_on brew_year genryomai hiire kakemai kobo
+    %w[alcohol aminosando bindume_on brewery_year genryomai hiire kakemai kobo
        kura moto name nihonshudo price roka sando season seimai_buai shibori
        size todofuken tokutei_meisho warimizu].include?(key)
   end
@@ -179,7 +179,7 @@ class SakesController < ApplicationController
   # Only allow a list of trusted parameters through.
   def sake_params
     params.require(:sake)
-          .permit(:name, :kura, :bindume_on, :brew_year,
+          .permit(:name, :kura, :bindume_on, :brewery_year,
                   :todofuken, :taste_value, :aroma_value,
                   :nihonshudo, :sando, :aroma_impression,
                   :color, :taste_impression, :nigori, :awa,

--- a/app/models/sake.rb
+++ b/app/models/sake.rb
@@ -8,9 +8,9 @@
 #  aroma_impression :text
 #  aroma_value      :integer
 #  awa              :string
-#  bindume_date     :date
+#  bindume_on       :date
 #  bottle_level     :integer          default("sealed")
-#  brew_year        :date
+#  brewery_year     :date
 #  color            :string
 #  emptied_at       :datetime         default(Fri, 01 Jan 2021 00:00:00.000000000 JST +09:00), not null
 #  genryomai        :string

--- a/app/views/sakes/_form_abstract.html.erb
+++ b/app/views/sakes/_form_abstract.html.erb
@@ -100,9 +100,9 @@
                   <input type="hidden" id="sake_<%= :brew_year %>_3i" name="sake[<%= :brew_year %>(3i)]" value="1">
                 </div>
                 <div class="col-12">
-                  <%= form.label(:bindume_date, class: "form-label") %>
+                  <%= form.label(:bindume_on, class: "form-label") %>
                   <div class="w-100"></div>
-                  <%= form.date_select(:bindume_date,
+                  <%= form.date_select(:bindume_on,
                                        {
                                          start_year: Time.current.year - start_year_limit,
                                          end_year: Time.current.year,

--- a/app/views/sakes/_form_abstract.html.erb
+++ b/app/views/sakes/_form_abstract.html.erb
@@ -81,23 +81,23 @@
             <div class="col-12 col-lg-6">
               <div class="row g-2">
                 <div class="col-12">
-                  <%= form.label(:brew_year, class: "form-label") %>
+                  <%= form.label(:brewery_year, class: "form-label") %>
                   <%# HACK: 不明を最後に表示するため、form.date_selectを使わない %>
-                  <%= form.select(:brew_year,
+                  <%= form.select(:brewery_year,
                                   nil,
                                   {},
-                                  id: "sake_brew_year_1i",
-                                  name: "sake[brew_year(1i)]",
+                                  id: "sake_brewery_year_1i",
+                                  name: "sake[brewery_year(1i)]",
                                   class: "form-select w-50",
-                                  data: { testid: "sake_brew_year" }) do %>
+                                  data: { testid: "sake_brewery_year" }) do %>
                     <% by_range.each do |by| %>
-                      <%= tag.option(with_japanese_era(by), value: by.year, selected: by.year == sake.brew_year&.year) %>
+                      <%= tag.option(with_japanese_era(by), value: by.year, selected: by.year == sake.brewery_year&.year) %>
                     <% end %>
-                    <%= tag.option(t(".unknown"), value: "", selected: sake.brew_year.nil?) %>
+                    <%= tag.option(t(".unknown"), value: "", selected: sake.brewery_year.nil?) %>
                   <% end %>
                   <%# 使わない月日はBY始まりの7/1とする. SEE: SakesHelper.to_by %>
-                  <input type="hidden" id="sake_<%= :brew_year %>_2i" name="sake[<%= :brew_year %>(2i)]" value="7">
-                  <input type="hidden" id="sake_<%= :brew_year %>_3i" name="sake[<%= :brew_year %>(3i)]" value="1">
+                  <input type="hidden" id="sake_<%= :brewery_year %>_2i" name="sake[<%= :brewery_year %>(2i)]" value="7">
+                  <input type="hidden" id="sake_<%= :brewery_year %>_3i" name="sake[<%= :brewery_year %>(3i)]" value="1">
                 </div>
                 <div class="col-12">
                   <%= form.label(:bindume_on, class: "form-label") %>

--- a/app/views/sakes/_sake.json.jbuilder
+++ b/app/views/sakes/_sake.json.jbuilder
@@ -1,6 +1,6 @@
 json.extract!(sake,
               :id, :alcohol, :aminosando, :aroma_impression, :aroma_value,
-              :awa, :bindume_on, :bottle_level, :brew_year, :color,
+              :awa, :bindume_on, :bottle_level, :brewery_year, :color,
               :genryomai, :hiire, :kakemai, :kobo, :kura, :moto, :name,
               :nigori, :nihonshudo, :note, :price, :roka, :sando, :season,
               :seimai_buai, :shibori, :size, :taste_impression, :taste_value,

--- a/app/views/sakes/_sake.json.jbuilder
+++ b/app/views/sakes/_sake.json.jbuilder
@@ -1,6 +1,6 @@
 json.extract!(sake,
               :id, :alcohol, :aminosando, :aroma_impression, :aroma_value,
-              :awa, :bindume_date, :bottle_level, :brew_year, :color,
+              :awa, :bindume_on, :bottle_level, :brew_year, :color,
               :genryomai, :hiire, :kakemai, :kobo, :kura, :moto, :name,
               :nigori, :nihonshudo, :note, :price, :roka, :sando, :season,
               :seimai_buai, :shibori, :size, :taste_impression, :taste_value,

--- a/app/views/sakes/_show_abstract.html.erb
+++ b/app/views/sakes/_show_abstract.html.erb
@@ -34,9 +34,9 @@
           <%= sake.brew_year.year %>
           <%= Sake.human_attribute_name(:brew_year) %>
         <% end %>
-        <%= "‒" if sake.brew_year.present? && sake.bindume_date.present? %>
-        <% if sake.bindume_date.present? %>
-          <%= sake.bindume_date.strftime("%Y/%m") %>
+        <%= "‒" if sake.brew_year.present? && sake.bindume_on.present? %>
+        <% if sake.bindume_on.present? %>
+          <%= sake.bindume_on.strftime("%Y/%m") %>
           <%= t(".made") %>
         <% end %>
       </div>

--- a/app/views/sakes/_show_abstract.html.erb
+++ b/app/views/sakes/_show_abstract.html.erb
@@ -30,11 +30,11 @@
         </div>
       <% end %>
       <div class="col-auto <%= "ps-0" if sake.season.present? %>">
-        <% if sake.brew_year.present? %>
-          <%= sake.brew_year.year %>
-          <%= Sake.human_attribute_name(:brew_year) %>
+        <% if sake.brewery_year.present? %>
+          <%= sake.brewery_year.year %>
+          <%= Sake.human_attribute_name(:brewery_year) %>
         <% end %>
-        <%= "‒" if sake.brew_year.present? && sake.bindume_on.present? %>
+        <%= "‒" if sake.brewery_year.present? && sake.bindume_on.present? %>
         <% if sake.bindume_on.present? %>
           <%= sake.bindume_on.strftime("%Y/%m") %>
           <%= t(".made") %>

--- a/config/locales/models/sake.ja.yml
+++ b/config/locales/models/sake.ja.yml
@@ -7,7 +7,7 @@ ja:
         name: 名前
         kura: 蔵
         photos: 画像
-        bindume_date: 製造年月日
+        bindume_on: 製造年月日
         brew_year: BY
         todofuken: 都道府県
         taste_value: 味の濃淡

--- a/config/locales/models/sake.ja.yml
+++ b/config/locales/models/sake.ja.yml
@@ -8,7 +8,7 @@ ja:
         kura: 蔵
         photos: 画像
         bindume_on: 製造年月日
-        brew_year: BY
+        brewery_year: BY
         todofuken: 都道府県
         taste_value: 味の濃淡
         aroma_value: 香りの高低

--- a/db/migrate/20230216073620_rename_date_columns.rb
+++ b/db/migrate/20230216073620_rename_date_columns.rb
@@ -1,0 +1,6 @@
+class RenameDateColumns < ActiveRecord::Migration[7.0]
+  def change
+    rename_column(:sakes, :bindume_date, :bindume_on)
+    rename_column(:sakes, :brew_year, :brewery_year)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,23 +10,25 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_27_072306) do
-
+ActiveRecord::Schema[7.0].define(version: 2023_02_16_073620) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "data_migrations", primary_key: "version", id: :string, force: :cascade do |t|
+  end
 
   create_table "photos", force: :cascade do |t|
     t.string "image"
     t.integer "sake_id"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "sakes", force: :cascade do |t|
     t.string "name"
     t.string "kura"
-    t.date "bindume_date"
-    t.date "brew_year"
+    t.date "bindume_on"
+    t.date "brewery_year"
     t.string "todofuken"
     t.integer "taste_value"
     t.integer "aroma_value"
@@ -54,10 +56,10 @@ ActiveRecord::Schema.define(version: 2022_01_27_072306) do
     t.integer "hiire", default: 0
     t.integer "price"
     t.integer "size"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.datetime "opened_at", precision: 6, default: "2021-01-01 00:00:00", null: false
-    t.datetime "emptied_at", precision: 6, default: "2021-01-01 00:00:00", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "opened_at", default: "2021-01-01 00:00:00", null: false
+    t.datetime "emptied_at", default: "2021-01-01 00:00:00", null: false
     t.integer "rating", default: 0, null: false
   end
 
@@ -65,27 +67,27 @@ ActiveRecord::Schema.define(version: 2022_01_27_072306) do
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
+    t.datetime "reset_password_sent_at", precision: nil
+    t.datetime "remember_created_at", precision: nil
     t.integer "sign_in_count", default: 0, null: false
-    t.datetime "current_sign_in_at"
-    t.datetime "last_sign_in_at"
+    t.datetime "current_sign_in_at", precision: nil
+    t.datetime "last_sign_in_at", precision: nil
     t.string "current_sign_in_ip"
     t.string "last_sign_in_ip"
     t.integer "failed_attempts", default: 0, null: false
     t.string "unlock_token"
-    t.datetime "locked_at"
+    t.datetime "locked_at", precision: nil
     t.boolean "admin", default: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "confirmation_token"
-    t.datetime "confirmed_at"
-    t.datetime "confirmation_sent_at"
+    t.datetime "confirmed_at", precision: nil
+    t.datetime "confirmation_sent_at", precision: nil
     t.string "unconfirmed_email"
     t.string "invitation_token"
-    t.datetime "invitation_created_at"
-    t.datetime "invitation_sent_at"
-    t.datetime "invitation_accepted_at"
+    t.datetime "invitation_created_at", precision: nil
+    t.datetime "invitation_sent_at", precision: nil
+    t.datetime "invitation_accepted_at", precision: nil
     t.integer "invitation_limit"
     t.integer "invited_by_id"
     t.string "invited_by_type"
@@ -94,4 +96,5 @@ ActiveRecord::Schema.define(version: 2022_01_27_072306) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
   end
+
 end

--- a/spec/factories/sakes.rb
+++ b/spec/factories/sakes.rb
@@ -8,9 +8,9 @@
 #  aroma_impression :text
 #  aroma_value      :integer
 #  awa              :string
-#  bindume_date     :date
+#  bindume_on       :date
 #  bottle_level     :integer          default("sealed")
-#  brew_year        :date
+#  brewery_year     :date
 #  color            :string
 #  emptied_at       :datetime         default(Fri, 01 Jan 2021 00:00:00.000000000 JST +09:00), not null
 #  genryomai        :string

--- a/spec/models/sake_spec.rb
+++ b/spec/models/sake_spec.rb
@@ -8,9 +8,9 @@
 #  aroma_impression :text
 #  aroma_value      :integer
 #  awa              :string
-#  bindume_date     :date
+#  bindume_on       :date
 #  bottle_level     :integer          default("sealed")
-#  brew_year        :date
+#  brewery_year     :date
 #  color            :string
 #  emptied_at       :datetime         default(Fri, 01 Jan 2021 00:00:00.000000000 JST +09:00), not null
 #  genryomai        :string

--- a/spec/system/copy_sakes_spec.rb
+++ b/spec/system/copy_sakes_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Copy Sakes", type: :system do
            aroma_impression: "華やかな吟醸香",
            taste_impression: "フレッシュな味",
            awa: "微炭酸", note: "今年は米が硬かった",
-           bindume_date: Date.new(2002, 2, 1),
+           bindume_on: Date.new(2002, 2, 1),
            brew_year: Date.new(2001, 7, 1),
            taste_value: 5, aroma_value: 5, nihonshudo: 1.0,
            sando: 1.3, aminosando: 0.8, tokutei_meisho: :junmai_ginjo,
@@ -91,16 +91,16 @@ RSpec.describe "Copy Sakes", type: :system do
       end
     end
 
-    describe "bindume_date year" do
+    describe "bindume_on year" do
       it "has copied bindume year", js: true do
-        year = with_japanese_era(sake.bindume_date)
+        year = with_japanese_era(sake.bindume_on)
         expect(page).to have_select(test_id: "sake_bindume_year", selected: year)
       end
     end
 
-    describe "bindume_date month" do
+    describe "bindume_on month" do
       it "has copied bindume month", js: true do
-        month = I18n.l(sake.bindume_date, format: "%b")
+        month = I18n.l(sake.bindume_on, format: "%b")
         expect(page).to have_select(test_id: "sake_bindume_month", selected: month)
       end
     end

--- a/spec/system/copy_sakes_spec.rb
+++ b/spec/system/copy_sakes_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Copy Sakes", type: :system do
            taste_impression: "フレッシュな味",
            awa: "微炭酸", note: "今年は米が硬かった",
            bindume_on: Date.new(2002, 2, 1),
-           brew_year: Date.new(2001, 7, 1),
+           brewery_year: Date.new(2001, 7, 1),
            taste_value: 5, aroma_value: 5, nihonshudo: 1.0,
            sando: 1.3, aminosando: 0.8, tokutei_meisho: :junmai_ginjo,
            alcohol: 18, warimizu: :genshu, moto: :sokujo, bottle_level: :empty,
@@ -105,10 +105,10 @@ RSpec.describe "Copy Sakes", type: :system do
       end
     end
 
-    describe "brew_year" do
-      it "has copied brew_year" do
-        by = with_japanese_era(sake.brew_year)
-        expect(page).to have_select(test_id: "sake_brew_year", selected: by)
+    describe "brewery_year" do
+      it "has copied brewery_year" do
+        by = with_japanese_era(sake.brewery_year)
+        expect(page).to have_select(test_id: "sake_brewery_year", selected: by)
       end
     end
   end

--- a/spec/system/sake_form_bindume_date_spec.rb
+++ b/spec/system/sake_form_bindume_date_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Sake Form Bindume Date", type: :system do
     sign_in user
   end
 
-  describe "year of bindume_date" do
+  describe "year of bindume_on" do
     context "when visiting new sake page" do
       before do
         visit new_sake_path
@@ -18,57 +18,57 @@ RSpec.describe "Sake Form Bindume Date", type: :system do
 
       it "selects this year" do
         year = with_japanese_era(Time.current)
-        expect(page).to have_select("sake_bindume_date_1i", selected: year)
+        expect(page).to have_select("sake_bindume_on_1i", selected: year)
       end
     end
 
-    context "when creating sake whoes bindume_date is this year" do
+    context "when creating sake whoes bindume_on is this year" do
       before do
         visit new_sake_path
         fill_in("sake_name", with: "生道井")
         year = with_japanese_era(Time.current)
-        select(year, from: "sake_bindume_date_1i")
+        select(year, from: "sake_bindume_on_1i")
         click_button("form_submit")
       end
 
       it "has this year" do
         sake = sake_from_show_path(page.current_path)
-        expect(sake.bindume_date.year).to eq(Time.current.year)
+        expect(sake.bindume_on.year).to eq(Time.current.year)
       end
     end
 
-    context "when creating sake whoes bindume_date is past year" do
+    context "when creating sake whoes bindume_on is past year" do
       ago = Time.current.ago(10.years)
 
       before do
         visit new_sake_path
         fill_in("sake_name", with: "生道井")
         year = with_japanese_era(ago)
-        select(year, from: "sake_bindume_date_1i")
+        select(year, from: "sake_bindume_on_1i")
         click_button("form_submit")
       end
 
       it "has past year" do
         sake = sake_from_show_path(page.current_path)
-        expect(sake.bindume_date.year).to eq(ago.year)
+        expect(sake.bindume_on.year).to eq(ago.year)
       end
     end
 
     context "when visiting edit sake page" do
-      let(:sake) { create(:sake, bindume_date: Date.parse("2021-07-01")) }
+      let(:sake) { create(:sake, bindume_on: Date.parse("2021-07-01")) }
 
       before do
         visit edit_sake_path(sake.id)
       end
 
       it "selects the year of sake" do
-        year = with_japanese_era(sake.bindume_date)
-        expect(page).to have_select("sake_bindume_date_1i", selected: year)
+        year = with_japanese_era(sake.bindume_on)
+        expect(page).to have_select("sake_bindume_on_1i", selected: year)
       end
     end
   end
 
-  describe "month of bindume_date" do
+  describe "month of bindume_on" do
     context "when visiting new sake page" do
       before do
         visit new_sake_path
@@ -76,50 +76,50 @@ RSpec.describe "Sake Form Bindume Date", type: :system do
 
       it "selected this month" do
         month = I18n.l(Time.current, format: "%b")
-        expect(page).to have_select("sake_bindume_date_2i", selected: month)
+        expect(page).to have_select("sake_bindume_on_2i", selected: month)
       end
     end
 
-    context "when creating sake whoes bindume_date is January" do
+    context "when creating sake whoes bindume_on is January" do
       before do
         visit new_sake_path
         fill_in("sake_name", with: "生道井")
         month = I18n.l(Time.zone.parse("2022-01-01 10:30:00"), format: "%b")
-        select(month, from: "sake_bindume_date_2i")
+        select(month, from: "sake_bindume_on_2i")
         click_button("form_submit")
       end
 
       it "has January" do
         sake = sake_from_show_path(page.current_path)
-        expect(sake.bindume_date.month).to eq(1)
+        expect(sake.bindume_on.month).to eq(1)
       end
     end
 
-    context "when creating sake whoes bindume_date is December" do
+    context "when creating sake whoes bindume_on is December" do
       before do
         visit new_sake_path
         fill_in("sake_name", with: "生道井")
         month = I18n.l(Time.zone.parse("2022-12-01 10:30:00"), format: "%b")
-        select(month, from: "sake_bindume_date_2i")
+        select(month, from: "sake_bindume_on_2i")
         click_button("form_submit")
       end
 
       it "has December" do
         sake = sake_from_show_path(page.current_path)
-        expect(sake.bindume_date.month).to eq(12)
+        expect(sake.bindume_on.month).to eq(12)
       end
     end
 
     context "when visiting edit sake page" do
-      let(:sake) { create(:sake, bindume_date: Date.parse("2021-07-01")) }
+      let(:sake) { create(:sake, bindume_on: Date.parse("2021-07-01")) }
 
       before do
         visit edit_sake_path(sake.id)
       end
 
       it "selects the month of sake" do
-        month = I18n.l(sake.bindume_date, format: "%b")
-        expect(page).to have_select("sake_bindume_date_2i", selected: month)
+        month = I18n.l(sake.bindume_on, format: "%b")
+        expect(page).to have_select("sake_bindume_on_2i", selected: month)
       end
     end
   end

--- a/spec/system/sake_form_brewery_year_spec.rb
+++ b/spec/system/sake_form_brewery_year_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Sake Form Brew Year", type: :system do
     sign_in(user)
   end
 
-  describe "brew_year" do
+  describe "brewery_year" do
     context "when visiting new sake page before 7/1" do
       before do
         datetime = Time.zone.parse("2022-06-30 20:30:00")
@@ -20,7 +20,7 @@ RSpec.describe "Sake Form Brew Year", type: :system do
 
       it "selects this BY, not same with this year" do
         by = with_japanese_era(to_by(Time.current))
-        expect(page).to have_select("sake_brew_year", selected: by)
+        expect(page).to have_select("sake_brewery_year", selected: by)
       end
     end
 
@@ -33,7 +33,7 @@ RSpec.describe "Sake Form Brew Year", type: :system do
 
       it "selects this BY, same with this year" do
         by = with_japanese_era(to_by(Time.current))
-        expect(page).to have_select("sake_brew_year", selected: by)
+        expect(page).to have_select("sake_brewery_year", selected: by)
       end
     end
 
@@ -42,13 +42,13 @@ RSpec.describe "Sake Form Brew Year", type: :system do
         visit new_sake_path
         fill_in("sake_name", with: "生道井")
         by = with_japanese_era(to_by(Time.current))
-        select(by, from: "sake_brew_year")
+        select(by, from: "sake_brewery_year")
         click_button("form_submit")
       end
 
       it "has this BY" do
         sake = sake_from_show_path(page.current_path)
-        expect(sake.brew_year).to eq(to_by(Time.current))
+        expect(sake.brewery_year).to eq(to_by(Time.current))
       end
     end
 
@@ -59,31 +59,31 @@ RSpec.describe "Sake Form Brew Year", type: :system do
         visit new_sake_path
         fill_in("sake_name", with: "生道井")
         by = with_japanese_era(to_by(ago))
-        select(by, from: "sake_brew_year")
+        select(by, from: "sake_brewery_year")
         click_button("form_submit")
       end
 
       it "has past BY" do
         sake = sake_from_show_path(page.current_path)
-        expect(sake.brew_year).to eq(to_by(ago))
+        expect(sake.brewery_year).to eq(to_by(ago))
       end
     end
 
     context "when visiting edit page for sake having BY" do
-      let(:sake) { create(:sake, brew_year: Date.new(2021, 7, 1)) }
+      let(:sake) { create(:sake, brewery_year: Date.new(2021, 7, 1)) }
 
       before do
         visit edit_sake_path(sake.id)
       end
 
       it "selects the BY of sake" do
-        by = with_japanese_era(sake.brew_year)
-        expect(page).to have_select("sake_brew_year", selected: by)
+        by = with_japanese_era(sake.brewery_year)
+        expect(page).to have_select("sake_brewery_year", selected: by)
       end
     end
 
     context "when visiting edit page for sake not having BY" do
-      let(:sake) { create(:sake, brew_year: nil) }
+      let(:sake) { create(:sake, brewery_year: nil) }
 
       before do
         visit edit_sake_path(sake.id)
@@ -91,7 +91,7 @@ RSpec.describe "Sake Form Brew Year", type: :system do
 
       it "selects nil" do
         text = I18n.t("sakes.form_abstract.unknown")
-        expect(page).to have_select("sake_brew_year", selected: text)
+        expect(page).to have_select("sake_brewery_year", selected: text)
       end
     end
   end


### PR DESCRIPTION
close #402

**`rails db:migrate`が必要！**

## やったこと

- DBカラム名を変更するマイグレーションを作成
  - bindume_date -> bindume_on
  - brew_year -> brewery_year
- マイグレーション`rails db:migrate`の実行
- カラム名の変更に合わせて既存変数やファイル名を変更
