### PR TITLE
酒カードのフォーマットを変更した

### DIFF
--- a/app/views/sakes/_sake.html.erb
+++ b/app/views/sakes/_sake.html.erb
@@ -56,9 +56,10 @@
         <div class="col-6">
           <div class="row">
             <div class="col-12">
-              <%= t(".time_ago",
-                    count: time_ago_in_words(latest_at(sake), include_seconds: true),
-                    done: t(".#{sake.bottle_level}")) %>
+              <%= sake.bottle_level_i18n %>
+              <span class="text-muted">
+                ‒ <%= t(".time_ago", count: time_ago_in_words(latest_at(sake))) %>
+              </span>
             </div>
             <div class="col-12">
               <%= render(partial: "rating", locals: { rating: sake.rating }) %>

--- a/app/views/sakes/_sake.html.erb
+++ b/app/views/sakes/_sake.html.erb
@@ -39,7 +39,7 @@
     <%# HACK: 名前の長さによって揃わない要素を、footerを使って揃える %>
     <div class="card-footer">
       <div class="row">
-        <div class="col-7">
+        <div class="col-6">
           <div class="row">
             <div class="col-12">
               <% if sake.tokutei_meisho == "none" %>
@@ -53,7 +53,7 @@
             </div>
           </div>
         </div>
-        <div class="col-5">
+        <div class="col-6">
           <div class="row">
             <div class="col-12">
               <%= t(".time_ago",
@@ -65,17 +65,17 @@
             </div>
           </div>
         </div>
-        <div class="col-7 mt-3">
-          <div class="ratio ratio-4x3">
+        <div class="col-6 pe-4 align-self-center">
+          <% thumb_url = sake.photos.any? ? sake.photos.first.image.thumb.url : image_url("sake-no-photo.png") %>
+          <%= cl_image_tag(thumb_url, { class: "img-fulid img-thumbnail" }) %>
+        </div>
+        <div class="col-6 mt-1 ps-2">
+          <div class="ratio ratio-1x1">
             <canvas id="sake-<%= sake.id %>"
               data-taste-value="<%= sake.taste_value %>"
               data-aroma-value="<%= sake.aroma_value %>">
             </canvas>
           </div>
-        </div>
-        <div class="col-5 mt-3 align-self-center">
-          <% thumb_url = sake.photos.any? ? sake.photos.first.image.thumb.url : image_url("sake-no-photo.png") %>
-          <%= cl_image_tag(thumb_url, { class: "img-fulid img-thumbnail" }) %>
         </div>
       </div>
     </div>

--- a/config/locales/views/sake.ja.yml
+++ b/config/locales/views/sake.ja.yml
@@ -6,10 +6,7 @@ ja:
     sake:
       edit: 編集
       tokutei_meisho_none: :sakes.show_abstract.tokutei_meisho_none
-      time_ago: :sakes.show_abstract.time_ago
-      sealed: :sakes.show_abstract.sealed
-      opened: :sakes.show_abstract.opened
-      empty: :sakes.show_abstract.empty
+      time_ago: "%{count}前"
     show:
       delete: 削除
       confirm_delete: 本当に削除しますか？


### PR DESCRIPTION
close #492

わからん、運用してみないことには。

## やったこと

- 酒indexの画像とグラフの位置と大きさを変更
  - グラフとレビューは近いほうがよい。
- 酒indexにおける瓶状態のフォーマットを変えた
  - 「1ヶ月前に開封」から「未開封 - 1ヶ月前」にした
  - 瓶状態の位置がすべてのカードで揃うので、より瓶状態が見やすくなることを狙う
  - 後ろの1ヶ月前などは`muted`で薄くしている

## やってないこと

- READMEに貼るスクリーンショットの更新
  - レビュー通ってからやる

## カード比較

### 変更前

![image](https://user-images.githubusercontent.com/849256/221397477-37851242-0554-4e5a-9d3e-45ba50fe3175.png)

### 変更後

![image](https://user-images.githubusercontent.com/849256/221397504-7e39e68c-a6ed-42c0-88ae-c2256f6e8dbf.png)
