### PR TITLE
Fix: Rubyスクリプトを実行パスに依存しないようにした

### DIFF
--- a/cli-scripts/export_kura.rb
+++ b/cli-scripts/export_kura.rb
@@ -22,7 +22,7 @@ end
 #
 # @param output_file [File] 書き込み先のファイルオブジェクト
 def write_body(output_file)
-  input_file = "kura-list.ndjson"
+  input_file = "#{__dir__}/kura-list.ndjson"
   File.foreach(input_file, chomp: true) do |line|
     json = JSON.parse(line)
     name = json["name"]
@@ -33,7 +33,7 @@ def write_body(output_file)
 end
 
 def main
-  output_file = "../app/views/sakes/_kura_datalist.html.erb"
+  output_file = "#{__dir__}/../app/views/sakes/_kura_datalist.html.erb"
   File.open(output_file, "wb") do |out|
     write_header(out)
     write_body(out)

--- a/cli-scripts/export_meigara.rb
+++ b/cli-scripts/export_meigara.rb
@@ -8,7 +8,7 @@ require "json"
 #
 # @return [Array<Hash<Symbol => String, Array<String>>>] 蔵、地域、銘柄を持つjsonの配列
 def read_kura
-  filename = "kura-list.ndjson"
+  filename = "#{__dir__}/kura-list.ndjson"
   file = File.new(filename)
   jsons = []
   file.each_line do |line|
@@ -118,7 +118,7 @@ def main
   jsons = add_exceptional_duplication(jsons)
   dict = to_dict(jsons)
 
-  filename = "../app/javascript/autocompletion/meigaras.ts"
+  filename = "#{__dir__}/../app/javascript/autocompletion/meigaras.ts"
   write_dict(filename, dict)
 
   puts("Done!")

--- a/cli-scripts/export_sakamai.rb
+++ b/cli-scripts/export_sakamai.rb
@@ -20,7 +20,7 @@ end
 #
 # @param output_file [File] 書き込み先のファイルオブジェクト
 def write_body(output_file)
-  input_file = "sakamai-list.ndjson"
+  input_file = "#{__dir__}/sakamai-list.ndjson"
   File.foreach(input_file, chomp: true) do |line|
     json = JSON.parse(line)
     name = json["name"]
@@ -30,7 +30,7 @@ def write_body(output_file)
 end
 
 def main
-  output_file = "../app/views/sakes/_sakamai_datalist.html.erb"
+  output_file = "#{__dir__}/../app/views/sakes/_sakamai_datalist.html.erb"
   File.open(output_file, "wb") do |out|
     write_header(out)
     write_body(out)

--- a/cli-scripts/get_kura.rb
+++ b/cli-scripts/get_kura.rb
@@ -303,7 +303,8 @@ def main
   kuras = add_kuras(kuras)
 
   filename = "kura-list.ndjson"
-  write_ndjson(filename, kuras)
+  path = "#{__dir__}/#{filename}"
+  write_ndjson(path, kuras)
 
   puts("Done!")
   puts("Output to '#{filename}'")

--- a/cli-scripts/get_sakamai.rb
+++ b/cli-scripts/get_sakamai.rb
@@ -92,7 +92,8 @@ def main
   ndjson = to_ndjson(rices)
 
   filename = "sakamai-list.ndjson"
-  write_ndjson(filename, ndjson)
+  path = "#{__dir__}/#{filename}"
+  write_ndjson(path, ndjson)
 
   puts("Done!")
   puts("Output to '#{filename}'")


### PR DESCRIPTION
fix #624 

これでどこからでも呼び出せるわ！

例えば、

- `./cli-script/export_kura.rb`
- `cd ./cli-script && ./export_kura.rb`

のどちらも正しく動くようにした！