### PR TITLE
mainでのRubocopエラーを修正

### DIFF
--- a/spec/views/layouts/application.html.erb_spec.rb
+++ b/spec/views/layouts/application.html.erb_spec.rb
@@ -2,14 +2,14 @@ require "rails_helper"
 
 # Capybaraを使うためにsystem specを指定する
 RSpec.describe "layouts/application", type: :system do
-  before do
-    visit root_path
-  end
+  context "when production environment" do
+    before do
+      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("production"))
+    end
 
-  describe "letter_opener link" do
-    context "when production environment" do
+    describe "letter_opener link" do
       before do
-        allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("production"))
+        visit root_path
       end
 
       it "does not exist" do

--- a/spec/views/layouts/application.html.erb_spec.rb
+++ b/spec/views/layouts/application.html.erb_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "layouts/application", type: :system do
       end
 
       it "does not exist" do
-        expect(page).not_to have_selector(:css, 'a[href="/letter_opener"]')
+        expect(page).not_to have_xpath('//a[@href="/letter_opener"]')
       end
     end
   end


### PR DESCRIPTION
fix #676

mainが❌になっている！！

## やったこと

- Rubocopエラーの修正
  - have_selectorの変わりにhave_xpathを使うようにした
- テスト時の環境の変更のバグを修正
  - テスト時の環境の変更は一番先にしないといけない
  - 変更前はページ描画してから環境を変更していて、意味のないテストをしていた
