### PR TITLE
一部の初期化処理のリファクタ

### DIFF
--- a/app/controllers/sakes_controller.rb
+++ b/app/controllers/sakes_controller.rb
@@ -135,9 +135,7 @@ class SakesController < ApplicationController
   # @return [Hash<Symbol => Integer, Date>] デフォルト酒情報のハッシュ
   def default_attributes
     {
-      size: 720,
       brewery_year: to_by(Time.current),
-      bindume_on: Time.current.to_date.beginning_of_month,
     }
   end
 

--- a/app/models/sake.rb
+++ b/app/models/sake.rb
@@ -12,7 +12,7 @@
 #  bottle_level     :integer          default("sealed")
 #  brewery_year     :date
 #  color            :string
-#  emptied_at       :datetime         default(Fri, 01 Jan 2021 00:00:00.000000000 JST +09:00), not null
+#  emptied_at       :datetime         not null
 #  genryomai        :string
 #  hiire            :integer          default("unknown")
 #  kakemai          :string
@@ -23,7 +23,7 @@
 #  nigori           :string
 #  nihonshudo       :float
 #  note             :text
-#  opened_at        :datetime         default(Fri, 01 Jan 2021 00:00:00.000000000 JST +09:00), not null
+#  opened_at        :datetime         not null
 #  price            :integer
 #  rating           :integer          default(0), not null
 #  roka             :string
@@ -31,7 +31,7 @@
 #  season           :string
 #  seimai_buai      :integer
 #  shibori          :string
-#  size             :integer
+#  size             :integer          default(720)
 #  taste_impression :text
 #  taste_value      :integer
 #  todofuken        :string

--- a/app/models/sake.rb
+++ b/app/models/sake.rb
@@ -113,6 +113,12 @@ class Sake < ApplicationRecord
   validates :emptied_at, presence: true
   validates :rating, numericality: { only_integer: true }, inclusion: 0..5
 
+  after_initialize do |sake|
+    sake.opened_at ||= Time.current
+    sake.emptied_at ||= Time.current
+    sake.bindume_on ||= Time.current.to_date.beginning_of_month
+  end
+
   # rubocop:disable Layout/LineLength
   ransack_alias :all_text, :aroma_impression_or_awa_or_color_or_genryomai_or_kakemai_or_kobo_or_kura_or_name_or_nigori_or_note_or_roka_or_season_or_shibori_or_taste_impression_or_todofuken
   # rubocop:enable Layout/LineLength

--- a/db/migrate/20230325130307_change_sakes_default.rb
+++ b/db/migrate/20230325130307_change_sakes_default.rb
@@ -1,0 +1,7 @@
+class ChangeSakesDefault < ActiveRecord::Migration[7.0]
+  def change
+    change_column_default(:sakes, :size, from: nil, to: 720)
+    change_column_default(:sakes, :opened_at, from: Time.zone.local(2021), to: nil)
+    change_column_default(:sakes, :emptied_at, from: Time.zone.local(2021), to: nil)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_16_073620) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_25_130307) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-
-  create_table "data_migrations", primary_key: "version", id: :string, force: :cascade do |t|
-  end
 
   create_table "photos", force: :cascade do |t|
     t.string "image"
@@ -55,11 +52,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_16_073620) do
     t.integer "bottle_level", default: 0
     t.integer "hiire", default: 0
     t.integer "price"
-    t.integer "size"
+    t.integer "size", default: 720
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.datetime "opened_at", default: "2021-01-01 00:00:00", null: false
-    t.datetime "emptied_at", default: "2021-01-01 00:00:00", null: false
+    t.datetime "opened_at", null: false
+    t.datetime "emptied_at", null: false
     t.integer "rating", default: 0, null: false
   end
 

--- a/spec/factories/sakes.rb
+++ b/spec/factories/sakes.rb
@@ -12,7 +12,7 @@
 #  bottle_level     :integer          default("sealed")
 #  brewery_year     :date
 #  color            :string
-#  emptied_at       :datetime         default(Fri, 01 Jan 2021 00:00:00.000000000 JST +09:00), not null
+#  emptied_at       :datetime         not null
 #  genryomai        :string
 #  hiire            :integer          default("unknown")
 #  kakemai          :string
@@ -23,7 +23,7 @@
 #  nigori           :string
 #  nihonshudo       :float
 #  note             :text
-#  opened_at        :datetime         default(Fri, 01 Jan 2021 00:00:00.000000000 JST +09:00), not null
+#  opened_at        :datetime         not null
 #  price            :integer
 #  rating           :integer          default(0), not null
 #  roka             :string
@@ -31,7 +31,7 @@
 #  season           :string
 #  seimai_buai      :integer
 #  shibori          :string
-#  size             :integer
+#  size             :integer          default(720)
 #  taste_impression :text
 #  taste_value      :integer
 #  todofuken        :string

--- a/spec/models/sake_spec.rb
+++ b/spec/models/sake_spec.rb
@@ -12,7 +12,7 @@
 #  bottle_level     :integer          default("sealed")
 #  brewery_year     :date
 #  color            :string
-#  emptied_at       :datetime         default(Fri, 01 Jan 2021 00:00:00.000000000 JST +09:00), not null
+#  emptied_at       :datetime         not null
 #  genryomai        :string
 #  hiire            :integer          default("unknown")
 #  kakemai          :string
@@ -23,7 +23,7 @@
 #  nigori           :string
 #  nihonshudo       :float
 #  note             :text
-#  opened_at        :datetime         default(Fri, 01 Jan 2021 00:00:00.000000000 JST +09:00), not null
+#  opened_at        :datetime         not null
 #  price            :integer
 #  rating           :integer          default(0), not null
 #  roka             :string
@@ -31,7 +31,7 @@
 #  season           :string
 #  seimai_buai      :integer
 #  shibori          :string
-#  size             :integer
+#  size             :integer          default(720)
 #  taste_impression :text
 #  taste_value      :integer
 #  todofuken        :string


### PR DESCRIPTION
### やったこと
- Controllerに定義されていた下記カラムの初期化処理を、Migrationに定義した
  - size
- Migrationに定義されていた下記カラムの初期化処理を、Sakeモデルに移した。
  - opened_at
  - emptied_at 
- Controllerに定義されていた下記カラムの初期化処理を、Sakeモデルに移した。
  - bindume_on

### できてないこと
- Controller定義されているbrewery_yearの初期化処理を、Sakeモデルに移せてない。
  - to_byメソッドをSakeモデルに移動することになりそうなので、#594 もかかわってくる。

関連：#611 #594