### PR TITLE
キーボードによるフォーカスリングの問題を修正

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -47,7 +47,6 @@ h1 {
   @extend .btn;
   @extend .btn-primary;
   @extend .rounded-pill;
-  @extend .shadow;
 }
 
 .float-button-secondary {
@@ -56,7 +55,6 @@ h1 {
   @extend .border-primary;
   @extend .border;
   @extend .rounded-pill;
-  @extend .shadow;
 }
 
 // ------ index ------

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,7 +21,7 @@
       <div class="py-5 bg-light">
         <%= debug(params) %>
         <div>
-          <a href="/letter_opener">letter_opener</>
+          <a href="/letter_opener">letter_opener</a>
         </div>
       </div>
     <% end %>

--- a/app/views/sakes/_sake.html.erb
+++ b/app/views/sakes/_sake.html.erb
@@ -10,7 +10,7 @@
             <div class="col-auto pe-0">
               <div class="dropdown" data-testid="sake_buttons_<%= sake.id %>">
                 <% id = "dropdownMenuSake#{sake.id}" %>
-                <button class="btn dropdown-toggle py-0" type="button"
+                <button class="btn btn-link dropdown-toggle py-0" type="button"
                   id="<%= id %>" data-bs-toggle="dropdown" aria-expanded="false"
                   data-testid="dropdown_toggle_<%= sake.id %>">
                   <i class="bi-three-dots-vertical fs-5 text-primary"></i>


### PR DESCRIPTION
close #690

- Fix: typo
- Fix: 酒カードの三点メニューボタンがキーボードフォーカス時にフォーカスリングがでないのを修正
    - ![image](https://github.com/momocus/sakazuki/assets/849256/e904f5dd-753a-4f2f-9b8c-2a4b199bd69a)
- Fix: float-buttonがキーボードフォーカス時にフォーカスリングがでないのを修正
    - float-buttonのshadowクラス適用をやめた
        - focus-ringとshadowクラスは同じCSSのbox-shadowを使っているので干渉するのは仕様
        - https://github.com/twbs/bootstrap/issues/39668
    - ![image](https://github.com/momocus/sakazuki/assets/849256/7ee89602-09d8-4625-aa68-dbfbe3e7fc67)
