### PR TITLE
Fix: CloudinaryのAVIF画像が間違った横向きになるのを修正

### DIFF
--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -15,4 +15,14 @@ class Photo < ApplicationRecord
   def chackbox_name
     "photo_delete_#{id}"
   end
+
+  # cl_image_tag/cl_image_pathで使える画像への参照を返す
+  #
+  # production環境では`full_public_id`を返す
+  # それ以外では画像ファイルのパスを返す
+  # @note production環境以外ではcl_image_tagにパスを渡すことで`angle: ignore`のような変換オプションを無視する
+  # @return [String] 画像への参照
+  def cl_reference
+    Rails.env.production? ? image.full_public_id : image.url
+  end
 end

--- a/app/views/sakes/_sake.html.erb
+++ b/app/views/sakes/_sake.html.erb
@@ -66,7 +66,9 @@
         <div class="col-6 pe-4 align-self-center photo-gallery" data-controller="simple-lightbox">
           <% if sake.photos.any? %>
             <% image = sake.photos.first.image %>
-            <%= link_to(cl_image_tag(image.thumb.url, class: "img-thumbnail img-fluid"), image.url) %>
+            <% original_url = cl_image_path(image.file.filename, angle: :ignore) %>
+            <% thumb_tag = cl_image_tag(image.thumb.url, class: "img-thumbnail") %>
+            <%= link_to(thumb_tag, original_url) %>
           <% else %>
             <%= cl_image_tag(image_url("sake-no-photo.avif"), class: "img-thumbnail img-fluid") %>
           <% end %>

--- a/app/views/sakes/_sake.html.erb
+++ b/app/views/sakes/_sake.html.erb
@@ -65,12 +65,10 @@
         </div>
         <div class="col-6 pe-4 align-self-center photo-gallery" data-controller="simple-lightbox">
           <% if sake.photos.any? %>
-            <% image = sake.photos.first.image %>
-            <% thumb_tag = cl_image_tag(image.thumb.url, class: "img-thumbnail") %>
-            <% image_id = Rails.env.production? ? image.full_public_id : image.url %>
-            <%# HACK: image_idが/upload/...のようなpathのときはangle: :ignoreが無視される %>
-            <% original_url = cl_image_path(image_id, angle: :ignore) %>
-            <%= link_to(thumb_tag, original_url) %>
+            <% photo = sake.photos.first %>
+            <% thumb_tag = cl_image_tag(photo.image.thumb.url, class: "img-thumbnail") %>
+            <% image_url = cl_image_path(photo.cl_reference, angle: :ignore) %>
+            <%= link_to(thumb_tag, image_url) %>
           <% else %>
             <%= cl_image_tag(image_url("sake-no-photo.avif"), class: "img-thumbnail img-fluid") %>
           <% end %>

--- a/app/views/sakes/_sake.html.erb
+++ b/app/views/sakes/_sake.html.erb
@@ -66,8 +66,10 @@
         <div class="col-6 pe-4 align-self-center photo-gallery" data-controller="simple-lightbox">
           <% if sake.photos.any? %>
             <% image = sake.photos.first.image %>
-            <% original_url = cl_image_path(image.file.filename, angle: :ignore) %>
             <% thumb_tag = cl_image_tag(image.thumb.url, class: "img-thumbnail") %>
+            <% image_id = Rails.env.production? ? image.full_public_id : image.url %>
+            <%# HACK: image_idが/upload/...のようなpathのときはangle: :ignoreが無視される %>
+            <% original_url = cl_image_path(image_id, angle: :ignore) %>
             <%= link_to(thumb_tag, original_url) %>
           <% else %>
             <%= cl_image_tag(image_url("sake-no-photo.avif"), class: "img-thumbnail img-fluid") %>

--- a/app/views/sakes/_show_abstract.html.erb
+++ b/app/views/sakes/_show_abstract.html.erb
@@ -97,10 +97,8 @@
         <% sake.photos.each do |photo| %>
           <div class="col-lg-2 col-6" data-testid="sake_photo">
             <% thumb_tag = cl_image_tag(photo.image.thumb.url, class: "img-thumbnail") %>
-            <% image_id = Rails.env.production? ? photo.image.full_public_id : photo.image.url %>
-            <%# HACK: image_idが/upload/...のようなpathのときはangle: :ignoreが無視される %>
-            <% original_url = cl_image_path(image_id, angle: :ignore) %>
-            <%= link_to(thumb_tag, original_url) %>
+            <% image_url = cl_image_path(photo.cl_reference, angle: :ignore) %>
+            <%= link_to(thumb_tag, image_url) %>
           </div>
         <% end %>
       </div>

--- a/app/views/sakes/_show_abstract.html.erb
+++ b/app/views/sakes/_show_abstract.html.erb
@@ -96,8 +96,10 @@
       <div class="row g-2 photo-gallery" data-controller="simple-lightbox">
         <% sake.photos.each do |photo| %>
           <div class="col-lg-2 col-6" data-testid="sake_photo">
-            <% original_url = cl_image_path(photo.image.file.filename, angle: :ignore) %>
             <% thumb_tag = cl_image_tag(photo.image.thumb.url, class: "img-thumbnail") %>
+            <% image_id = Rails.env.production? ? photo.image.full_public_id : photo.image.url %>
+            <%# HACK: image_idが/upload/...のようなpathのときはangle: :ignoreが無視される %>
+            <% original_url = cl_image_path(image_id, angle: :ignore) %>
             <%= link_to(thumb_tag, original_url) %>
           </div>
         <% end %>

--- a/app/views/sakes/_show_abstract.html.erb
+++ b/app/views/sakes/_show_abstract.html.erb
@@ -96,7 +96,9 @@
       <div class="row g-2 photo-gallery" data-controller="simple-lightbox">
         <% sake.photos.each do |photo| %>
           <div class="col-lg-2 col-6" data-testid="sake_photo">
-            <%= link_to(cl_image_tag(photo.image.thumb.url, class: "img-thumbnail"), photo.image.url) %>
+            <% original_url = cl_image_path(photo.image.file.filename, angle: :ignore) %>
+            <% thumb_tag = cl_image_tag(photo.image.thumb.url, class: "img-thumbnail") %>
+            <%= link_to(thumb_tag, original_url) %>
           </div>
         <% end %>
       </div>


### PR DESCRIPTION
fix #679 

## やったこと

- Production環境におけるCloudinaryの画像URLに`a_ignore`を含めるようにした
  - 既存DBのURLにはバージョン情報が含まれており、このままでは画像変換が動かない
  - バージョン情報が含まれない`public_full_id`を使うようにした
    - `full_public_id`（isvrjjmhbqaahkz59avgのような画像を表すID）
  - `cl_image_path`を`angle: :ignore`つきで呼び出し、`a_ignore`が含まれたURLを生成するようにした
- Development/Test環境では今まで通り、DBの画像URLを使うようにした
  - `/public/upload/.../sake.jpg`（Railsルートからのパス）
  - `cl_image_path`等での`angle: :ignore`のような変換オプションは無視される
- 画像の参照を取得する共通処理を、Photoモデルのメソッドにした
  - 同じ処理が酒のindex/showの二箇所で使われていた
