### PR TITLE
Refactor: 必要ないbundle configを削除

### DIFF
--- a/fly.Dockerfile
+++ b/fly.Dockerfile
@@ -75,8 +75,7 @@ RUN --mount=type=cache,id=dev-apt-cache,sharing=locked,target=/var/cache/apt \
 FROM build_deps as gems
 
 COPY Gemfile Gemfile.lock ./
-RUN bundle config set --local without 'development test' && \
-    bundle install && \
+RUN bundle install && \
     rm -rf vendor/bundle/ruby/*/cache
 
 #######################################################################


### PR DESCRIPTION
すでに環境変数BUNDLE_WITHOUTを設定してある。
そのため、bundle configで改めて設定する必要はない。

## 参考

- Bundler - bundle config
  - https://bundler.io/v2.4/man/bundle-config.1.html#CONFIGURATION-KEYS