### PR TITLE
Flyデプロイでスワップファイルの生成に失敗するのを修正

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -4,6 +4,7 @@ app = "sakazuki"
 kill_signal = "SIGINT"
 kill_timeout = 5
 processes = []
+swap_size_mb = 512
 
 [build]
   [build.args]

--- a/lib/tasks/fly.rake
+++ b/lib/tasks/fly.rake
@@ -17,8 +17,7 @@ namespace :fly do
   #  - full access to secrets, databases
   #  - failures here result in VM being stated, shutdown, and rolled back
   #    to last successful deploy (if any).
-  task :server do
-    sh "bin/rails assets:precompile"
+  task server: "assets:precompile" do
     sh "bin/rails server"
   end
 end

--- a/lib/tasks/fly.rake
+++ b/lib/tasks/fly.rake
@@ -17,22 +17,8 @@ namespace :fly do
   #  - full access to secrets, databases
   #  - failures here result in VM being stated, shutdown, and rolled back
   #    to last successful deploy (if any).
-  task server: :swapfile do
+  task :server do
     sh "bin/rails assets:precompile"
     sh "bin/rails server"
-  end
-
-  # optional SWAPFILE task:
-  #  - adjust fallocate size as needed
-  #  - performance critical applications should scale memory to the
-  #    point where swap is rarely used.  'fly scale help' for details.
-  #  - disable by removing dependency on the :server task, thus:
-  #        task :server do
-  task swapfile: :environment do
-    sh "fallocate -l 512M /swapfile"
-    sh "chmod 0600 /swapfile"
-    sh "mkswap /swapfile"
-    sh "echo 10 > /proc/sys/vm/swappiness"
-    sh "swapon /swapfile"
   end
 end


### PR DESCRIPTION
fix #713

## やったこと

- swapの設定をrake taskからfly.tomlに移動した
  - 自分でswapファイルを生成する方法はすでに古いようだ
  - 現在のドキュメントだと、fly.tomlに記述するとスワップを生成してくれる。
  - https://fly.io/docs/reference/configuration/#swap_size_mb-option
- rake taskの依存関係を、rake taskらしい記法にした
  - 参考：https://qiita.com/Teach/items/858cc7fcd29cf68d6e16