### PR TITLE
Fix: 酒indexページでSimpleLightboxが重複して起動する不具合を修正

### DIFF
--- a/app/views/sakes/_sake.html.erb
+++ b/app/views/sakes/_sake.html.erb
@@ -63,7 +63,7 @@
             </div>
           </div>
         </div>
-        <div class="col-6 pe-4 align-self-center photo-gallery">
+        <div class="col-6 pe-4 align-self-center photo-gallery" data-testid="sake_photo_<%= sake.id %>">
           <% if sake.photos.any? %>
             <% image = sake.photos.first.image %>
             <%= link_to(cl_image_tag(image.thumb.url, class: "img-thumbnail img-fluid"), image.url) %>

--- a/app/views/sakes/_sake.html.erb
+++ b/app/views/sakes/_sake.html.erb
@@ -63,7 +63,7 @@
             </div>
           </div>
         </div>
-        <div class="col-6 pe-4 align-self-center photo-gallery" data-controller="simple-lightbox">
+        <div class="col-6 pe-4 align-self-center photo-gallery">
           <% if sake.photos.any? %>
             <% image = sake.photos.first.image %>
             <%= link_to(cl_image_tag(image.thumb.url, class: "img-thumbnail img-fluid"), image.url) %>

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -44,7 +44,7 @@
   <%= turbo_frame_tag("sakes", target: "_top", data: { turbo_action: :advance }, class: "col") do %>
     <div class="row row-cols-1 g-3">
       <div class="col">
-        <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-2">
+        <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-2" data-controller="simple-lightbox">
           <%= render(partial: "sake", collection: @sakes) %>
         </div>
       </div>

--- a/spec/factories/photos.rb
+++ b/spec/factories/photos.rb
@@ -10,7 +10,6 @@
 #
 FactoryBot.define do
   factory :photo do
-    id { 1 }
     image { "temp_path" }
     sake
   end

--- a/spec/models/photo_spec.rb
+++ b/spec/models/photo_spec.rb
@@ -16,6 +16,6 @@ RSpec.describe Photo do
 
     let(:photo) { create(:photo) }
 
-    it { is_expected.to eq "photo_delete_1" }
+    it { is_expected.to eq "photo_delete_#{photo.id}" }
   end
 end

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -8,3 +8,7 @@ def sake_with_photos(photo_count: 1, sake_options: {}, file_ext: "avif")
     FactoryBot.create_list(:photo, photo_count, sake:, image:)
   end
 end
+
+def sakes_with_photos(sake_count: 1, photo_count: 1, sake_options: {})
+  Array.new(sake_count).map { |_| sake_with_photos(photo_count:, sake_options:) }
+end

--- a/spec/system/simple_lightboxes_spec.rb
+++ b/spec/system/simple_lightboxes_spec.rb
@@ -31,4 +31,21 @@ RSpec.describe "Simple Lightboxes", :js do
       end
     end
   end
+
+  context "with sake index page" do
+    let!(:sakes) { sakes_with_photos(sake_count: 2) }
+
+    before do
+      visit sakes_path
+      find(:test_id, "sake_photo_#{sakes.first.id}").click
+    end
+
+    it "does not change current path" do
+      expect(page).to have_current_path(sakes_path)
+    end
+
+    it "exists only one" do
+      expect(all(:css, ".simple-lightbox").length).to eq(1)
+    end
+  end
 end

--- a/spec/system/simple_lightboxes_spec.rb
+++ b/spec/system/simple_lightboxes_spec.rb
@@ -3,31 +3,33 @@ require "rails_helper"
 RSpec.describe "Simple Lightboxes", :js do
   let(:sake) { sake_with_photos(photo_count: 1) }
 
-  before do
-    visit sake_path(sake.id)
-  end
-
-  context "with avif photo" do
-    let(:sake) { sake_with_photos }
-
+  context "with sake show page" do
     before do
-      find(:test_id, "sake_photo").click
+      visit sake_path(sake.id)
     end
 
-    it "has same path" do
-      expect(page).to have_current_path(sake_path(sake.id))
+    context "with avif photo" do
+      let(:sake) { sake_with_photos }
+
+      before do
+        find(:test_id, "sake_photo").click
+      end
+
+      it "has same path" do
+        expect(page).to have_current_path(sake_path(sake.id))
+      end
     end
-  end
 
-  context "with jpg photo" do
-    let(:sake) { sake_with_photos(file_ext: "jpg") }
+    context "with jpg photo" do
+      let(:sake) { sake_with_photos(file_ext: "jpg") }
 
-    before do
-      find(:test_id, "sake_photo").click
-    end
+      before do
+        find(:test_id, "sake_photo").click
+      end
 
-    it "has same path" do
-      expect(page).to have_current_path(sake_path(sake.id))
+      it "has same path" do
+        expect(page).to have_current_path(sake_path(sake.id))
+      end
     end
   end
 end

--- a/spec/system/simple_lightboxes_spec.rb
+++ b/spec/system/simple_lightboxes_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Sake Show Simple Lightboxes", :js do
+RSpec.describe "Simple Lightboxes", :js do
   let(:sake) { sake_with_photos(photo_count: 1) }
 
   before do

--- a/spec/system/simple_lightboxes_spec.rb
+++ b/spec/system/simple_lightboxes_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.describe "Simple Lightboxes", :js do
-  let(:sake) { sake_with_photos(photo_count: 1) }
-
   context "with sake show page" do
     before do
       visit sake_path(sake.id)

--- a/spec/system/simple_lightboxes_spec.rb
+++ b/spec/system/simple_lightboxes_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Simple Lightboxes", :js do
     context "with avif photo" do
       let(:sake) { sake_with_photos }
 
-      it "has same path" do
+      it "does not change current path" do
         find(:test_id, "sake_photo").click
         expect(page).to have_current_path(sake_path(sake.id))
       end
@@ -18,7 +18,7 @@ RSpec.describe "Simple Lightboxes", :js do
     context "with jpg photo" do
       let(:sake) { sake_with_photos(file_ext: "jpg") }
 
-      it "has same path" do
+      it "does not change current path" do
         find(:test_id, "sake_photo").click
         expect(page).to have_current_path(sake_path(sake.id))
       end

--- a/spec/system/simple_lightboxes_spec.rb
+++ b/spec/system/simple_lightboxes_spec.rb
@@ -4,14 +4,18 @@ RSpec.describe "Simple Lightboxes", :js do
   context "with sake show page" do
     before do
       visit sake_path(sake.id)
+      find(:test_id, "sake_photo").click
     end
 
     context "with avif photo" do
       let(:sake) { sake_with_photos }
 
       it "does not change current path" do
-        find(:test_id, "sake_photo").click
         expect(page).to have_current_path(sake_path(sake.id))
+      end
+
+      it "exists" do
+        expect(page).to have_css(".simple-lightbox")
       end
     end
 
@@ -19,8 +23,11 @@ RSpec.describe "Simple Lightboxes", :js do
       let(:sake) { sake_with_photos(file_ext: "jpg") }
 
       it "does not change current path" do
-        find(:test_id, "sake_photo").click
         expect(page).to have_current_path(sake_path(sake.id))
+      end
+
+      it "exists" do
+        expect(page).to have_css(".simple-lightbox")
       end
     end
   end

--- a/spec/system/simple_lightboxes_spec.rb
+++ b/spec/system/simple_lightboxes_spec.rb
@@ -9,11 +9,8 @@ RSpec.describe "Simple Lightboxes", :js do
     context "with avif photo" do
       let(:sake) { sake_with_photos }
 
-      before do
-        find(:test_id, "sake_photo").click
-      end
-
       it "has same path" do
+        find(:test_id, "sake_photo").click
         expect(page).to have_current_path(sake_path(sake.id))
       end
     end
@@ -21,11 +18,8 @@ RSpec.describe "Simple Lightboxes", :js do
     context "with jpg photo" do
       let(:sake) { sake_with_photos(file_ext: "jpg") }
 
-      before do
-        find(:test_id, "sake_photo").click
-      end
-
       it "has same path" do
+        find(:test_id, "sake_photo").click
         expect(page).to have_current_path(sake_path(sake.id))
       end
     end


### PR DESCRIPTION
fix #683

変更前はSimpleLightboxを呼び出すdata-controllerが複数存在していた。
そのため、StimulusがSimpleLightboxを複数回起動していた。
data-controllerを1つにしたため、正しくSimpleLightboxが1つだけ呼び出されるようにした。
