### PR TITLE
ESLintに新たなエラー設定を増やした

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,7 @@
 {
   "env": {
     "browser": true,
-    "es2021": true
+    "es2022": true
   },
   "parserOptions": {
     "sourceType": "module"

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,6 @@
     "sourceType": "module"
   },
   "ignorePatterns": ["/coverage/", "/app/assets/builds"],
-  "plugins": [],
   "extends": ["eslint:recommended", "prettier"],
   "rules": {
     "indent": ["error", 2],

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,6 +18,7 @@
       { "varsIgnorePattern": "^_", "argsIgnorePattern": "^_" }
     ]
   },
+  "reportUnusedDisableDirectives": true,
   "overrides": [
     {
       "files": ["*.ts", "*.tsx"],

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,7 +24,7 @@
       "parser": "@typescript-eslint/parser",
       "parserOptions": {
         "tsconfigRootDir": ".",
-        "project": ["./tsconfig.json"]
+        "project": "./tsconfig.json"
       },
       "plugins": ["@typescript-eslint"],
       "extends": [

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "typescript": ">=4.9.5 <5"
   },
   "scripts": {
-    "lint:eslint": "eslint --ignore-path .gitignore --ext .js,.ts .",
+    "lint:eslint": "eslint --max-warnings=0  --ignore-path .gitignore --ext .js,.ts .",
     "lint:eslint:fix": "yarn run lint:eslint --fix",
     "lint:tsc": "yarn run tsc --noEmit",
     "lint:prettier": "prettier --ignore-path .gitignore --check .",


### PR DESCRIPTION
close #599

## 今まで

- 警告はESLintがエラーせずに終わる
- 必要ない`eslint-disable`コメントのチェックが抜けていた

## やったこｔ

- 消し忘れたeslint-disableコメントを警告にした
- eslintの警告を1個以上でexit 1するようにした
- 細かなリファクタ
  - JS/TSの構文バージョンを最新に指定
  - 空のplugin項目を削除
  - 必要ない配列表記を削除
