### PR TITLE
Fix: シェアボタン用テキストにいらないスペースや改行が入っていたのを修正

### DIFF
--- a/app/views/sakes/_show_abstract.html.erb
+++ b/app/views/sakes/_show_abstract.html.erb
@@ -12,9 +12,7 @@
           <i class="bi bi-share"></i>
         </a>
         <%# HACK: hiddenのtextareaをシェア機能から参照する %>
-        <textarea class="d-none" data-share-target="text">
-          <%= t("helper.share.text", sake:) %>
-        </textarea>
+        <textarea class="d-none" data-share-target="text"><%= t("helper.share.text", sake:) %></textarea>
       </div>
       <div class="col-lg-12 order-lg-2 col order-1 fs-3">
         <% if sake.kura.present? %>


### PR DESCRIPTION
close #692

## やったこと

- シェア対象の文字列から、いらないスペースや改行を削除