### PR TITLE
Fix: 味香りグラフで0を入力できない不具合を修正

### DIFF
--- a/app/javascript/taste_graph/taste_graph.ts
+++ b/app/javascript/taste_graph/taste_graph.ts
@@ -65,10 +65,15 @@ export class TasteGraph extends Chart {
 
   /**
    * グラフデータをDOMデータに変換する
+   *
+   * @param p - グラフデータ、ただし空グラフのときにNaNを含みうる
+   * @returns 文字列変換されたDOMデータ
    */
   protected static toDom(p: Point): DomValues {
-    const pointToDom = (num: number) =>
-      (num + TasteGraph.middle || "").toString()
+    const pointToDom = (num: number) => {
+      const v = num + TasteGraph.middle
+      return isNaN(v) ? "" : v.toString()
+    }
     return { taste: pointToDom(p.x), aroma: pointToDom(p.y) }
   }
 


### PR DESCRIPTION
fix #636

味香りグラフで一番左下の(-3,-3)を入力すると、
グラフ上は描画できているが、Railsでのデータが(null,null)になっていた。
正しくは、Railsで(0,0)の値がDBに登録されてほしい。

問題は、or条件で0が誤判定されているのが原因だった。
この条件式を書き直すことで修正。

こういったテストの導入はまだ行っていない。
JUnitのようなJS/TSのテストや、ブラウザサイズ固定のfeatureテストが必要かも。
