### PR TITLE
酒タイトルから酒情報を補完する

### DIFF
--- a/app/javascript/autocompletion/complete_detail.ts
+++ b/app/javascript/autocompletion/complete_detail.ts
@@ -12,13 +12,13 @@ type CompletionCandidate = {
 type CompletionDict = Array<CompletionCandidate>
 
 /**
- * 指定した複数文字列のいづれか1つでも含まれるかをチェックする
+ * 指定した複数文字列のいずれか1つでも含まれるかをチェックする
  *
  * String.includesの複数候補版。
  *
  * @param target 検索対象の文字列
  * @param keywords 検索する複数キーワード
- * @returns 検索対象にいづれかのキーワードが1つでも含まれればtrue
+ * @returns 検索対象にいずれかのキーワードが1つでも含まれればtrue
  */
 function includesAny(target: string, keywords: Array<string>): boolean {
   return keywords.some((word) => {

--- a/app/javascript/autocompletion/complete_detail.ts
+++ b/app/javascript/autocompletion/complete_detail.ts
@@ -1,0 +1,99 @@
+import * as dicts from "./detail_dicts"
+
+/** 補完候補 */
+type CompletionCandidate = {
+  /** このキーワードが含まれていたら補完を行う */
+  keywords: Array<string>
+  /** 補完に使う文字列 */
+  completion: string
+}
+
+/** 補完辞書 */
+type CompletionDict = Array<CompletionCandidate>
+
+/**
+ * 指定した複数文字列のいづれか1つでも含まれるかをチェックする
+ *
+ * String.includesの複数候補版。
+ *
+ * @param target 検索対象の文字列
+ * @param keywords 検索する複数キーワード
+ * @returns 検索対象にいづれかのキーワードが1つでも含まれればtrue
+ */
+function includesAny(target: string, keywords: Array<string>): boolean {
+  return keywords
+    .map((word) => {
+      return target.includes(word)
+    })
+    .includes(true)
+}
+
+/**
+ * 補完候補を採用するかチェックする
+ *
+ * @param name 酒の名前
+ * @param cand 補完候補
+ * @returns 採用されれば補完候補、採用されなければ空文字列を返す
+ */
+function check(name: string, cand: CompletionCandidate): string {
+  return includesAny(name, cand.keywords) ? cand.completion : ""
+}
+
+/**
+ * 酒の名前と補完辞書から補完する文字列を決定する
+ *
+ * @param name 酒の名前
+ * @param dict 補完辞書
+ * @returns 補完できるなら補完候補、補完できないなら空文字を返す
+ */
+function lookup(name: string, dict: CompletionDict): string {
+  const found = dict.find((cand) => {
+    return check(name, cand) !== ""
+  })
+  return found?.completion ?? ""
+}
+
+/**
+ * 酒の名前から指定された酒フォームの補完を行う
+ *
+ * 未入力状態のときのみ補完を行う。
+ * 未入力状態かはフォームの内容`value`が`empty`と同じかで判定する。
+ *
+ * @param name 酒の名前
+ * @param dict 補完辞書
+ * @param targetId 補完対象のエレメントID
+ * @param empty 補完対象の未入力状態
+ */
+function complete(
+  name: string,
+  dict: CompletionDict,
+  targetId: string,
+  empty: string
+): void {
+  const element = document.getElementById(targetId) as
+    | HTMLSelectElement
+    | HTMLInputElement
+  if (element.value === empty) {
+    const completion = lookup(name, dict)
+    if (completion !== "") {
+      element.value = completion
+      element.dispatchEvent(new Event("change"))
+    }
+  }
+}
+
+{
+  // 酒の名前の入力先
+  const nameElem = document.getElementById("sake_name") as HTMLInputElement
+
+  nameElem.addEventListener("change", (_event) => {
+    const name = nameElem.value
+    complete(name, dicts.tokutei_meisho, "sake_tokutei_meisho", "none")
+    complete(name, dicts.season, "sake_season", "")
+    complete(name, dicts.moto, "sake_moto", "unknown")
+    complete(name, dicts.shibori, "sake_shibori", "")
+    complete(name, dicts.roka, "sake_roka", "")
+    complete(name, dicts.hiire, "sake_hiire", "unknown")
+    complete(name, dicts.warimizu, "sake_warimizu", "unknown")
+  })
+}

--- a/app/javascript/autocompletion/complete_detail.ts
+++ b/app/javascript/autocompletion/complete_detail.ts
@@ -21,10 +21,9 @@ type CompletionDict = Array<CompletionCandidate>
  * @returns 検索対象にいづれかのキーワードが1つでも含まれればtrue
  */
 function includesAny(target: string, keywords: Array<string>): boolean {
-  return keywords
-    .some((word) => {
-      return target.includes(word)
-    })
+  return keywords.some((word) => {
+    return target.includes(word)
+  })
 }
 
 /**

--- a/app/javascript/autocompletion/complete_detail.ts
+++ b/app/javascript/autocompletion/complete_detail.ts
@@ -22,10 +22,9 @@ type CompletionDict = Array<CompletionCandidate>
  */
 function includesAny(target: string, keywords: Array<string>): boolean {
   return keywords
-    .map((word) => {
+    .some((word) => {
       return target.includes(word)
     })
-    .includes(true)
 }
 
 /**

--- a/app/javascript/autocompletion/detail_dicts.ts
+++ b/app/javascript/autocompletion/detail_dicts.ts
@@ -1,0 +1,109 @@
+// MEMO:
+// この辞書は先にヒットした内容が優先される
+// そのため、部分集合となるようなキーワードがある場合はヒットしづらいものを先に書く。
+// 例えば、純米大吟醸と大吟醸は、純米大吟醸を先に書いておく必要がある。
+
+// HACK:
+// 生や夏は、これだけでは想定外のヒットが予想される。
+// 例えば、生だけでは生酛や生路井などがヒットしてしまう。
+// そこで検索ワードは工夫している。
+// 具体的には、SAKAZUKI2年運用で出てきた酒名を参考にした。
+
+const tokutei_meisho = [
+  { keywords: ["特別本醸造"], completion: "tokubetsu_honjozo" },
+  { keywords: ["本醸造"], completion: "honjozo" },
+  { keywords: ["純米大吟醸"], completion: "junmai_daiginjo" },
+  { keywords: ["純米吟醸"], completion: "junmai_ginjo" },
+  { keywords: ["大吟醸"], completion: "daiginjo" },
+  { keywords: ["吟醸"], completion: "ginjo" },
+  { keywords: ["純米"], completion: "junmai" },
+]
+
+const hiyaoroshi_keywords = [
+  "冷卸し",
+  "冷やおろし",
+  "ひやおろし",
+  "秋上がり",
+  "秋あがり",
+]
+const season = [
+  {
+    keywords: ["新酒", "しぼりたて", "初しぼり", "はつしぼり"],
+    completion: "新酒",
+  },
+  { keywords: ["立春朝搾り"], completion: "立春朝搾り" },
+  { keywords: ["夏酒", "夏限定", "夏の", "の夏"], completion: "夏酒" },
+  { keywords: hiyaoroshi_keywords, completion: "ひやおろし" },
+  { keywords: ["古酒", "年熟成"], completion: "古酒" },
+]
+
+const moto = [
+  { keywords: ["生酛", "生もと"], completion: "kimoto" },
+  { keywords: ["山廃"], completion: "yamahai" },
+  { keywords: ["速醸"], completion: "sokujo" },
+]
+
+const shibori = [
+  { keywords: ["槽搾り", "槽しぼり"], completion: "槽搾り" },
+  {
+    keywords: [
+      "雫取り",
+      "雫どり",
+      "しずくどり",
+      "雫囲い",
+      "しずく囲い",
+      "しずく搾り",
+      "袋吊り",
+      "吊るし酒",
+      "斗瓶囲い",
+      "斗瓶取り",
+      "斗瓶採り",
+      "斗瓶どり",
+    ],
+    completion: "雫取り",
+  },
+  {
+    keywords: ["荒走り", "あらばしり"],
+    completion: "あらばしり",
+  },
+  {
+    keywords: [
+      "中取り",
+      "中どり",
+      "なかどり",
+      "中垂れ",
+      "中だれ",
+      "なかだれ",
+      "中汲み",
+      "中くみ",
+      "なかくみ",
+    ],
+    completion: "中取り",
+  },
+  { keywords: ["責め"], completion: "責め" },
+]
+
+const roka = [
+  { keywords: ["無濾過", "無ろ過"], completion: "無濾過" },
+  { keywords: ["素濾過", "素ろ過"], completion: "素濾過" },
+]
+
+const hiire = [
+  {
+    keywords: [
+      "生原酒",
+      "しぼりたて生",
+      "無濾過生",
+      "無ろ過生",
+      " 生 ",
+      "生酒",
+    ],
+    completion: "namanama",
+  },
+  { keywords: hiyaoroshi_keywords.concat(["生詰"]), completion: "mae_hiire" },
+  { keywords: ["生貯"], completion: "ato_hiire" },
+]
+
+const warimizu = [{ keywords: ["原酒"], completion: "genshu" }]
+
+export { tokutei_meisho, season, moto, shibori, roka, hiire, warimizu }

--- a/app/javascript/autocompletion/detail_dicts.ts
+++ b/app/javascript/autocompletion/detail_dicts.ts
@@ -16,6 +16,7 @@ const tokutei_meisho = [
   { keywords: ["純米吟醸"], completion: "junmai_ginjo" },
   { keywords: ["大吟醸"], completion: "daiginjo" },
   { keywords: ["吟醸"], completion: "ginjo" },
+  { keywords: ["特別純米"], completion: "tokubetsu_junmai" },
   { keywords: ["純米"], completion: "junmai" },
 ]
 

--- a/app/javascript/sakes_form.js
+++ b/app/javascript/sakes_form.js
@@ -1,4 +1,5 @@
 import "./autocompletion/complete_meigara"
+import "./autocompletion/complete_detail"
 import "./sync_dom/sync_kura_todofuken"
 import "./taste_graph/input_taste_graph"
 import "./rating/rating"

--- a/app/views/sakes/_form_detail.html.erb
+++ b/app/views/sakes/_form_detail.html.erb
@@ -61,7 +61,7 @@
                                   data: { testid: "sake_shibori" }) %>
               <datalist id="shibori-list">
                 <option value="ヤブタ式"></option>
-                <option value="槽絞り"></option>
+                <option value="槽搾り"></option>
                 <option value="袋吊り"></option>
                 <option value="雫取り"></option>
                 <option value="斗瓶取り"></option>

--- a/app/views/sakes/_form_detail.html.erb
+++ b/app/views/sakes/_form_detail.html.erb
@@ -1,7 +1,8 @@
 <div class="accordion-item">
   <h2 class="accordion-header" id="headingDetail">
     <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
-      data-bs-target="#collapseDetail" aria-expanded="false" aria-controls="collapseDetail">
+      data-bs-target="#collapseDetail" aria-expanded="false" aria-controls="collapseDetail"
+      data-testid="accordion_detail">
       <%= t(".detail") %>
     </button>
   </h2>

--- a/config/locales/models/sake.ja.yml
+++ b/config/locales/models/sake.ja.yml
@@ -32,7 +32,7 @@ ja:
         moto: 酛
         seimai_buai: 精米歩合
         roka: ろ過
-        shibori: 絞り
+        shibori: 搾り
         bottle_level: 開封状態
         price: 価格(円)
         price_unit: 円

--- a/config/locales/models/sake.ja.yml
+++ b/config/locales/models/sake.ja.yml
@@ -17,7 +17,7 @@ ja:
         aroma_impression: 香り
         color: 色
         taste_impression: 味
-        hiire: 火入れ状態
+        hiire: 火入れ
         nigori: にごり
         awa: 炭酸
         tokutei_meisho: 特定名称

--- a/spec/system/sake_form_completion_for_detail_spec.rb
+++ b/spec/system/sake_form_completion_for_detail_spec.rb
@@ -1,0 +1,164 @@
+require "rails_helper"
+
+RSpec.describe "Sake Form Completion for Detail", js: true do
+  let(:user) { create(:user) }
+
+  before do
+    sign_in user
+    visit new_sake_path
+  end
+
+  describe "tokutei_meisho" do
+    it "is completed 本醸造" do
+      fill_in("sake_name", with: "生道井 本醸造").send_keys(:tab)
+      selected = I18n.t("enums.sake.tokutei_meisho.honjozo")
+      expect(page).to have_select("sake_tokutei_meisho", selected:)
+    end
+
+    it "is completed 吟醸" do
+      fill_in("sake_name", with: "生道井 吟醸").send_keys(:tab)
+      selected = I18n.t("enums.sake.tokutei_meisho.ginjo")
+      expect(page).to have_select("sake_tokutei_meisho", selected:)
+    end
+
+    it "is completed 大吟醸" do
+      fill_in("sake_name", with: "生道井 大吟醸").send_keys(:tab)
+      selected = I18n.t("enums.sake.tokutei_meisho.daiginjo")
+      expect(page).to have_select("sake_tokutei_meisho", selected:)
+    end
+
+    it "is completed 純米" do
+      fill_in("sake_name", with: "生道井 純米").send_keys(:tab)
+      selected = I18n.t("enums.sake.tokutei_meisho.junmai")
+      expect(page).to have_select("sake_tokutei_meisho", selected:)
+    end
+
+    it "is completed 純米吟醸" do
+      fill_in("sake_name", with: "生道井 純米吟醸").send_keys(:tab)
+      selected = I18n.t("enums.sake.tokutei_meisho.junmai_ginjo")
+      expect(page).to have_select("sake_tokutei_meisho", selected:)
+    end
+
+    it "is completed 純米大吟醸" do
+      fill_in("sake_name", with: "生道井 純米大吟醸").send_keys(:tab)
+      selected = I18n.t("enums.sake.tokutei_meisho.junmai_daiginjo")
+      expect(page).to have_select("sake_tokutei_meisho", selected:)
+    end
+  end
+
+  describe "season" do
+    it "is completed 新酒" do
+      fill_in("sake_name", with: "生道井 しぼりたて").send_keys(:tab)
+      expect(find(:test_id, "sake_season").value).to eq("新酒")
+    end
+
+    it "is completed 夏酒" do
+      fill_in("sake_name", with: "生道井 夏の吟醸").send_keys(:tab)
+      expect(find(:test_id, "sake_season").value).to eq("夏酒")
+    end
+
+    it "is completed ひやおろし" do
+      fill_in("sake_name", with: "生道井 ひやおろし").send_keys(:tab)
+      expect(find(:test_id, "sake_season").value).to eq("ひやおろし")
+    end
+
+    it "is completed 古酒" do
+      fill_in("sake_name", with: "生道井 10年大古酒").send_keys(:tab)
+      expect(find(:test_id, "sake_season").value).to eq("古酒")
+    end
+  end
+
+  context "for detail accordion" do
+    # 以下テストは詳細アコーディオンの中なので、アコーディオンを開いておく
+    before do
+      click_button("accordion_detail")
+    end
+
+    describe "moto" do
+      it "is completed 生酛" do
+        fill_in("sake_name", with: "生道井 生酛造り").send_keys(:tab)
+        selected = I18n.t("enums.sake.moto.kimoto")
+        expect(page).to have_select("sake_moto", selected:)
+      end
+
+      it "is completed 山廃" do
+        fill_in("sake_name", with: "生道井 山廃純米").send_keys(:tab)
+        selected = I18n.t("enums.sake.moto.yamahai")
+        expect(page).to have_select("sake_moto", selected:)
+      end
+
+      it "is completed 速醸" do
+        fill_in("sake_name", with: "生道井 速醸").send_keys(:tab)
+        selected = I18n.t("enums.sake.moto.sokujo")
+        expect(page).to have_select("sake_moto", selected:)
+      end
+    end
+
+    describe "shibori" do
+      it "is completed 槽搾り" do
+        fill_in("sake_name", with: "生道井 槽搾り").send_keys(:tab)
+        expect(find(:test_id, "sake_shibori").value).to eq("槽搾り")
+      end
+
+      it "is completed 雫取り" do
+        fill_in("sake_name", with: "生道井 雫どり").send_keys(:tab)
+        expect(find(:test_id, "sake_shibori").value).to eq("雫取り")
+      end
+
+      it "is completed あらばしり" do
+        fill_in("sake_name", with: "生道井 荒走り").send_keys(:tab)
+        expect(find(:test_id, "sake_shibori").value).to eq("あらばしり")
+      end
+
+      it "is completed 中取り" do
+        fill_in("sake_name", with: "生道井 中汲み").send_keys(:tab)
+        expect(find(:test_id, "sake_shibori").value).to eq("中取り")
+      end
+
+      it "is completed 責め" do
+        fill_in("sake_name", with: "生道井 責め").send_keys(:tab)
+        expect(find(:test_id, "sake_shibori").value).to eq("責め")
+      end
+    end
+
+    describe "roka" do
+      it "is completed 無濾過" do
+        fill_in("sake_name", with: "生道井 無ろ過").send_keys(:tab)
+        expect(find(:test_id, "sake_roka").value).to eq("無濾過")
+      end
+
+      it "is completed 素濾過" do
+        fill_in("sake_name", with: "生道井 素ろ過").send_keys(:tab)
+        expect(find(:test_id, "sake_roka").value).to eq("素濾過")
+      end
+    end
+
+    describe "hiire" do
+      it "is completed 生生" do
+        fill_in("sake_name", with: "生道井 無濾過生").send_keys(:tab)
+        selected = I18n.t("enums.sake.hiire.namanama")
+        expect(page).to have_select("sake_hiire", selected:)
+      end
+
+      it "is completed 前火入れ" do
+        fill_in("sake_name", with: "生道井 生詰め").send_keys(:tab)
+        selected = I18n.t("enums.sake.hiire.mae_hiire")
+        expect(page).to have_select("sake_hiire", selected:)
+      end
+
+      it "is completed 後火入れ" do
+        fill_in("sake_name", with: "生道井 生貯蔵酒").send_keys(:tab)
+        selected = I18n.t("enums.sake.hiire.ato_hiire")
+        expect(page).to have_select("sake_hiire", selected:)
+      end
+    end
+
+    describe "warimizu" do
+      it "is completed 原酒" do
+        fill_in("sake_name", with: "生道井 生原酒").send_keys(:tab)
+        selected = I18n.t("enums.sake.warimizu.genshu")
+        expect(page).to have_select("sake_warimizu", selected:)
+      end
+    end
+  end
+end

--- a/spec/system/sake_form_completion_for_detail_spec.rb
+++ b/spec/system/sake_form_completion_for_detail_spec.rb
@@ -44,6 +44,18 @@ RSpec.describe "Sake Form Completion for Detail", js: true do
       selected = I18n.t("enums.sake.tokutei_meisho.junmai_daiginjo")
       expect(page).to have_select("sake_tokutei_meisho", selected:)
     end
+
+    it "is completed 特別本醸造" do
+      fill_in("sake_name", with: "生道井 特別本醸造").send_keys(:tab)
+      selected = I18n.t("enums.sake.tokutei_meisho.tokubetsu_honjozo")
+      expect(page).to have_select("sake_tokutei_meisho", selected:)
+    end
+
+    it "is completed 特別純米" do
+      fill_in("sake_name", with: "生道井 特別純米").send_keys(:tab)
+      selected = I18n.t("enums.sake.tokutei_meisho.tokubetsu_junmai")
+      expect(page).to have_select("sake_tokutei_meisho", selected:)
+    end
   end
 
   describe "season" do

--- a/spec/system/sake_form_completion_for_kura_and_todofuken_spec.rb
+++ b/spec/system/sake_form_completion_for_kura_and_todofuken_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Sake Form Completion From Names", type: :system do
+RSpec.describe "Sake Form Completion for Kura and Todofuken", type: :system do
   let(:user) { create(:user) }
 
   before do


### PR DESCRIPTION
close #379

これが欲しかった

## やったこと

- 酒の”しぼり”のtypo修正（絞り→搾り）
- 酒フォームでなぜか残っていた「火入れ状態」から状態を削除
- 名前からの酒情報補完機能のテストを追加
  - 合わせて、蔵・都道府県の補完機能のスペック名を変更
- 酒の名前から詳細情報などを補完する機能を実装した
  - 補完される項目は、特定名称、季節、酛、搾り、ろ過、火入れ、加水。
