### PR TITLE
酒indexでも画像を拡大表示できるようにした

### DIFF
--- a/app/assets/stylesheets/sakes_index.scss
+++ b/app/assets/stylesheets/sakes_index.scss
@@ -1,5 +1,6 @@
 @import "./bootstrap/custom";
 @import "bootstrap/scss/bootstrap";
+@import "simplelightbox/src/simple-lightbox";
 
 // Ransackが生成するスタイル
 // stylelint-disable selector-class-pattern

--- a/app/javascript/sakes_index.js
+++ b/app/javascript/sakes_index.js
@@ -1,1 +1,2 @@
 import "./taste_graph/show_taste_graph"
+import "./simple_lightbox/simple_lightbox.ts"

--- a/app/views/sakes/_sake.html.erb
+++ b/app/views/sakes/_sake.html.erb
@@ -63,9 +63,13 @@
             </div>
           </div>
         </div>
-        <div class="col-6 pe-4 align-self-center">
-          <% thumb_url = sake.photos.any? ? sake.photos.first.image.thumb.url : image_url("sake-no-photo.png") %>
-          <%= cl_image_tag(thumb_url, { class: "img-fulid img-thumbnail" }) %>
+        <div class="col-6 pe-4 align-self-center photo-gallery">
+          <% if sake.photos.any? %>
+            <% image = sake.photos.first.image %>
+            <%= link_to(cl_image_tag(image.thumb.url, class: "img-thumbnail img-fluid"), image.url) %>
+          <% else %>
+            <%= cl_image_tag(image_url("sake-no-photo.png"), class: "img-thumbnail img-fluid") %>
+          <% end %>
         </div>
         <div class="col-6 mt-1 ps-2">
           <div class="ratio ratio-1x1">

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -2,8 +2,8 @@ RSpec.configure do |config|
   config.include(FactoryBot::Syntax::Methods)
 end
 
-def sake_with_photos(photo_count: 3, file_ext: "avif")
-  FactoryBot.create(:sake) do |sake|
+def sake_with_photos(photo_count: 1, sake_options: {}, file_ext: "avif")
+  FactoryBot.create(:sake, sake_options) do |sake|
     image = Rack::Test::UploadedFile.new(Rails.root.join("spec/system/files/sake_photo1.#{file_ext}"))
     FactoryBot.create_list(:photo, photo_count, sake:, image:)
   end

--- a/spec/system/sake_show_simple_lightboxes_spec.rb
+++ b/spec/system/sake_show_simple_lightboxes_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Sake Show Simple Lightboxes", js: true do
   end
 
   context "with avif photo" do
-    let(:sake) { sake_with_photos(photo_count: 1) }
+    let(:sake) { sake_with_photos }
 
     before do
       find(:test_id, "sake_photo").click
@@ -20,7 +20,7 @@ RSpec.describe "Sake Show Simple Lightboxes", js: true do
   end
 
   context "with jpg photo" do
-    let(:sake) { sake_with_photos(photo_count: 1, file_ext: "jpg") }
+    let(:sake) { sake_with_photos(file_ext: "jpg") }
 
     before do
       find(:test_id, "sake_photo").click

--- a/spec/views/sakes/index.html.erb_spec.rb
+++ b/spec/views/sakes/index.html.erb_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 # Capybaraを使うためにsystem specを指定する
 RSpec.describe "sakes/index", type: :system do
-  let!(:sake) { create(:sake, size: 720) }
+  let!(:sake) { sake_with_photos(sake_options: { size: 720 }) }
 
   before do
     visit sakes_path
@@ -14,6 +14,17 @@ RSpec.describe "sakes/index", type: :system do
       text = I18n.t("sakes.sake.edit")
       path = edit_sake_path(sake.id)
       expect(find(:test_id, buttons)).to have_link(text, href: path)
+    end
+
+    it "has image link" do
+      within(".card") do
+        expect(page).to have_link(nil, href: /(jpg|avif)$/)
+      end
+    end
+
+    it "has image link by SimpleLightbox", js: true do
+      find(".img-thumbnail").click
+      expect(page).to have_current_path(sakes_path)
     end
   end
 


### PR DESCRIPTION
close #488

~~after #571~~
~~conflict with #573~~

## やったこと

- 酒indexの酒画像の拡大表示ができることのviewテストを追加
- 酒indexの画像をSimpleLightboxで拡大表示できるようにした
