### PR TITLE
ページネーションの動作にTurbo Frameを導入した

### DIFF
--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,3 +1,7 @@
 <li class="page-item <%= "disabled" if current_page.last? %>">
-  <%= link_to(tag.i(class: "bi-chevron-right"), url, class: "page-link", rel: "next") %>
+  <%= link_to(tag.i(class: "bi-chevron-right"),
+              url,
+              class: "page-link",
+              rel: "next",
+              data: { turbo_frame: "_self" }) %>
 </li>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -6,6 +6,10 @@
   </li>
 <% else %>
   <li class="page-item">
-    <%= link_to(page, url, class: "page-link", rel: page.rel) %>
+    <%= link_to(page,
+                url,
+                class: "page-link",
+                rel: page.rel,
+                data: { turbo_frame: "_self" }) %>
   </li>
 <% end %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,3 +1,7 @@
 <li class="page-item <%= "disabled" if current_page.first? %>">
-  <%= link_to(tag.i(class: "bi-chevron-left"), url, class: "page-link", rel: "prev") %>
+  <%= link_to(tag.i(class: "bi-chevron-left"),
+              url,
+              class: "page-link",
+              rel: "prev",
+              data: { turbo_frame: "_self" }) %>
 </li>

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -41,7 +41,7 @@
       </div>
     <% end %>
   </div>
-  <%= turbo_frame_tag("sakes", target: "_top") do %>
+  <%= turbo_frame_tag("sakes", target: "_top", data: { turbo_action: :advance }) do %>
     <div class="col">
       <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-2">
         <%= render(partial: "sake", collection: @sakes) %>

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -10,7 +10,7 @@
     </h1>
   </div>
   <div class="col">
-    <%= search_form_for(@search) do |f| %>
+    <%= search_form_for(@search, html: { data: { turbo_frame: "sakes" } }) do |f| %>
       <div class="row mx-0 align-items-center">
         <div class="col ps-0 input-group">
           <%= f.label(:all_text_cont, "search word", class: "form-label visually-hidden") %>

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -41,18 +41,20 @@
       </div>
     <% end %>
   </div>
-  <div class="col">
-    <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-2">
-      <%= render(partial: "sake", collection: @sakes) %>
+  <%= turbo_frame_tag("sakes") do %>
+    <div class="col">
+      <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-2">
+        <%= render(partial: "sake", collection: @sakes) %>
+      </div>
     </div>
-  </div>
-  <% if include_empty?(params[:q]) %>
-    <div class="col d-none d-sm-block">
-      <%= paginate(@sakes) %>
-    </div>
-    <div class="col d-sm-none d-block">
-      <%# 小さい画面 %>
-      <%= paginate(@sakes, window: 1) %>
-    </div>
+    <% if include_empty?(params[:q]) %>
+      <div class="col d-none d-sm-block">
+        <%= paginate(@sakes) %>
+      </div>
+      <div class="col d-sm-none d-block">
+        <%# 小さい画面 %>
+        <%= paginate(@sakes, window: 1) %>
+      </div>
+    <% end %>
   <% end %>
 </div>

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -41,20 +41,22 @@
       </div>
     <% end %>
   </div>
-  <%= turbo_frame_tag("sakes", target: "_top", data: { turbo_action: :advance }) do %>
-    <div class="col">
-      <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-2">
-        <%= render(partial: "sake", collection: @sakes) %>
+  <%= turbo_frame_tag("sakes", target: "_top", data: { turbo_action: :advance }, class: "col") do %>
+    <div class="row row-cols-1 g-3">
+      <div class="col">
+        <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-2">
+          <%= render(partial: "sake", collection: @sakes) %>
+        </div>
       </div>
+      <% if include_empty?(params[:q]) %>
+        <div class="col d-none d-sm-block">
+          <%= paginate(@sakes) %>
+        </div>
+        <div class="col d-sm-none d-block">
+          <%# 小さい画面 %>
+          <%= paginate(@sakes, window: 1) %>
+        </div>
+      <% end %>
     </div>
-    <% if include_empty?(params[:q]) %>
-      <div class="col d-none d-sm-block">
-        <%= paginate(@sakes) %>
-      </div>
-      <div class="col d-sm-none d-block">
-        <%# 小さい画面 %>
-        <%= paginate(@sakes, window: 1) %>
-      </div>
-    <% end %>
   <% end %>
 </div>

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -41,7 +41,7 @@
       </div>
     <% end %>
   </div>
-  <%= turbo_frame_tag("sakes") do %>
+  <%= turbo_frame_tag("sakes", target: "_top") do %>
     <div class="col">
       <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-2">
         <%= render(partial: "sake", collection: @sakes) %>


### PR DESCRIPTION
**feature-hotwireへのマージ**

超高速なページネーションを！

## Turbo Frameって何？

- （復習）Turbo Driveは、ページのbodyのみを書き換えることで高速化していた
- Turbo Frameは任意のフレーム（実際にはHTMLタグ1つ）のみを書き換えることでより高速化する。
- SAKAZUKIでいうと、indexページの酒の一覧表示の更新をTurbo Frame化することで高速化できる。

## やったこと

- indexページの酒カードが並ぶ箇所をTurbo Frame化
- ページネーションによる遷移でTurbo Frameを利用
- 検索による遷移でTurbo Frameを利用

## あえてやらなかったこと

- 空き瓶表示におけるチェックボックスによる遷移でTurbo Frameを利用する
  - チェックボックスはJSで更新を発火させており、Turbo Frame化が複雑と思われる
  - チェックボックスで遷移すると、Turbo Frame外の更新がいるためTurbo Frame利用できない
    - 具体的には、H1タグの酒総量の更新もいるため。デザイン変更が必要。