### PR TITLE
Update: docker compose上でブラウザテストできるようにした

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,14 @@ $ docker compose up
 
 - Gem/Node Package の更新があった場合は、`docker compose build`でイメージを更新する
 
+- テスト
+  - 別シェルで`docker compose up`しておくか、`docker compose up -d # バックグラウンドで起動`した状態で、以下のコマンドを実行する
+
+```console
+$ docker compose exec web bundle exec rspec
+```
+
+
 ## How to Contribute
 
 - GitHub の Issue/Pull Request にて受けつけています

--- a/README.md
+++ b/README.md
@@ -132,7 +132,8 @@ $ docker compose up
   - 別シェルで`docker compose up`しておくか、`docker compose up -d # バックグラウンドで起動`した状態で、以下のコマンドを実行する
 
 ```console
-docker compose exec web bundle exec rspec
+$ docker compose exec web bundle exec rspec
+...
 ```
 
 ## How to Contribute

--- a/README.md
+++ b/README.md
@@ -128,8 +128,7 @@ $ docker compose up
 
 - Gem/Node Package の更新があった場合は、`docker compose build`でイメージを更新する
 
-- テスト
-  - 別シェルで`docker compose up`しておくか、`docker compose up -d # バックグラウンドで起動`した状態で、以下のコマンドを実行する
+- 起動している Docker コンテナでテストを実行する
 
 ```console
 $ docker compose exec web bundle exec rspec

--- a/README.md
+++ b/README.md
@@ -132,9 +132,8 @@ $ docker compose up
   - 別シェルで`docker compose up`しておくか、`docker compose up -d # バックグラウンドで起動`した状態で、以下のコマンドを実行する
 
 ```console
-$ docker compose exec web bundle exec rspec
+docker compose exec web bundle exec rspec
 ```
-
 
 ## How to Contribute
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       POSTGRES_USERNAME: postgres
       POSTGRES_PASSWORD: password
       POSTGRES_HOSTNAME: db
+      IN_DOCKER: true
     build:
       context: .
       dockerfile: dev.Dockerfile
@@ -49,3 +50,10 @@ services:
     ports:
       - 3000
     command: "yarn build:css --watch"
+  selenium:
+    image: selenium/standalone-firefox:latest
+    ports:
+      - 4444:4444
+      - 7900:7900
+    environment:
+      shm-size: 512m

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,6 @@ services:
     command: "yarn build:css --watch"
   selenium:
     image: selenium/standalone-firefox:latest
+    shm_size: 512m
     ports:
       - 4444:4444
-    environment:
-      shm-size: 512m

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,9 @@ services:
       POSTGRES_USERNAME: postgres
       POSTGRES_PASSWORD: password
       POSTGRES_HOSTNAME: db
-      IN_DOCKER: true
+      CAPYBARA_SERVER_HOST: web
+      REMOTE_DRIVER_HOST: selenium
+      REMOTE_DRIVER_PORT: 4444
     build:
       context: .
       dockerfile: dev.Dockerfile
@@ -39,6 +41,7 @@ services:
       - "3000:3000"
     depends_on:
       - db
+      - selenium
   js:
     <<: *web
     tty: true
@@ -54,6 +57,5 @@ services:
     image: selenium/standalone-firefox:latest
     ports:
       - 4444:4444
-      - 7900:7900
     environment:
       shm-size: 512m

--- a/dotenv.example
+++ b/dotenv.example
@@ -16,10 +16,10 @@ POSTGRES_PASSWORD=
 # To test using a remote firefox, configure the following.
 # Refer to "capybara.rb" and "docker-compose.yml" in this repository.
 #
-# REMOTE_DRIVER_HOST=
-# REMOTE_DRIVER_PORT=
-# CAPYBARA_APP_HOST=
-# CAPYBARA_SERVER_HOST=
+# CAPYBARA_APP_HOST=http://host.docker.internal
+# CAPYBARA_SERVER_HOST=0.0.0.0
+# REMOTE_DRIVER_HOST=localhost
+# REMOTE_DRIVER_PORT=4444
 
 ### Google AdSense
 

--- a/dotenv.example
+++ b/dotenv.example
@@ -11,6 +11,16 @@
 POSTGRES_USERNAME=
 POSTGRES_PASSWORD=
 
+### Capybara
+
+# To test using a remote firefox, configure the following.
+# Refer to "capybara.rb" and "docker-compose.yml" in this repository.
+#
+# REMOTE_DRIVER_HOST=
+# REMOTE_DRIVER_PORT=
+# CAPYBARA_APP_HOST=
+# CAPYBARA_SERVER_HOST=
+
 ### Google AdSense
 
 # Client ID

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -2,23 +2,20 @@ require "capybara/rails"
 require "capybara/rspec"
 require "selenium-webdriver"
 
-Capybara.register_driver(:remote_firefox) do |app|
-  url = "http://selenium:4444/wd/hub"
-  options = Selenium::WebDriver::Firefox::Options.new
-  options.add_argument("--headless")
-  Capybara::Selenium::Driver.new(
-    app,
-    browser: :remote,
-    options:,
-    url:
-  )
-end
-
 Capybara.default_driver = :rack_test
 
-if ENV.fetch("IN_DOCKER", nil)
-  Capybara.javascript_driver = :remote_firefox
-  Capybara.server_host = "web"
+if ENV["REMOTE_DRIVER_HOST"]
+  Capybara.app_host = ENV.fetch("CAPYBARA_APP_HOST", nil)
+  Capybara.server_host = ENV.fetch("CAPYBARA_SERVER_HOST", nil)
+  Capybara.register_driver(:remote_firefox_headless) do |app|
+    host = ENV["REMOTE_DRIVER_HOST"]
+    port = ENV.fetch("REMOTE_DRIVER_PORT", 4444)
+    url = "http://#{host}:#{port}/wd/hub"
+    options = Selenium::WebDriver::Firefox::Options.new
+    options.add_argument("-headless")
+    Capybara::Selenium::Driver.new(app, browser: :remote, options:, url:)
+  end
+  Capybara.javascript_driver = :remote_firefox_headless
 else
   Capybara.javascript_driver = :selenium_headless
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,8 +1,28 @@
 require "capybara/rails"
 require "capybara/rspec"
+require "selenium-webdriver"
+
+Capybara.register_driver(:remote_firefox) do |app|
+  url = "http://selenium:4444/wd/hub"
+  options = Selenium::WebDriver::Firefox::Options.new
+  options.add_argument("--headless")
+  Capybara::Selenium::Driver.new(
+    app,
+    browser: :remote,
+    options:,
+    url:
+  )
+end
 
 Capybara.default_driver = :rack_test
-Capybara.javascript_driver = :selenium_headless
+
+if ENV.fetch("IN_DOCKER", nil)
+  Capybara.javascript_driver = :remote_firefox
+  Capybara.server_host = "web"
+else
+  Capybara.javascript_driver = :selenium_headless
+end
+
 RSpec.configure do |config|
   config.before(:each, type: :system) do |example|
     # context/describe/itの`js: true`でdriverを切り替える


### PR DESCRIPTION
Close #202

やったこと
docker compose上でrspecを実行する時、リモートのfirefoxブラウザを使ってブラウザテストをできるようにした。

やってないこと
docker composeを使わずにdockerコンテナで動かすときは、リモートのfirefoxブラウザを使わない（今まで通りローカルのfirefoxを使おうとする）