### PR TITLE
TSDocを必須とした

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,7 +21,12 @@
     "no-unused-vars": [
       "error",
       { "varsIgnorePattern": "^_", "argsIgnorePattern": "^_" }
-    ]
+    ],
+    "jsdoc/require-asterisk-prefix": ["warn"],
+    "jsdoc/require-description": ["warn"],
+    "jsdoc/require-throws": ["warn"],
+    "jsdoc/sort-tags": ["warn"],
+    "jsdoc/tag-lines": ["warn", "any", { "startLines": 1 }]
   },
   "reportUnusedDisableDirectives": true,
   "overrides": [

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,12 @@
     "sourceType": "module"
   },
   "ignorePatterns": ["/coverage/", "/app/assets/builds"],
-  "extends": ["eslint:recommended", "prettier"],
+  "plugins": ["jsdoc"],
+  "extends": [
+    "eslint:recommended",
+    "prettier",
+    "plugin:jsdoc/recommended-typescript"
+  ],
   "rules": {
     "indent": ["error", 2],
     "linebreak-style": ["error", "unix"],

--- a/app/javascript/controllers/input_taste_graph_controller.ts
+++ b/app/javascript/controllers/input_taste_graph_controller.ts
@@ -1,6 +1,10 @@
 import { Controller } from "@hotwired/stimulus"
 import { TasteGraph } from "../taste_graph/taste_graph"
-import type { DomValues } from "../taste_graph/taste_graph"
+import type {
+  DomValues,
+  DomCallback,
+  TasteGraphOptions,
+} from "../taste_graph/taste_graph"
 
 // Connects to data-controller="input-taste-graph"
 export default class InputTasteGraphController extends Controller<HTMLDivElement> {
@@ -14,10 +18,14 @@ export default class InputTasteGraphController extends Controller<HTMLDivElement
       taste: this.tasteTarget.value,
       aroma: this.aromaTarget.value,
     }
-    const domCallback = ({ taste, aroma }: Readonly<DomValues>) => {
+    const domCallback: DomCallback = ({
+      taste,
+      aroma,
+    }: Readonly<DomValues>) => {
       this.tasteTarget.value = taste
       this.aromaTarget.value = aroma
     }
-    new TasteGraph({ canvas: this.canvasTarget, dom, domCallback })
+    const opts: TasteGraphOptions = { domCallback }
+    new TasteGraph(this.canvasTarget, dom, opts)
   }
 }

--- a/app/javascript/controllers/show_taste_graph_controller.ts
+++ b/app/javascript/controllers/show_taste_graph_controller.ts
@@ -20,7 +20,7 @@ export default class ShowTasteGraphController extends Controller<HTMLCanvasEleme
 
   connect() {
     const dom: DomValues = { taste: this.tasteValue, aroma: this.aromaValue }
-    const config: TasteGraphConfig = { pointRadius: 6, zeroLineWidth: 3 }
+    const config: TasteGraphConfig = { pointRadius: 6, lineWidth: 3 }
     const opts: TasteGraphOptions = { config }
     new TasteGraph(this.canvasTarget, dom, opts)
   }

--- a/app/javascript/controllers/show_taste_graph_controller.ts
+++ b/app/javascript/controllers/show_taste_graph_controller.ts
@@ -1,6 +1,10 @@
 import { Controller } from "@hotwired/stimulus"
 import { TasteGraph } from "../taste_graph/taste_graph"
-import type { DomValues } from "../taste_graph/taste_graph"
+import type {
+  DomValues,
+  TasteGraphConfig,
+  TasteGraphOptions,
+} from "../taste_graph/taste_graph"
 
 // Connects to data-controller="show-taste-graph"
 export default class ShowTasteGraphController extends Controller<HTMLCanvasElement> {
@@ -16,7 +20,8 @@ export default class ShowTasteGraphController extends Controller<HTMLCanvasEleme
 
   connect() {
     const dom: DomValues = { taste: this.tasteValue, aroma: this.aromaValue }
-    const config = { pointRadius: 6, zeroLineWidth: 3 }
-    new TasteGraph({ canvas: this.canvasTarget, dom, config })
+    const config: TasteGraphConfig = { pointRadius: 6, zeroLineWidth: 3 }
+    const opts: TasteGraphOptions = { config }
+    new TasteGraph(this.canvasTarget, dom, opts)
   }
 }

--- a/app/javascript/taste_graph/taste_graph.ts
+++ b/app/javascript/taste_graph/taste_graph.ts
@@ -14,19 +14,13 @@ import { getRelativePosition } from "chart.js/helpers"
 
 Chart.register(ScatterController, PointElement, LinearScale)
 
-/**
- * DOMに保存された味・香りの数値
- */
+/** DOMに保存された味・香りの数値 */
 export type DomValues = { taste: string; aroma: string }
 
-/**
- * グラフクリックされた値に対するコールバック関数
- */
+/** グラフクリックされた値に対するコールバック関数 */
 export type DomCallback = (d: DomValues) => void
 
-/**
- * TasteGraphのカスタマイズ値
- */
+/** TasteGraphのカスタマイズ値 */
 export type TasteGraphConfig = {
   lineWidth?: number
   pointRadius?: number
@@ -54,6 +48,12 @@ export class TasteGraph extends Chart {
 
   /**
    * DOMデータをグラフデータに変換する
+   *
+   * このときオフセットのズレを補正する。
+   * 具体的にはDOMでは0~6のデータだが、グラフでは-3~3となる。
+   *
+   * @param v - 文字列で表したDOMデータの組
+   * @returns チャートのPoint型に変換したデータ
    */
   static fromDom(v: DomValues): Point {
     const domToPoint = (dom: string) => {
@@ -79,6 +79,10 @@ export class TasteGraph extends Chart {
 
   /**
    * クリックした位置のグラフデータを取得する
+   *
+   * @param event - chart.jsのイベント
+   * @param chart - チャート
+   * @returns クリックした位置のデータ
    */
   protected static getClickData(event: ChartEvent, chart: Chart) {
     // @ts-expect-error chart.jsのhelperの都合のエラーを無視する
@@ -90,6 +94,9 @@ export class TasteGraph extends Chart {
 
   /**
    * グラフにデータを挿入する
+   *
+   * @param chart - チャート
+   * @param data - チャートデータ
    */
   protected static pushData(chart: Chart, data: Point) {
     chart.data.datasets[0].data.push(data)
@@ -97,6 +104,9 @@ export class TasteGraph extends Chart {
 
   /**
    * chart.jsのpopが返すunion型を、Point型だけにガードする
+   *
+   * @param arg - chart.jsのpushが返す値
+   * @returns 対象がPoint型のときのみTrue
    */
   protected static isPoint(
     arg: number | [number, number] | Point | BubbleDataPoint | undefined | null,
@@ -106,6 +116,9 @@ export class TasteGraph extends Chart {
 
   /**
    * グラフにデータを削除・取得する
+   *
+   * @param chart - チャート
+   * @returns チャートデータ
    */
   protected static popData(chart: Chart): Point {
     const data = chart.data.datasets[0].data.pop()
@@ -114,6 +127,10 @@ export class TasteGraph extends Chart {
 
   /**
    * グラフデータの同値比較
+   *
+   * @param p1 - チャートデータ
+   * @param p2 - チャートデータ
+   * @returns 引数2つのデータが等しいときのみTrue
    */
   protected static eqPoint(p1: Point, p2: Point) {
     return p1.x === p2.x && p1.y === p2.y

--- a/app/javascript/taste_graph/taste_graph.ts
+++ b/app/javascript/taste_graph/taste_graph.ts
@@ -26,6 +26,14 @@ export type TasteGraphConfig = {
   pointRadius?: number
 }
 
+/** TasteGraphのカスタマイズオプション */
+export type TasteGraphOptions = {
+  /** グラフがクリックされたときのコールバック */
+  domCallback?: DomCallback
+  /** グラフ描画のカスタマイズ */
+  config?: TasteGraphConfig
+}
+
 /**
  * 味・香りグラフ
  *
@@ -137,23 +145,18 @@ export class TasteGraph extends Chart {
   }
 
   /**
+   * コンストラクタ
+   *
    * @param canvas - グラフ描画先
    * @param dom - 描画するグラフの初期値
-   * @param domCallback - クリックされた値に対するコールバック関数を与える。
-   *                    この引数を与えると、クリックで入力可能なグラフになる。
-   * @param config - グラフのカスタマイズ値
+   * @param opts - options - グラフのカスタマイズ値
    */
-  constructor({
-    canvas,
-    dom,
-    domCallback,
-    config,
-  }: {
-    canvas: HTMLCanvasElement
-    dom: DomValues
-    domCallback?: DomCallback
-    config?: TasteGraphConfig
-  }) {
+  //eslint-enable tsdoc/syntax
+  constructor(
+    canvas: HTMLCanvasElement,
+    dom: DomValues,
+    opts: TasteGraphOptions = {}
+  ) {
     // --- Data ---
     const p = TasteGraph.fromDom(dom)
     const data = {
@@ -162,7 +165,7 @@ export class TasteGraph extends Chart {
           data: [p],
           backgroundColor: "rgba(183, 40, 46, 0.9)",
           borderColor: "rgba(183, 40, 46, 1.0)",
-          pointRadius: config?.pointRadius ?? 10,
+          pointRadius: opts.config?.pointRadius ?? 10,
         },
       ],
     }
@@ -241,7 +244,7 @@ export class TasteGraph extends Chart {
     const axis = merge(commonAxis, {
       grid: {
         lineWidth: (context: ScriptableScaleContext) => {
-          const line = config?.lineWidth ?? 5
+          const line = opts.config?.lineWidth ?? 5
           // x=0/y=0だけ太くする
           return context.tick.value === 0 ? line : 1
         },
@@ -285,6 +288,8 @@ export class TasteGraph extends Chart {
      * 入力モードのときは、クリック位置に一番近い整数値データを入力できる。
      * 既存のデータをクリックすると入力をリセットできる。
      */
+    // 型推論のためにオブジェクトを剥がす
+    const domCallback = opts.domCallback
     const onClick = (() => {
       if (typeof domCallback === "undefined")
         (_e: ChartEvent, _el: ActiveElement[], _c: Chart): void => {
@@ -318,13 +323,13 @@ export class TasteGraph extends Chart {
     }
 
     // --- Config ---
-    const cconfig: ChartConfiguration = {
+    const config: ChartConfiguration = {
       type: "scatter",
       data,
       options,
       plugins: [quadrants],
     }
 
-    super(canvas, cconfig)
+    super(canvas, config)
   }
 }

--- a/app/javascript/taste_graph/taste_graph.ts
+++ b/app/javascript/taste_graph/taste_graph.ts
@@ -155,7 +155,7 @@ export class TasteGraph extends Chart {
   constructor(
     canvas: HTMLCanvasElement,
     dom: DomValues,
-    opts: TasteGraphOptions = {}
+    opts: TasteGraphOptions = {},
   ) {
     // --- Data ---
     const p = TasteGraph.fromDom(dom)

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@typescript-eslint/parser": ">=5.57.1 <6",
     "eslint": ">=8.35.0 <9",
     "eslint-config-prettier": ">=9.0.0 <10",
+    "eslint-plugin-jsdoc": ">=46.8.2 <47",
     "eslint-plugin-tsdoc": ">=0.2.17 <1",
     "markdownlint-cli": ">=0.33.0 <1",
     "prettier": ">=3.0.3 <4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -67,6 +67,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@es-joy/jsdoccomment@npm:~0.40.1":
+  version: 0.40.1
+  resolution: "@es-joy/jsdoccomment@npm:0.40.1"
+  dependencies:
+    comment-parser: 1.4.0
+    esquery: ^1.5.0
+    jsdoc-type-pratt-parser: ~4.0.0
+  checksum: 6098394cd97ad0532dde4f3171980e700e4199c231969311efd2362c2b5a4eefa9d59a0bc1fe513afbb5cc456ef7633491a2984d64252e7bd8ebe22489120610
+  languageName: node
+  linkType: hard
+
 "@esbuild/android-arm64@npm:0.17.11":
   version: 0.17.11
   resolution: "@esbuild/android-arm64@npm:0.17.11"
@@ -683,6 +694,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"are-docs-informative@npm:^0.0.2":
+  version: 0.0.2
+  resolution: "are-docs-informative@npm:0.0.2"
+  checksum: 7a48ca90d66e29afebc4387d7029d86cfe97bad7e796c8e7de01309e02dcfc027250231c02d4ca208d2984170d09026390b946df5d3d02ac638ab35f74501c74
+  languageName: node
+  linkType: hard
+
 "are-we-there-yet@npm:^3.0.0":
   version: 3.0.1
   resolution: "are-we-there-yet@npm:3.0.1"
@@ -783,6 +801,13 @@ __metadata:
   dependencies:
     fill-range: ^7.0.1
   checksum: e2a8e769a863f3d4ee887b5fe21f63193a891c68b612ddb4b68d82d1b5f3ff9073af066c343e9867a393fe4c2555dcb33e89b937195feb9c1613d259edfcd459
+  languageName: node
+  linkType: hard
+
+"builtin-modules@npm:^3.3.0":
+  version: 3.3.0
+  resolution: "builtin-modules@npm:3.3.0"
+  checksum: db021755d7ed8be048f25668fe2117620861ef6703ea2c65ed2779c9e3636d5c3b82325bd912244293959ff3ae303afa3471f6a15bf5060c103e4cc3a839749d
   languageName: node
   linkType: hard
 
@@ -953,6 +978,13 @@ __metadata:
   version: 9.4.1
   resolution: "commander@npm:9.4.1"
   checksum: bfb18e325a5bdf772763c2213d5c7d9e77144d944124e988bcd8e5e65fb6d45d5d4e86b09155d0f2556c9a59c31e428720e57968bcd050b2306e910a0bf3cf13
+  languageName: node
+  linkType: hard
+
+"comment-parser@npm:1.4.0":
+  version: 1.4.0
+  resolution: "comment-parser@npm:1.4.0"
+  checksum: e086da3b14af9455177f1ab801bc54de9139a77fcef55dbfb751ae68d687ac83b0effb83d113ccf8cd217d9d93ce2b472002953cac342092a3fadfb9f5cd8e38
   languageName: node
   linkType: hard
 
@@ -1249,6 +1281,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-plugin-jsdoc@npm:>=46.8.2 <47":
+  version: 46.8.2
+  resolution: "eslint-plugin-jsdoc@npm:46.8.2"
+  dependencies:
+    "@es-joy/jsdoccomment": ~0.40.1
+    are-docs-informative: ^0.0.2
+    comment-parser: 1.4.0
+    debug: ^4.3.4
+    escape-string-regexp: ^4.0.0
+    esquery: ^1.5.0
+    is-builtin-module: ^3.2.1
+    semver: ^7.5.4
+    spdx-expression-parse: ^3.0.1
+  peerDependencies:
+    eslint: ^7.0.0 || ^8.0.0
+  checksum: ec2c435246cd45847b7c3ff3c04cc1713c658e3a6023e55577bda25c7ce1547d022aab0bf3b4920c6f792d52ff473c031d61167308e314183c15b57d23ce59c3
+  languageName: node
+  linkType: hard
+
 "eslint-plugin-tsdoc@npm:>=0.2.17 <1":
   version: 0.2.17
   resolution: "eslint-plugin-tsdoc@npm:0.2.17"
@@ -1347,7 +1398,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esquery@npm:^1.4.2":
+"esquery@npm:^1.4.2, esquery@npm:^1.5.0":
   version: 1.5.0
   resolution: "esquery@npm:1.5.0"
   dependencies:
@@ -1893,6 +1944,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-builtin-module@npm:^3.2.1":
+  version: 3.2.1
+  resolution: "is-builtin-module@npm:3.2.1"
+  dependencies:
+    builtin-modules: ^3.3.0
+  checksum: e8f0ffc19a98240bda9c7ada84d846486365af88d14616e737d280d378695c8c448a621dcafc8332dbf0fcd0a17b0763b845400709963fa9151ddffece90ae88
+  languageName: node
+  linkType: hard
+
 "is-core-module@npm:^2.1.0, is-core-module@npm:^2.5.0":
   version: 2.11.0
   resolution: "is-core-module@npm:2.11.0"
@@ -1996,6 +2056,13 @@ __metadata:
   bin:
     js-yaml: bin/js-yaml.js
   checksum: c7830dfd456c3ef2c6e355cc5a92e6700ceafa1d14bba54497b34a99f0376cecbb3e9ac14d3e5849b426d5a5140709a66237a8c991c675431271c4ce5504151a
+  languageName: node
+  linkType: hard
+
+"jsdoc-type-pratt-parser@npm:~4.0.0":
+  version: 4.0.0
+  resolution: "jsdoc-type-pratt-parser@npm:4.0.0"
+  checksum: af0629c9517e484be778d8564440fec8de5b7610e0c9c88a3ba4554321364faf72b46689c8d8845faa12c0718437a9ed97e231977efc0f2d50e8a2dbad807eb3
   languageName: node
   linkType: hard
 
@@ -2923,6 +2990,7 @@ __metadata:
     esbuild: ">=0.17.11 <1"
     eslint: ">=8.35.0 <9"
     eslint-config-prettier: ">=9.0.0 <10"
+    eslint-plugin-jsdoc: ">=46.8.2 <47"
     eslint-plugin-tsdoc: ">=0.2.17 <1"
     just-zip-it: ">=3.2.0 <4"
     markdownlint-cli: ">=0.33.0 <1"
@@ -2951,7 +3019,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7":
+"semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.5.4":
   version: 7.5.4
   resolution: "semver@npm:7.5.4"
   dependencies:
@@ -3076,7 +3144,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"spdx-expression-parse@npm:^3.0.0":
+"spdx-expression-parse@npm:^3.0.0, spdx-expression-parse@npm:^3.0.1":
   version: 3.0.1
   resolution: "spdx-expression-parse@npm:3.0.1"
   dependencies:


### PR DESCRIPTION
close #640

ちゃんとTypeScriptでもドキュメントを書くぞ！

## やったこと

- eslint-plugin-jsodcを導入した
  - 使いやすいようにJSDocの設定を調整した
- 不足していたTSDocを書いた
- TSDocが書きやすいようにTasteGraphコンストラクタの型を変更した
  - TSDocが書きやすいほうが、コンストラクタも使いやすいと思う
  - 実際、TSDocに従ったらバグも見つけてしまった。
