### PR TITLE
画像アップロード時にサイズを小さくして容量節約

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 - 在庫量と総飲酒量の表示
 - 複数人での在庫の共有
 - PC・スマホ対応のレスポンシブデザイン
+- 画像は AVIF 形式に圧縮して [Cloudinary](https://cloudinary.com/) にアップロード
 
 ## Watch a demo
 

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -6,32 +6,25 @@ class ImageUploader < CarrierWave::Uploader::Base
     storage :file
   end
 
-  process(ocr: "adv_ocr:ja") if Rails.env.production?
-  process(convert: "webp")
+  if Rails.env.production?
+    process(ocr: "adv_ocr:ja")
+    process(convert: "webp")
+  end
 
   version :thumb do
     # HACK: 1:1でスマホで２つ並んでも潰れないサイズ
-    process(resize_to_fill: [600, 600])
+    process(resize_to_fill: [600, 600]) if Rails.env.production?
   end
 
   version :large_twitter_card do
     if Rails.env.production?
-      cloudinary_transformation(crop: :thumb, width: 600, height: 300, sign_url: true, gravity: :ocr_text)
-    else
-      process(resize_to_fill: [600, 300])
+      cloudinary_transformation(crop: :thumb, width: 600, height: 300, sign_url: true,
+                                gravity: :ocr_text)
     end
   end
 
   def store_dir
     "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
-  end
-
-  def filename
-    if Rails.env.production?
-      super
-    elsif original_filename.present?
-      "#{super.chomp(File.extname(super))}.webp"
-    end
   end
 
   def extension_allowlist

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -6,16 +6,16 @@ class ImageUploader < CarrierWave::Uploader::Base
     storage :file
   end
 
-  process(resize_to_limit: [4032, 4032], convert: "webp", ocr: "adv_ocr:ja") if Rails.env.production?
+  process(resize_to_limit: [4032, 4032], convert: "avif", ocr: "adv_ocr:ja") if Rails.env.production?
 
   version :thumb do
     # HACK: 1:1でスマホで２つ並んでも潰れないサイズ
-    process(resize_to_fill: [600, 600]) if Rails.env.production?
+    process(convert: "webp", resize_to_fill: [600, 600]) if Rails.env.production?
   end
 
   version :large_twitter_card do
     if Rails.env.production?
-      cloudinary_transformation(crop: :thumb, width: 600, height: 300, sign_url: true,
+      cloudinary_transformation(format: "webp", crop: :thumb, width: 600, height: 300, sign_url: true,
                                 gravity: :ocr_text)
     end
   end
@@ -25,6 +25,6 @@ class ImageUploader < CarrierWave::Uploader::Base
   end
 
   def extension_allowlist
-    %w[jpg jpeg gif png webp]
+    %w[jpg jpeg gif png webp avif]
   end
 end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -7,6 +7,7 @@ class ImageUploader < CarrierWave::Uploader::Base
   end
 
   process(ocr: "adv_ocr:ja") if Rails.env.production?
+  process(convert: "webp")
 
   version :thumb do
     # HACK: 1:1でスマホで２つ並んでも潰れないサイズ
@@ -26,6 +27,6 @@ class ImageUploader < CarrierWave::Uploader::Base
   end
 
   def extension_allowlist
-    %w[jpg jpeg gif png]
+    %w[jpg jpeg gif png webp]
   end
 end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -26,6 +26,14 @@ class ImageUploader < CarrierWave::Uploader::Base
     "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
   end
 
+  def filename
+    if Rails.env.production?
+      super
+    elsif original_filename.present?
+      "#{super.chomp(File.extname(super))}.webp"
+    end
+  end
+
   def extension_allowlist
     %w[jpg jpeg gif png webp]
   end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -6,7 +6,7 @@ class ImageUploader < CarrierWave::Uploader::Base
     storage :file
   end
 
-  process(resize_to_limit: [4032, 4032], convert: "avif", ocr: "adv_ocr:ja") if Rails.env.production?
+  process(resize_to_limit: [4032, 4032], convert: "avif", quality: auto, ocr: "adv_ocr:ja") if Rails.env.production?
 
   version :thumb do
     # HACK: 1:1でスマホで２つ並んでも潰れないサイズ

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -6,10 +6,7 @@ class ImageUploader < CarrierWave::Uploader::Base
     storage :file
   end
 
-  if Rails.env.production?
-    process(ocr: "adv_ocr:ja")
-    process(convert: "webp")
-  end
+  process(resize_to_limit: [4032, 4032], convert: "webp", ocr: "adv_ocr:ja") if Rails.env.production?
 
   version :thumb do
     # HACK: 1:1でスマホで２つ並んでも潰れないサイズ


### PR DESCRIPTION
Close https://github.com/momocus/sakazuki/issues/537
酒画像を.webpに変換してアップロードし、サイズが小さくなるようにした

本番環境でCloudinaryがどう動くかみようとしたらうっかり #558 がMergedになってしまったので、このプルリクを書いた。