### PR TITLE
Add: .gitattributesファイルを追加

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,19 @@
+## Generated Files
+
+# Completion
+/app/javascript/completion/meigara_dict.ts linguist-generated=true
+/app/views/sakes/_kura_datalist.html.erb linguist-generated=true
+/app/views/sakes/_sakamai_datalist.html.erb linguist-generated=true
+/cli-scripts/kura-list.ndjson linguist-generated=true
+/cli-scripts/sakamai-list.ndjson linguist-generated=true
+
+# Credentials
+/config/credentials.yml.enc linguist-generated=true
+/config/credentials/production.yml.enc linguist-generated=true
+
+# Bundler
+/Gemfile.lock linguist-generated=true
+
+# Yarn
+/yarn.lock linguist-generated=true
+/.yarn/releases/ linguist-generated=true


### PR DESCRIPTION
便利になるよ！

## やったこと

- .gitattributesファイルを追加した
  - 自動生成ファイルのリストを追加した。
  - これより、GitHubのdiff表示において、自動生成ファイルの内容は自動で折りたたまれる。

## やってないこと

- 自動生成ファイル以外のattributesの設定
  - ドキュメント
    - https://git-scm.com/docs/gitattributes
  - 他にできるらしいこと
    - 改行コードの指定
    - gitアーカイブ時の無視ファイル
    - バイナリファイルの指定
    - 特定ファイルのdiff/merge方法の指定
  - 今は必要なさそう
