### PR TITLE
Update: PR時に自動でレビュアー・アサイニーを登録するようにした

### DIFF
--- a/.github/auto_assign_configs.yml
+++ b/.github/auto_assign_configs.yml
@@ -1,0 +1,13 @@
+# Document
+# https://github.com/marketplace/actions/auto-assign-action
+
+# Set to true to add reviewers to pull requests
+addReviewers: true
+
+# A list of reviewers to be added to pull requests (GitHub user name)
+reviewers:
+  - momocus
+  - yonta
+
+# Set addAssignees to 'author' to set the PR creator as the assignee.
+addAssignees: author

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,13 @@
+name: "Auto Assign to PR Assignees"
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  add-reviews:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kentaro-m/auto-assign-action@v1.2.5
+        with:
+          configuration-path: ".github/auto_assign_configs.yml"


### PR DESCRIPTION
close #658

## やったこと

- Auto Assign Actionを導入した
  - PRにレビュアーと担当者が自動で割り当てられる
  - レビュアーはmomocusとyontaを指定した
  - 担当者はPR作成者とした

## やってないこと

- フォークレポジトリからのPRとdepended botのPRには担当者を自動付けしていない
  - ドキュメントにある通り、条件を`pull_request_target`にすればできる
  - とはいえフォークPRでActionsを動かせるため、セキュリティリスクが起こりうる、とドキュメントにも書いてある
  - 第三者からのPR少ないし、とりあえずオフでいいかなと

## 参考ドキュメント

- https://github.com/marketplace/actions/auto-assign-action
