### PR TITLE
Remove: すでに存在しない.yarn/plugins/のコピーをDockerfileたちから削除

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -55,7 +55,6 @@ EOF
 # yarn install
 COPY package.json yarn.lock .yarnrc.yml ./
 COPY .yarn/releases/ ./.yarn/releases/
-COPY .yarn/plugins/ ./.yarn/plugins/
 RUN yarn install && yarn cache clean
 
 # Add a script to be executed every time the container starts.

--- a/fly.Dockerfile
+++ b/fly.Dockerfile
@@ -86,7 +86,6 @@ FROM build_deps as node_modules
 
 COPY package.json yarn.lock .yarnrc.yml ./
 COPY .yarn/releases/ ./.yarn/releases/
-COPY .yarn/plugins/ ./.yarn/plugins/
 RUN yarn workspaces focus --all --production
 
 #######################################################################


### PR DESCRIPTION
fix #688

## やったこと

- 存在しない`.yarn/plugins`のCOPY節をDockerファイルから削除
