### PR TITLE
letter_openerへのリンクをdev環境で追加

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,6 +20,9 @@
     <% if Rails.env.development? %>
       <div class="py-5 bg-light">
         <%= debug(params) %>
+        <div>
+          <a href="/letter_opener">letter_opener</>
+        </div>
       </div>
     <% end %>
   </body>

--- a/spec/views/layouts/application.html.erb_spec.rb
+++ b/spec/views/layouts/application.html.erb_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "layouts/application", type: :system do
         allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("production"))
       end
 
-      it "is not in production and test environment" do
+      it "does not exist" do
         expect(page).not_to have_selector(:css, 'a[href="/letter_opener"]')
       end
     end

--- a/spec/views/layouts/application.html.erb_spec.rb
+++ b/spec/views/layouts/application.html.erb_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+# Capybaraを使うためにsystem specを指定する
+RSpec.describe "layouts/application", type: :system do
+  before do
+    visit root_path
+  end
+
+  describe "letter_opener link" do
+    it "is not in production and test environment" do
+      expect(page).not_to have_selector(:css, 'a[href="/letter_opener"]')
+    end
+  end
+end

--- a/spec/views/layouts/application.html.erb_spec.rb
+++ b/spec/views/layouts/application.html.erb_spec.rb
@@ -7,8 +7,14 @@ RSpec.describe "layouts/application", type: :system do
   end
 
   describe "letter_opener link" do
-    it "is not in production and test environment" do
-      expect(page).not_to have_selector(:css, 'a[href="/letter_opener"]')
+    context "when production environment" do
+      before do
+        allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("production"))
+      end
+
+      it "is not in production and test environment" do
+        expect(page).not_to have_selector(:css, 'a[href="/letter_opener"]')
+      end
     end
   end
 end


### PR DESCRIPTION
close #669

## やったこと

- Test/Prod環境でレターオープナーへのリンクがないテストを追加
- letter_openerへのリンクを、下部のデバッグ情報に追加

## スクリーンショット

![image](https://github.com/momocus/sakazuki/assets/849256/60d3c1ac-4b29-4788-817a-dbc6a56d98ca)

