### PR TITLE
flyとActionsのコンテナ環境の指定間違いを修正

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -60,9 +60,6 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-      - name: Install bundle dependencies
-        run: |
-          bundle install
       - name: Run Rubocop
         run: bundle exec rubocop --parallel
       - name: Run ERB Lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,21 +53,26 @@ jobs:
       - name: Install Dependencies
         run: yarn workspaces focus --all --production
       - name: Set up Ruby
+        env:
+          BUNDLE_WITHOUT: development
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
       - name: Setup Database
         env:
+          BUNDLE_WITHOUT: development
           RAILS_ENV: test
           POSTGRES_USERNAME: postgres
           POSTGRES_PASSWORD: password
         run: bundle exec rails db:create
       - name: Assets precompile
         env:
+          BUNDLE_WITHOUT: development
           RAILS_ENV: test
         run: bundle exec rails assets:precompile
       - name: Run tests
         env:
+          BUNDLE_WITHOUT: development
           POSTGRES_USERNAME: postgres
           POSTGRES_PASSWORD: password
         run: bundle exec rspec

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,11 +58,6 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-      - name: Install bundle dependencies
-        run: |
-          bundle config set --local without development
-          bundle config set --local with test
-          bundle install
       - name: Setup Database
         env:
           RAILS_ENV: test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,6 @@ jobs:
         run: bundle exec rails assets:precompile
       - name: Run tests
         env:
-          RAILS_ENV: test
           POSTGRES_USERNAME: postgres
           POSTGRES_PASSWORD: password
         run: bundle exec rspec

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,9 +51,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-${{ env.cache-env }}-
       - name: Install Dependencies
-        run: |
-          yarn workspaces focus --production
-          yarn install
+        run: yarn workspaces focus --all --production
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/fly.Dockerfile
+++ b/fly.Dockerfile
@@ -75,7 +75,9 @@ RUN --mount=type=cache,id=dev-apt-cache,sharing=locked,target=/var/cache/apt \
 FROM build_deps as gems
 
 COPY Gemfile Gemfile.lock ./
-RUN bundle install &&  rm -rf vendor/bundle/ruby/*/cache
+RUN bundle config set --local without 'development test' && \
+    bundle install && \
+    rm -rf vendor/bundle/ruby/*/cache
 
 #######################################################################
 
@@ -86,7 +88,7 @@ FROM build_deps as node_modules
 COPY package.json yarn.lock .yarnrc.yml ./
 COPY .yarn/releases/ ./.yarn/releases/
 COPY .yarn/plugins/ ./.yarn/plugins/
-RUN yarn install
+RUN yarn workspaces focus --all --production
 
 #######################################################################
 


### PR DESCRIPTION
小さなミスを何個か見つけちった

## やったこと

- fly.io向けコンテナのyarnとbundleでproduction環境を使うようにした
  - 今まで無駄なファイルがデプロイされていた気がする
  - 動かしてみないと正しいかわからない
- Actionsで必要ないbundle installを削除
  - ruby/setup-ruby@v1がやってくれるので必要なかった
- Test Actionでの無駄な`yanr install`を削除
  - `yarn workspaces focus --all --production`だけでよく、その後の`yarn install`は余計だった
- Test Actionで必要ないtest環境指定を削除
  - rspecはrailsじゃないので`RAILS_ENV=test`は必要ない
- Test Actionでbundle環境にtest環境を指定した
  - ruby/setup-ruby@v1で指定したbundleのtest環境指定は、bundleコマンドを使う各種で指定する
