### PR TITLE
esbuild-bundle-analyzerのGithubActionを導入した

### DIFF
--- a/.github/workflows/esbuild-bundle-analyzer.yml
+++ b/.github/workflows/esbuild-bundle-analyzer.yml
@@ -1,0 +1,30 @@
+name: ESBuild Bundle Analyzer
+
+on: [pull_request]
+
+permissions:
+  contents: read # for checkout repository
+  actions: read # for fetching base branch bundle stats
+  pull-requests: write # for comments
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+          cache: "yarn"
+      - name: Install Dependencies
+        run: yarn workspaces focus --all --production
+      - name: Run esbuld
+        run: yarn run build:metafile
+
+      # Call this action after the build
+      - name: Analyze esbuild bundle size
+        # uses: exoego/esbuild-bundle-analyzer@main # If you prefer nightly!
+        uses: exoego/esbuild-bundle-analyzer@v1
+        with:
+          metafiles: "meta.json"

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "lint:stylelint": "stylelint 'app/assets/stylesheets/**/*.{scss,css}' --ignore-path .gitignore",
     "lint:stylelint:fix": "yarn run lint:stylelint --fix",
     "build": "esbuild app/javascript/*.* --bundle --sourcemap --define:global=window --outdir=app/assets/builds",
+    "build:metafile": "esbuild app/javascript/*.* --bundle --metafile=meta.json --outdir=app/assets/builds",
     "build:css": "sass ./app/assets/stylesheets/:./app/assets/builds/ --no-source-map --load-path=node_modules"
   },
   "packageManager": "yarn@4.0.2"


### PR DESCRIPTION
fix #717

## やったこと

- たつのさんのesbuild-bundle-analyzerを導入した
  - esbuildのbundleサイズをコメントで出してくれるすごいやつ
  - 急に増えるのを監視したり、bundle最適化の効果だったりがわかるぞい。
- 上記Action用にpackage.jsonにスクリプトを追加
  - esbuild時にmetafileを書き出すスクリプト
  - https://esbuild.github.io/api/#metafile

## やってないこと

- esbuild v0.20系になるとCLIじゃなくてJSで書かないといけないかも？