### PR TITLE
酒フォームで製造年月の年と月を1つのセレクタで選ぶようにした

### DIFF
--- a/app/assets/stylesheets/sakes_form.scss
+++ b/app/assets/stylesheets/sakes_form.scss
@@ -1,18 +1,6 @@
 @import "./bootstrap/custom";
 @import "bootstrap/scss/bootstrap";
 
-// Railsがdatte_selectで生成する日付セレクトのスタイル
-
-.year {
-  @extend .w-50;
-  @extend .me-1;
-  @extend .me-lg-2;
-}
-
-.month {
-  @extend .w-25;
-}
-
 .select-delete-photos input[type="checkbox"] {
   display: none;
 }

--- a/app/controllers/sakes_controller.rb
+++ b/app/controllers/sakes_controller.rb
@@ -27,7 +27,6 @@ class SakesController < ApplicationController
     # Kaminari pager
     @sakes = @sakes.page(params[:page]) if include_empty?(query)
   end
-
   # rubocop:enable Metrics/AbcSize
 
   # GET /sakes/1
@@ -266,5 +265,4 @@ class SakesController < ApplicationController
     view_context.link_to(text, path, { class: "alert-link" })
   end
 end
-
 # rubocop:enable Metrics/ClassLength

--- a/app/controllers/sakes_controller.rb
+++ b/app/controllers/sakes_controller.rb
@@ -43,7 +43,7 @@ class SakesController < ApplicationController
       attr = copy_attributes(copied)
       @sake = Sake.new(attr)
     else
-      @sake = Sake.new(size: 720, brewery_year: to_by(Time.current))
+      @sake = Sake.new(size: 720, brewery_year: to_by(Time.current), bindume_on: to_day_one(Time.current))
     end
   end
 

--- a/app/controllers/sakes_controller.rb
+++ b/app/controllers/sakes_controller.rb
@@ -36,15 +36,13 @@ class SakesController < ApplicationController
 
   # GET /sakes/new
   def new
-    copied_id = params[:copied_from]
-    if copied_id
-      copied = Sake.find(copied_id)
-      flash[:info] = t(".copy", name: alert_link_tag(copied.name, sake_path(copied_id)))
-      attr = copy_attributes(copied)
-      @sake = Sake.new(attr)
-    else
-      @sake = Sake.new(size: 720, brewery_year: to_by(Time.current), bindume_on: to_day_one(Time.current))
-    end
+    copy = params[:copied_from].present?
+    copied = Sake.find(params[:copied_from]) if copy
+
+    attr = copy ? copy_attributes(copied) : default_attributes
+    @sake = Sake.new(attr)
+
+    flash[:info] = t(".copy", name: alert_link_tag(copied.name, sake_path(copied))) if copy
   end
 
   # GET /sakes/1/edit
@@ -152,6 +150,17 @@ class SakesController < ApplicationController
   def copy_attributes(sake)
     all = sake.attributes
     all.select { |key, _v| copy_key?(key) }
+  end
+
+  # 新規酒のデフォルト情報をもったハッシュを作成する
+  #
+  # @return [Hash<Symbol => Integer, Date>] デフォルト酒情報のハッシュ
+  def default_attributes
+    {
+      size: 720,
+      brewery_year: to_by(Time.current),
+      bindume_on: to_day_one(Time.current),
+    }
   end
 
   # Use callbacks to share common setup or constraints between actions.

--- a/app/controllers/sakes_controller.rb
+++ b/app/controllers/sakes_controller.rb
@@ -160,7 +160,7 @@ class SakesController < ApplicationController
     {
       size: 720,
       brewery_year: to_by(Time.current),
-      bindume_on: to_day_one(Time.current),
+      bindume_on: Time.current.to_date.beginning_of_month,
     }
   end
 

--- a/app/controllers/sakes_controller.rb
+++ b/app/controllers/sakes_controller.rb
@@ -35,13 +35,15 @@ class SakesController < ApplicationController
 
   # GET /sakes/new
   def new
-    copy = params[:copied_from].present?
-    copied = Sake.find(params[:copied_from]) if copy
-
-    attr = copy ? copy_attributes(copied) : default_attributes
-    @sake = Sake.new(attr)
-
-    flash[:info] = t(".copy", name: alert_link_tag(copied.name, sake_path(copied))) if copy
+    copied_id = params[:copied_from]
+    if copied_id
+      copied = Sake.find(copied_id)
+      attr = copy_attributes(copied)
+      @sake = Sake.new(attr)
+      flash[:info] = t(".copy", name: alert_link_tag(copied.name, sake_path(copied)))
+    else
+      @sake = Sake.new(default_attributes)
+    end
   end
 
   # GET /sakes/1/edit

--- a/app/helpers/sakes_helper.rb
+++ b/app/helpers/sakes_helper.rb
@@ -52,20 +52,15 @@ module SakesHelper
     collection.push([I18n.t("sakes.form_abstract.unknown"), ""])
   end
 
-  # 指定された期間で年月のレンジを作成する
+  # 製造年月で使う30年分の年月のレンジを作成する
   #
-  # 作成されるレンジのステップは1ヶ月となる。
-  #
-  # @example 4500 mlは2升5合
-  #   month_range(Date.parse("2022-12-06", Date.parse("2023-01-06") #=> [2022-12-01, 2023-01-01]のようなレンジ
+  # 作成されるレンジのステップは1ヶ月ごととなる。
   #
   # MEMO:
-  # Dateクラスのレンジオブジェクトを作るため、効率が悪い。
+  # 途中で各日のレンジオブジェクトを作るため、効率が悪い。
   # 具体的な使用例でいうと、30年×365日分のオブジェクトが一時的に作られる。
   # 現状はコードの綺麗さを重視し、動作の重さが気になったら更新する。
   #
-  # @param first [Date] 最初の年月
-  # @param last [Date] 最後の年月
   # @return [Range<Date>] 年月のレンジオブジェクト
   def month_range
     first = Time.current.ago(start_year_limit.years)

--- a/app/helpers/sakes_helper.rb
+++ b/app/helpers/sakes_helper.rb
@@ -32,7 +32,7 @@ module SakesHelper
   def by_range
     this_by = to_by(Time.current).year
     years = (this_by - start_year_limit)..this_by
-    years.map { |year| Date.new(year, 7, 1) }
+    years.map { |year| Date.new(year, 7) } # 7/1
   end
 
   # 日付を和暦付き年の文字列に変換する
@@ -42,6 +42,11 @@ module SakesHelper
   # @return [String] "2021 / 令和3年"のような年の文字列
   def with_japanese_era(date)
     "#{date.year} / #{date.to_era('%O%K-E年')}"
+  end
+
+  def by_collection
+    collection = by_range.map { |d| [with_japanese_era(d), d.to_s] }
+    collection.push([I18n.t("sakes.form_abstract.unknown"), ""])
   end
 
   # Dateオブジェクトの日付を1にする

--- a/app/helpers/sakes_helper.rb
+++ b/app/helpers/sakes_helper.rb
@@ -70,7 +70,7 @@ module SakesHelper
   def month_range
     first = Time.current.ago(start_year_limit.years)
     last = Time.current
-    (first.to_date..last.to_date).map { |d| d.beginning_of_month }.uniq
+    (first.to_date..last.to_date).map(&:beginning_of_month).uniq
   end
 
   # 製造年月の候補を作成する

--- a/app/helpers/sakes_helper.rb
+++ b/app/helpers/sakes_helper.rb
@@ -44,6 +44,9 @@ module SakesHelper
     "#{date.year} / #{date.to_era('%O%K-E年')}"
   end
 
+  # BYの候補を作成する
+  #
+  # @return [Array<String, String>] BYセレクタで使う、表示用文字列と日付データ
   def by_collection
     collection = by_range.map { |d| [with_japanese_era(d), d.to_s] }
     collection.push([I18n.t("sakes.form_abstract.unknown"), ""])

--- a/app/helpers/sakes_helper.rb
+++ b/app/helpers/sakes_helper.rb
@@ -35,13 +35,55 @@ module SakesHelper
     years.map { |year| Date.new(year, 7, 1) }
   end
 
-  # 日付を和暦付き文字列に変換する
+  # 日付を和暦付き年の文字列に変換する
   #
   # 7/1の月日を持つBYのDateオブジェクトを渡しても、正しく和暦をつけることができる。
   # @param date [Date] 日付
-  # @return [String] "2021 / 令和3年"のような文字列
+  # @return [String] "2021 / 令和3年"のような年の文字列
   def with_japanese_era(date)
     "#{date.year} / #{date.to_era('%O%K-E年')}"
+  end
+
+  # Dateオブジェクトの日付を1にする
+  #
+  # @param date [Date] 対象の日付
+  # @return [Date] 日付を1日にしたDate
+  def to_day_one(date)
+    Date.new(date.year, date.month)
+  end
+
+  # 指定された期間で年月のレンジを作成する
+  #
+  # 作成されるレンジのステップは1ヶ月となる。
+  #
+  # @example 4500 mlは2升5合
+  #   month_range(Date.parse("2022-12-06", Date.parse("2023-01-06") #=> [2022-12-01, 2023-01-01]のようなレンジ
+  #
+  # MEMO:
+  # Dateクラスのレンジオブジェクトを作るため、効率が悪い。
+  # 具体的な使用例でいうと、30年×365日分のオブジェクトが一時的に作られる。
+  # 現状はコードの綺麗さを重視し、動作の重さが気になったら更新する。
+  #
+  # @param first [Date] 最初の年月
+  # @param last [Date] 最後の年月
+  # @return [Range<Date>] 年月のレンジオブジェクト
+  def month_range
+    first = Time.current.ago(start_year_limit.years)
+    last = Time.current
+    (first.to_date..last.to_date).map { |d| to_day_one(d) }.uniq
+  end
+
+  # 製造年月の候補を作成する
+  #
+  # 現在の日付から30年分を生成する
+  #
+  # @return [Array<String, String>] 製造年月セレクタで使う、表示用文字列と日付データ
+  def bindume_collection
+    month_range.map { |d|
+      year = with_japanese_era(d)
+      month = I18n.l(d, format: "%B")
+      ["#{year} #{month}", d.to_s]
+    }
   end
 
   # どの瓶状態（bottle_level）にもマッチしない値

--- a/app/helpers/sakes_helper.rb
+++ b/app/helpers/sakes_helper.rb
@@ -52,14 +52,6 @@ module SakesHelper
     collection.push([I18n.t("sakes.form_abstract.unknown"), ""])
   end
 
-  # Dateオブジェクトの日付を1にする
-  #
-  # @param date [Date] 対象の日付
-  # @return [Date] 日付を1日にしたDate
-  def to_day_one(date)
-    Date.new(date.year, date.month)
-  end
-
   # 指定された期間で年月のレンジを作成する
   #
   # 作成されるレンジのステップは1ヶ月となる。
@@ -78,7 +70,7 @@ module SakesHelper
   def month_range
     first = Time.current.ago(start_year_limit.years)
     last = Time.current
-    (first.to_date..last.to_date).map { |d| to_day_one(d) }.uniq
+    (first.to_date..last.to_date).map { |d| d.beginning_of_month }.uniq
   end
 
   # 製造年月の候補を作成する

--- a/app/views/sakes/_form_abstract.html.erb
+++ b/app/views/sakes/_form_abstract.html.erb
@@ -79,22 +79,11 @@
             </div>
             <div class="col-12 col-lg-3">
               <%= form.label(:brewery_year, class: "form-label") %>
-              <%# HACK: 不明を最後に表示するため、form.date_selectを使わない %>
               <%= form.select(:brewery_year,
-                              nil,
+                              by_collection,
                               {},
-                              id: "sake_brewery_year_1i",
-                              name: "sake[brewery_year(1i)]",
                               class: "form-select",
-                              data: { testid: "sake_brewery_year" }) do %>
-                <% by_range.each do |by| %>
-                  <%= tag.option(with_japanese_era(by), value: by.year, selected: by.year == sake.brewery_year&.year) %>
-                <% end %>
-                <%= tag.option(t(".unknown"), value: "", selected: sake.brewery_year.nil?) %>
-              <% end %>
-              <%# 使わない月日はBY始まりの7/1とする. SEE: SakesHelper.to_by %>
-              <input type="hidden" id="sake_<%= :brewery_year %>_2i" name="sake[<%= :brewery_year %>(2i)]" value="7">
-              <input type="hidden" id="sake_<%= :brewery_year %>_3i" name="sake[<%= :brewery_year %>(3i)]" value="1">
+                              data: { testid: "sake_brewery_year" }) %>
             </div>
             <div class="col-12 col-lg-3">
               <%= form.label(:bindume_on, class: "form-label") %>

--- a/app/views/sakes/_form_abstract.html.erb
+++ b/app/views/sakes/_form_abstract.html.erb
@@ -77,42 +77,28 @@
                 <option value="限定酒"></option>
               </datalist>
             </div>
-            <div class="w-100 m-0"></div>
-            <div class="col-12 col-lg-6">
-              <div class="row g-2">
-                <div class="col-12">
-                  <%= form.label(:brewery_year, class: "form-label") %>
-                  <%# HACK: 不明を最後に表示するため、form.date_selectを使わない %>
-                  <%= form.select(:brewery_year,
-                                  nil,
-                                  {},
-                                  id: "sake_brewery_year_1i",
-                                  name: "sake[brewery_year(1i)]",
-                                  class: "form-select w-50",
-                                  data: { testid: "sake_brewery_year" }) do %>
-                    <% by_range.each do |by| %>
-                      <%= tag.option(with_japanese_era(by), value: by.year, selected: by.year == sake.brewery_year&.year) %>
-                    <% end %>
-                    <%= tag.option(t(".unknown"), value: "", selected: sake.brewery_year.nil?) %>
-                  <% end %>
-                  <%# 使わない月日はBY始まりの7/1とする. SEE: SakesHelper.to_by %>
-                  <input type="hidden" id="sake_<%= :brewery_year %>_2i" name="sake[<%= :brewery_year %>(2i)]" value="7">
-                  <input type="hidden" id="sake_<%= :brewery_year %>_3i" name="sake[<%= :brewery_year %>(3i)]" value="1">
-                </div>
-                <div class="col-12">
-                  <%= form.label(:bindume_on, class: "form-label") %>
-                  <div class="w-100"></div>
-                  <%= form.date_select(:bindume_on,
-                                       {
-                                         start_year: Time.current.year - start_year_limit,
-                                         end_year: Time.current.year,
-                                         year_format: ->(year) { with_japanese_era(Date.new(year, 1, 1)) },
-                                         discard_day: true,
-                                         with_css_classes: true,
-                                       },
-                                       class: "form-select d-inline-block") %>
-                </div>
-              </div>
+            <div class="col-12 col-lg-3">
+              <%= form.label(:brewery_year, class: "form-label") %>
+              <%# HACK: 不明を最後に表示するため、form.date_selectを使わない %>
+              <%= form.select(:brewery_year,
+                              nil,
+                              {},
+                              id: "sake_brewery_year_1i",
+                              name: "sake[brewery_year(1i)]",
+                              class: "form-select",
+                              data: { testid: "sake_brewery_year" }) do %>
+                <% by_range.each do |by| %>
+                  <%= tag.option(with_japanese_era(by), value: by.year, selected: by.year == sake.brewery_year&.year) %>
+                <% end %>
+                <%= tag.option(t(".unknown"), value: "", selected: sake.brewery_year.nil?) %>
+              <% end %>
+              <%# 使わない月日はBY始まりの7/1とする. SEE: SakesHelper.to_by %>
+              <input type="hidden" id="sake_<%= :brewery_year %>_2i" name="sake[<%= :brewery_year %>(2i)]" value="7">
+              <input type="hidden" id="sake_<%= :brewery_year %>_3i" name="sake[<%= :brewery_year %>(3i)]" value="1">
+            </div>
+            <div class="col-12 col-lg-3">
+              <%= form.label(:bindume_on, class: "form-label") %>
+              <%= form.select(:bindume_on, bindume_collection, {}, class: "form-select") %>
             </div>
           </div>
         </fieldset>

--- a/app/views/sakes/_form_abstract.html.erb
+++ b/app/views/sakes/_form_abstract.html.erb
@@ -98,7 +98,11 @@
             </div>
             <div class="col-12 col-lg-3">
               <%= form.label(:bindume_on, class: "form-label") %>
-              <%= form.select(:bindume_on, bindume_collection, {}, class: "form-select") %>
+              <%= form.select(:bindume_on,
+                              bindume_collection,
+                              {},
+                              class: "form-select",
+                              data: { testid: "sake_bindume_on" }) %>
             </div>
           </div>
         </fieldset>

--- a/config/locales/models/sake.ja.yml
+++ b/config/locales/models/sake.ja.yml
@@ -7,7 +7,7 @@ ja:
         name: 名前
         kura: 蔵
         photos: 画像
-        bindume_on: 製造年月日
+        bindume_on: 製造年月
         brewery_year: BY
         todofuken: 都道府県
         taste_value: 味の濃淡

--- a/spec/helpers/sakes_helper_spec.rb
+++ b/spec/helpers/sakes_helper_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe SakesHelper do
     end
 
     it "generates a range starting with 30 years ago" do
-      date = 30.years.ago.to_date.to_date.beginning_of_month
+      date = 30.years.ago.to_date.beginning_of_month
       year = with_japanese_era(date)
       month = I18n.l(date, format: "%B")
       candidate = ["#{year} #{month}", date.to_s]

--- a/spec/helpers/sakes_helper_spec.rb
+++ b/spec/helpers/sakes_helper_spec.rb
@@ -60,13 +60,22 @@ RSpec.describe SakesHelper do
     end
   end
 
-  describe "by_range" do
-    it "generates a range ending with current" do
-      expect(by_range.last).to eq(to_by(Time.current))
+  describe "by_collection" do
+    it "generates a range ending with unknown" do
+      candidate = [I18n.t("sakes.form_abstract.unknown"), ""]
+      expect(by_collection.last).to eq(candidate)
+    end
+
+    it "generates a range having current year in second from last" do
+      by = to_by(Time.current)
+      candidate = [with_japanese_era(by), by.to_s]
+      expect(by_collection[-2]).to eq(candidate)
     end
 
     it "generates a range starting with 30 years ago" do
-      expect(by_range.first).to eq(to_by(Time.current) - 30.years)
+      by = to_by(30.years.ago)
+      candidate = [with_japanese_era(by), by.to_s]
+      expect(by_collection.first).to eq(candidate)
     end
   end
 

--- a/spec/helpers/sakes_helper_spec.rb
+++ b/spec/helpers/sakes_helper_spec.rb
@@ -79,6 +79,24 @@ RSpec.describe SakesHelper do
     end
   end
 
+  describe "bindume_collection" do
+    it "generates a range ending with current" do
+      date = Time.current.to_date.beginning_of_month
+      year = with_japanese_era(date)
+      month = I18n.l(date, format: "%B")
+      candidate = ["#{year} #{month}", date.to_s]
+      expect(bindume_collection.last).to eq(candidate)
+    end
+
+    it "generates a range starting with 30 years ago" do
+      date = 30.years.ago.to_date.to_date.beginning_of_month
+      year = with_japanese_era(date)
+      month = I18n.l(date, format: "%B")
+      candidate = ["#{year} #{month}", date.to_s]
+      expect(bindume_collection.first).to eq(candidate)
+    end
+  end
+
   describe "with_japanese_era" do
     context "for normal year" do
       it "returns formated year including 令和" do

--- a/spec/system/copy_sakes_spec.rb
+++ b/spec/system/copy_sakes_spec.rb
@@ -92,16 +92,9 @@ RSpec.describe "Copy Sakes" do
     end
 
     describe "bindume_on year" do
-      it "has copied bindume year", js: true do
-        year = with_japanese_era(sake.bindume_on)
-        expect(page).to have_select(test_id: "sake_bindume_year", selected: year)
-      end
-    end
-
-    describe "bindume_on month" do
-      it "has copied bindume month", js: true do
-        month = I18n.l(sake.bindume_on, format: "%b")
-        expect(page).to have_select(test_id: "sake_bindume_month", selected: month)
+      it "has copied bindume year" do
+        bindume = "#{with_japanese_era(sake.bindume_on)} #{I18n.l(sake.bindume_on, format: '%B')}"
+        expect(page).to have_select(test_id: "sake_bindume_on", selected: bindume)
       end
     end
 

--- a/spec/system/sake_form_bindume_date_spec.rb
+++ b/spec/system/sake_form_bindume_date_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "Sake Form Bindume Date" do
 
     it "has this year and month" do
       sake = sake_from_show_path(page.current_path)
-      expect(sake.bindume_on).to eq(to_day_one(Time.current))
+      expect(sake.bindume_on).to eq(Time.current.to_date.beginning_of_month)
     end
   end
 

--- a/spec/system/sake_form_bindume_date_spec.rb
+++ b/spec/system/sake_form_bindume_date_spec.rb
@@ -10,117 +10,42 @@ RSpec.describe "Sake Form Bindume Date" do
     sign_in user
   end
 
-  describe "year of bindume_on" do
-    context "when visiting new sake page" do
-      before do
-        visit new_sake_path
-      end
-
-      it "selects this year" do
-        year = with_japanese_era(Time.current)
-        expect(page).to have_select("sake_bindume_on_1i", selected: year)
-      end
+  context "when visiting new sake page" do
+    before do
+      visit new_sake_path
     end
 
-    context "when creating sake whoes bindume_on is this year" do
-      before do
-        visit new_sake_path
-        fill_in("sake_name", with: "生道井")
-        year = with_japanese_era(Time.current)
-        select(year, from: "sake_bindume_on_1i")
-        click_button("form_submit")
-      end
-
-      it "has this year" do
-        sake = sake_from_show_path(page.current_path)
-        expect(sake.bindume_on.year).to eq(Time.current.year)
-      end
-    end
-
-    context "when creating sake whoes bindume_on is past year" do
-      ago = Time.current.ago(10.years)
-
-      before do
-        visit new_sake_path
-        fill_in("sake_name", with: "生道井")
-        year = with_japanese_era(ago)
-        select(year, from: "sake_bindume_on_1i")
-        click_button("form_submit")
-      end
-
-      it "has past year" do
-        sake = sake_from_show_path(page.current_path)
-        expect(sake.bindume_on.year).to eq(ago.year)
-      end
-    end
-
-    context "when visiting edit sake page" do
-      let(:sake) { create(:sake, bindume_on: Date.parse("2021-07-01")) }
-
-      before do
-        visit edit_sake_path(sake.id)
-      end
-
-      it "selects the year of sake" do
-        year = with_japanese_era(sake.bindume_on)
-        expect(page).to have_select("sake_bindume_on_1i", selected: year)
-      end
+    it "selects this year and month" do
+      bindume = "#{with_japanese_era(Time.current)} #{I18n.l(Time.current, format: '%B')}"
+      expect(page).to have_select("sake_bindume_on", selected: bindume)
     end
   end
 
-  describe "month of bindume_on" do
-    context "when visiting new sake page" do
-      before do
-        visit new_sake_path
-      end
-
-      it "selected this month" do
-        month = I18n.l(Time.current, format: "%b")
-        expect(page).to have_select("sake_bindume_on_2i", selected: month)
-      end
+  context "when creating sake" do
+    before do
+      visit new_sake_path
+      fill_in("sake_name", with: "生道井")
+      bindume = "#{with_japanese_era(Time.current)} #{I18n.l(Time.current, format: '%B')}"
+      select(bindume, from: "sake_bindume_on")
+      click_button("form_submit")
     end
 
-    context "when creating sake whoes bindume_on is January" do
-      before do
-        visit new_sake_path
-        fill_in("sake_name", with: "生道井")
-        month = I18n.l(Time.zone.parse("2022-01-01 10:30:00"), format: "%b")
-        select(month, from: "sake_bindume_on_2i")
-        click_button("form_submit")
-      end
+    it "has this year and month" do
+      sake = sake_from_show_path(page.current_path)
+      expect(sake.bindume_on).to eq(to_day_one(Time.current))
+    end
+  end
 
-      it "has January" do
-        sake = sake_from_show_path(page.current_path)
-        expect(sake.bindume_on.month).to eq(1)
-      end
+  context "when editing sake" do
+    let(:sake) { create(:sake, bindume_on: Date.parse("2021-07-01")) }
+
+    before do
+      visit edit_sake_path(sake.id)
     end
 
-    context "when creating sake whoes bindume_on is December" do
-      before do
-        visit new_sake_path
-        fill_in("sake_name", with: "生道井")
-        month = I18n.l(Time.zone.parse("2022-12-01 10:30:00"), format: "%b")
-        select(month, from: "sake_bindume_on_2i")
-        click_button("form_submit")
-      end
-
-      it "has December" do
-        sake = sake_from_show_path(page.current_path)
-        expect(sake.bindume_on.month).to eq(12)
-      end
-    end
-
-    context "when visiting edit sake page" do
-      let(:sake) { create(:sake, bindume_on: Date.parse("2021-07-01")) }
-
-      before do
-        visit edit_sake_path(sake.id)
-      end
-
-      it "selects the month of sake" do
-        month = I18n.l(sake.bindume_on, format: "%b")
-        expect(page).to have_select("sake_bindume_on_2i", selected: month)
-      end
+    it "selects year and month of the sake" do
+      bindume = "#{with_japanese_era(sake.bindume_on)} #{I18n.l(sake.bindume_on, format: '%B')}"
+      expect(page).to have_select("sake_bindume_on", selected: bindume)
     end
   end
 end


### PR DESCRIPTION
close #477
after #555

我々が本当にほしかったもの

## やったこと

- 酒formにおける製造年月の入力を年・月別々のセレクタから1つのセレクタにした
- 酒のアトリビュートの翻訳を「製造年月日」から「製造年月」に変更
  - 日なんて概念なかった
- 酒フォームの製造年月の実装に合わせて、BYもリファクタ
  - めちゃくちゃスッキリした
- フォームが変わったのに伴い、関連テストを修正
