### PR TITLE
TypeScriptのverbatime module syntaxオプションをオンにした

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -42,6 +42,7 @@
             "argsIgnorePattern": "^_"
           }
         ],
+        "@typescript-eslint/consistent-type-imports": "error",
         "tsdoc/syntax": "warn"
       }
     }

--- a/app/javascript/taste_graph/input_taste_graph.ts
+++ b/app/javascript/taste_graph/input_taste_graph.ts
@@ -1,4 +1,5 @@
-import { DomValues, TasteGraph } from "./taste_graph"
+import { TasteGraph } from "./taste_graph"
+import type { DomValues } from "./taste_graph"
 
 // Main
 {

--- a/app/javascript/taste_graph/show_taste_graph.ts
+++ b/app/javascript/taste_graph/show_taste_graph.ts
@@ -1,4 +1,5 @@
-import { DomValues, TasteGraph } from "./taste_graph"
+import { TasteGraph } from "./taste_graph"
+import type { DomValues } from "./taste_graph"
 
 function getDomValues(canvas: HTMLCanvasElement): DomValues {
   const taste = canvas.dataset.tasteValue ?? ""

--- a/app/javascript/taste_graph/taste_graph.ts
+++ b/app/javascript/taste_graph/taste_graph.ts
@@ -1,14 +1,11 @@
 import merge from "ts-deepmerge"
-import {
-  Chart,
-  ScatterController,
-  PointElement,
-  LinearScale,
+import { Chart, ScatterController, PointElement, LinearScale } from "chart.js"
+import type {
   Color,
-  ScriptableScaleContext,
   ChartOptions,
   ChartConfiguration,
   ChartEvent,
+  ScriptableScaleContext,
   ActiveElement,
   BubbleDataPoint,
   Point,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,11 @@
 {
   "compilerOptions": {
-    "isolatedModules": true,
     "esModuleInterop": true,
     "moduleResolution": "bundler",
     "module": "esnext",
     "strict": true,
     "target": "esnext",
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "verbatimModuleSyntax": true
   }
 }


### PR DESCRIPTION
close #626 
after #623 

型のインポートには明示的な構文を使おう！

## このパッチで何が起こる

- 型をimportするのに`import type`を使うの強制できる
  - tscのチェックでエラーが起こる
- 関数と型のどちらを読み込んだのか、importの構文で明示できる！

### 正しい

```typescript
import type { TypeName } from "module" // eslint --fixによるオートフィクスはこの形になる
import { type TypeName, ClassName } from "module"
import type * as t from "module"
```

### エラー

```typescript
import { TyepName } from "module"
```

```console
$ yarn lint:tsc
hogehoge.ts:1:10 - error TS1484: 'TypeName' is a type and must be imported using a type-only import when 'verbatimModuleSyntax' is enabled.

1 import { TypeName } from "./module"
```

## やったこと

- Update: 新たなオプションverbatimModuleSyntaxをオンにした
  - 合わせて、対応するESLintのルールをオンにした
  - これがあると、`eslint --fix`で自動修正もできるので便利
  - https://typescript-eslint.io/rules/consistent-type-imports/
- Refactor: 型のインポートにimport typeを使うようにした
