### PR TITLE
水酛を追加した

### DIFF
--- a/app/javascript/autocompletion/detail_dicts.ts
+++ b/app/javascript/autocompletion/detail_dicts.ts
@@ -42,6 +42,7 @@ const moto = [
   { keywords: ["生酛", "生もと"], completion: "kimoto" },
   { keywords: ["山廃"], completion: "yamahai" },
   { keywords: ["速醸"], completion: "sokujo" },
+  { keywords: ["水酛"], completion: "mizumoto" },
 ]
 
 const shibori = [

--- a/app/models/sake.rb
+++ b/app/models/sake.rb
@@ -71,6 +71,7 @@ class Sake < ApplicationRecord
     kimoto: 1,
     yamahai: 2,
     sokujo: 3,
+    mizumoto: 4,
   }, _prefix: true
   enum warimizu: {
     unknown: 0,

--- a/app/models/sake.rb
+++ b/app/models/sake.rb
@@ -41,6 +41,7 @@
 #  updated_at       :datetime         not null
 #
 
+# rubocop:disable Metrics/ClassLength
 class Sake < ApplicationRecord
   has_many :photos, dependent: :destroy
   enum bottle_level: {
@@ -184,3 +185,4 @@ class Sake < ApplicationRecord
     (price.to_f / size * 180 * SELLING_RATE).ceil(-2)
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/config/locales/enums/sake.ja.yml
+++ b/config/locales/enums/sake.ja.yml
@@ -26,6 +26,7 @@ ja:
         kimoto: 生酛
         yamahai: 山廃
         sokujo: 速醸
+        mizumoto: 水酛
       warimizu:
         unknown: 不明
         kasui: 加水

--- a/spec/system/sake_form_completion_for_detail_spec.rb
+++ b/spec/system/sake_form_completion_for_detail_spec.rb
@@ -104,6 +104,12 @@ RSpec.describe "Sake Form Completion for Detail", js: true do
         selected = I18n.t("enums.sake.moto.sokujo")
         expect(page).to have_select("sake_moto", selected:)
       end
+
+      it "is completed 水酛" do
+        fill_in("sake_name", with: "生道井 水酛").send_keys(:tab)
+        selected = I18n.t("enums.sake.moto.mizumoto")
+        expect(page).to have_select("sake_moto", selected:)
+      end
     end
 
     describe "shibori" do


### PR DESCRIPTION
close #565

ふしぎなふしぎな みずもとつくり

本当にこれでenumに追加されてる？

## やったこと

- 水酛を酒モデルに追加した
- 補完機能で水酛に対応した
