### PR TITLE
Add: 新たなrubocop-capybaraを有効化した

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,7 @@ inherit_from:
 require:
   - rubocop-rails
   - rubocop-rspec
+  - rubocop-capybara
 
 AllCops:
   DisabledByDefault: false # Cookpad Styleguideの上書き


### PR DESCRIPTION
Rubocopを実行すると下記のようなメッセージが出ていた。
いつの間にか、新たなrubocop-capybara gemが入っているようである。

メッセージに従い、有効化した。

```console
)$ rubocop
Inspecting 90 files
..........................................................................................

90 files inspected, no offenses detected

The following RuboCop extension libraries are installed but not loaded in config:
  * rubocop-capybara

You can opt out of this message by adding the following to your config (see https://docs.rubocop.org/rubocop/extensions.html#extension-suggestions for more options):
  AllCops:
    SuggestExtensions: false
```

## Copsの一覧

- https://docs.rubocop.org/rubocop-capybara/cops_capybara.html