### PR TITLE
ci: fork から PR が来たとき esbuild-bundle-analyzer がコケるのを修正

### DIFF
--- a/.github/workflows/esbuild-bundle-analyzer.yml
+++ b/.github/workflows/esbuild-bundle-analyzer.yml
@@ -1,6 +1,6 @@
 name: ESBuild Bundle Analyzer
 
-on: [pull_request, pull_request_target]
+on: [pull_request_target]
 
 permissions:
   contents: read # for checkout repository
@@ -11,11 +11,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: |
-      ( github.event.pull_request.head.repo.fork && github.event_name == 'pull_request_target') ||
-      (!github.event.pull_request.head.repo.fork && github.event_name != 'pull_request_target')
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: "${{ github.event.pull_request.merge_commit_sha }}"
       - uses: actions/setup-node@v3
         with:
           node-version: "18"

--- a/.github/workflows/esbuild-bundle-analyzer.yml
+++ b/.github/workflows/esbuild-bundle-analyzer.yml
@@ -1,6 +1,7 @@
 name: ESBuild Bundle Analyzer
 
 on: [pull_request]
+#on: [pull_request, pull_request_target]
 
 permissions:
   contents: read # for checkout repository
@@ -11,6 +12,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    #if: |
+    #  ( github.event.pull_request.head.repo.fork && github.event_name == 'pull_request_target') ||
+    #  (!github.event.pull_request.head.repo.fork && github.event_name != 'pull_request_target')
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/esbuild-bundle-analyzer.yml
+++ b/.github/workflows/esbuild-bundle-analyzer.yml
@@ -1,7 +1,6 @@
 name: ESBuild Bundle Analyzer
 
-on: [pull_request]
-#on: [pull_request, pull_request_target]
+on: [pull_request, pull_request_target]
 
 permissions:
   contents: read # for checkout repository
@@ -12,9 +11,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    #if: |
-    #  ( github.event.pull_request.head.repo.fork && github.event_name == 'pull_request_target') ||
-    #  (!github.event.pull_request.head.repo.fork && github.event_name != 'pull_request_target')
+    if: |
+      ( github.event.pull_request.head.repo.fork && github.event_name == 'pull_request_target') ||
+      (!github.event.pull_request.head.repo.fork && github.event_name != 'pull_request_target')
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3


### PR DESCRIPTION
GitHub Action のセキュリティ上の制限として、fork からプルリクに対する `pull_request` イベントでは、`GITHUB_TOKEN` に `pull-request` scope への write 権限が付与されません。

> https://docs.github.com/ja/actions/security-guides/automatic-token-authentication
> <img width="740" alt="image" src="https://github.com/momocus/sakazuki/assets/127635/b749d889-d077-438d-b79c-66304f9a77ce">
> ...
> [pull_request_target](https://docs.github.com/ja/actions/using-workflows/events-that-trigger-workflows#pull_request_target) イベントによってワークフローがトリガーされると、パブリック フォークからトリガーされた場合でも、GITHUB_TOKEN にはリポジトリの読み取り/書き込みアクセス許可が付与されます。 詳しくは、「[ワークフローをトリガーするイベント](https://docs.github.com/ja/actions/using-workflows/events-that-trigger-workflows#pull_request_target)」を参照してください。

esbuild-bundle-analyzer は pull-request にコメントを書き込むため、write 権限が必要です。
fork からのプルリクでも `GITHUB_TOKEN` に write 権限を与えるためには、`pull_request_target` という別のイベントを明示する必要があるようです。



注：
この PR は初めての `pull_request_target` の追加なので、マージされるまで発火しないようです。
このような変更をマージしたあと、fork から来た PR で `pull_request_target` が発火しているのは https://github.com/exoego/esbuild-bundle-analyzer/pull/43 で確認できます


