### PR TITLE
👓 GitHub Actionsの複数の警告を解消した

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -42,6 +42,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-${{ env.cache-env }}-
             ${{ runner.os }}-yarn- # enable to match production env
+      - if: ${{ steps.cache-yarn.outputs.cache-hit != 'true' }}
+        name: List the state of node modules
+        continue-on-error: true
+        run: yarn info
       - name: Install Dependencies
         run: yarn install --immutable
       - name: Run ESLint

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -32,7 +32,7 @@ jobs:
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
       - name: Restore Yarn cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: yarn-cache
         env:
           cache-env: dev

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -28,24 +28,10 @@ jobs:
         run: ./cli-scripts/check_endoffile_with_newline.sh
 
       # lint by node modules
-      - name: Get Yarn chache directory path
-        id: yarn-cache-dir
-        run: echo "PATH=$(yarn config get cacheFolder)" >> ${GITHUB_OUTPUT}
-      - name: Cache node modules
-        id: cache-yarn
-        uses: actions/cache@v3
-        env:
-          cache-env: dev
+      - uses: actions/setup-node@v3
         with:
-          path: ${{ steps.yarn-cache-dir.outputs.PATH }}
-          key: ${{ runner.os }}-yarn-${{ env.cache-env }}-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-${{ env.cache-env }}-
-            ${{ runner.os }}-yarn- # enable to match production env
-      - if: ${{ steps.cache-yarn.outputs.cache-hit != 'true' }}
-        name: List the state of node modules
-        continue-on-error: true
-        run: yarn info
+          node-version: "18"
+          cache: "yarn"
       - name: Install Dependencies
         run: yarn install --immutable
       - name: Run ESLint

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -29,21 +29,21 @@ jobs:
 
       # lint by node modules
       - name: Get Yarn chache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
-      - name: Restore Yarn cache
+        id: yarn-cache-dir
+        run: echo "PATH=$(yarn config get cacheFolder)" >> ${GITHUB_OUTPUT}
+      - name: Cache node modules
+        id: cache-yarn
         uses: actions/cache@v3
-        id: yarn-cache
         env:
           cache-env: dev
         with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          path: ${{ steps.yarn-cache-dir.outputs.PATH }}
           key: ${{ runner.os }}-yarn-${{ env.cache-env }}-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-${{ env.cache-env }}-
             ${{ runner.os }}-yarn- # enable to match production env
       - name: Install Dependencies
-        run: yarn install
+        run: yarn install --immutable
       - name: Run ESLint
         run: yarn run lint:eslint
       - name: Run tsc

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,7 +21,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # lint by sh scripts
       - name: End of File with Newline

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,9 +30,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v2
         with:
           languages: javascript, typescript, ruby
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+        uses: github/codeql-action/analyze@v2

--- a/.github/workflows/fix-command.yml
+++ b/.github/workflows/fix-command.yml
@@ -21,9 +21,6 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-      - name: Install bundle dependencies
-        run: |
-          bundle install
 
       - name: Add refactor commit to PR
         run: |

--- a/.github/workflows/fix-command.yml
+++ b/.github/workflows/fix-command.yml
@@ -6,7 +6,7 @@ jobs:
   fix:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.client_payload.pull_request.head.ref }}
 

--- a/.github/workflows/fix-command.yml
+++ b/.github/workflows/fix-command.yml
@@ -14,7 +14,7 @@ jobs:
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
       - name: Restore Yarn cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: yarn-cache
         env:
           cache-env: dev

--- a/.github/workflows/fix-command.yml
+++ b/.github/workflows/fix-command.yml
@@ -10,22 +10,12 @@ jobs:
         with:
           ref: ${{ github.event.client_payload.pull_request.head.ref }}
 
-      - name: Get Yarn chache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
-      - name: Restore Yarn cache
-        uses: actions/cache@v3
-        id: yarn-cache
-        env:
-          cache-env: dev
+      - uses: actions/setup-node@v3
         with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ env.cache-env }}-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-${{ env.cache-env }}-
-            ${{ runner.os }}-yarn- # enable to match production env
+          node-version: "18"
+          cache: "yarn"
       - name: Install Yarn Dependencies
-        run: yarn install
+        run: yarn install --immutable
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
       - name: Restore Yarn cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: yarn-cache
         env:
           cache-env: prod

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,23 +37,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Get Yarn chache directory path
-        id: yarn-cache-dir
-        run: echo "PATH=$(yarn config get cacheFolder)" >> ${GITHUB_OUTPUT}
-      - name: Cache node modules
-        uses: actions/cache@v3
-        id: cache-yarn
-        env:
-          cache-env: prod
+      - uses: actions/setup-node@v3
         with:
-          path: ${{ steps.yarn-cache-dir.outputs.PATH }}
-          key: ${{ runner.os }}-yarn-${{ env.cache-env }}-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-${{ env.cache-env }}-
-      - if: ${{ steps.cache-yarn.outputs.cache-hit != 'true' }}
-        name: List the state of node modules
-        continue-on-error: true
-        run: yarn info
+          node-version: "18"
+          cache: "yarn"
       - name: Install Dependencies
         run: yarn workspaces focus --all --production
       - name: Set up Ruby

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Get Yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,10 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ env.cache-env }}-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-${{ env.cache-env }}-
+      - if: ${{ steps.cache-yarn.outputs.cache-hit != 'true' }}
+        name: List the state of node modules
+        continue-on-error: true
+        run: yarn info
       - name: Install Dependencies
         run: yarn workspaces focus --all --production
       - name: Set up Ruby

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,16 +37,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Get Yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
-      - name: Restore Yarn cache
+      - name: Get Yarn chache directory path
+        id: yarn-cache-dir
+        run: echo "PATH=$(yarn config get cacheFolder)" >> ${GITHUB_OUTPUT}
+      - name: Cache node modules
         uses: actions/cache@v3
-        id: yarn-cache
+        id: cache-yarn
         env:
           cache-env: prod
         with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          path: ${{ steps.yarn-cache-dir.outputs.PATH }}
           key: ${{ runner.os }}-yarn-${{ env.cache-env }}-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-${{ env.cache-env }}-


### PR DESCRIPTION
close #582



## やったこと

- CodeQLのv1からv2にあげた
  - すでにv1は2023/01/18でdeprecatedになっている。
  - ここにあるように、1文字を2箇所変えただけ
  - https://github.blog/changelog/2023-01-18-code-scanning-codeql-action-v1-is-now-deprecated/
- checktout/cache actionをv2からv3にあげた
  - ここにあるように、1文字を何箇所か変えただけ
  - https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-versioned-actions
- ~~`::set-output`を使わないようにした~~
  - ~~新たな`GITHUB_OUTPUT`を使って書き直した~~
  - https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files
- ~~キャッシュヒット失敗したときにパッケージ一覧を出すようにした~~
  - ~~公式Docでやってて、デバッグに便利そう~~
  - ~~https://docs.github.com/ja/actions/using-workflows/caching-dependencies-to-speed-up-workflows~~
- お手性キャッシュをやめて、actions/setup-nodeを使ってキャッシュ処理するようにした
  - https://github.com/actions/setup-node

## ~~やってないこと~~

- ~~Yarnのキャッシュをライブラリに任せる、そのためのPnP化~~
  - ~~キャッシュは現在自分で書いている~~
  - ~~既存のキャッシュactionsであるactions/setup-nodeに任せたい！~~
    - https://github.com/actions/setup-node
  - ~~でも現状のactions/setup-nodeはnode_modulesに対応していない~~
    - ~~YarnをWebpackerの事情でnodeLinkerをnode-modulesで使っている~~
    - ~~PnP化したいね~~
  - もしくは、pnpmへの移行もあり。めちゃ早いらしい。
