### PR TITLE
fix: docker composeを立ち上げなおすと画像が消える #608

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ volumes:
     driver: local
   builds:
     driver: local
+  uploads:
+    driver: local
 services:
   db:
     image: postgres:13
@@ -26,6 +28,7 @@ services:
       - ./db:/sakazuki/db:cached
       - ./spec:/sakazuki/spec:cached
       - ./public:/sakazuki/public:cached
+      - uploads:/sakazuki/app/public/uploads:consistent
       - builds:/sakazuki/app/assets/builds:consistent
     environment:
       POSTGRES_USERNAME: postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       - ./lib:/sakazuki/lib:cached
       - ./db:/sakazuki/db:cached
       - ./spec:/sakazuki/spec:cached
+      - ./public:/sakazuki/public:cached
       - builds:/sakazuki/app/assets/builds:consistent
     environment:
       POSTGRES_USERNAME: postgres


### PR DESCRIPTION
Close #608

publicをバインドマウントして、画像が残るようになった。
