### PR TITLE
typescript-eslintのstrictをオンにした

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,6 +32,7 @@
         "eslint:recommended",
         "plugin:@typescript-eslint/recommended",
         "plugin:@typescript-eslint/recommended-requiring-type-checking",
+        "plugin:@typescript-eslint/strict",
         "prettier"
       ],
       "rules": {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -44,6 +44,7 @@
           }
         ],
         "@typescript-eslint/consistent-type-imports": "error",
+        "@typescript-eslint/consistent-type-definitions": ["warn", "type"],
         "tsdoc/syntax": "warn"
       }
     }

--- a/app/javascript/simple_lightbox/simplelightbox.d.ts
+++ b/app/javascript/simple_lightbox/simplelightbox.d.ts
@@ -73,8 +73,7 @@ declare module "simplelightbox" {
 
   type SimpleLightboxData = {
     currentImageIndex: number
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    currentImage: any /* TODO */ | null
+    currentImage: HTMLImageElement | null
     globalScrollbarWidth: number
   }
 

--- a/app/javascript/taste_graph/taste_graph.ts
+++ b/app/javascript/taste_graph/taste_graph.ts
@@ -83,8 +83,8 @@ export class TasteGraph extends Chart {
   protected static getClickData(event: ChartEvent, chart: Chart) {
     // @ts-expect-error chart.jsのhelperの都合のエラーを無視する
     const canvasPosition = getRelativePosition(event, chart)
-    const x = chart.scales.x.getValueForPixel(canvasPosition.x) || NaN
-    const y = chart.scales.y.getValueForPixel(canvasPosition.y) || NaN
+    const x = chart.scales.x.getValueForPixel(canvasPosition.x) ?? NaN
+    const y = chart.scales.y.getValueForPixel(canvasPosition.y) ?? NaN
     return { x: Math.round(x), y: Math.round(y) }
   }
 


### PR DESCRIPTION
覚悟を決めろ！

## やったこと

- typescript-eslintのstrictをオンにした
- TypeScriptにてinterfaceよりもtypeを優先的に使うようESLintに設定した
- 設定変更に伴う修正
