### PR TITLE
esbuild-bundle-analyzerが正しくファイルを認識するようにした

### DIFF
--- a/.github/workflows/esbuild-bundle-analyzer.yml
+++ b/.github/workflows/esbuild-bundle-analyzer.yml
@@ -2,18 +2,21 @@ name: ESBuild Bundle Analyzer
 
 on: [pull_request_target]
 
-permissions:
-  contents: read # for checkout repository
-  actions: read # for fetching base branch bundle stats
-  pull-requests: write # for comments
-
 jobs:
-  build:
+  # PLEASE AVOID ADDING OTHER JOBS IN THIS FILE
+  # BECAUSE THIS ACTION USE `pull_request_target` EVENT that grants write
+  # permissions to GitHub Actions running on PRs from forks.
+  analyze:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read # for checkout repository
+      actions: read # for fetching base branch bundle stats
+      pull-requests: write # for comments
     steps:
       - uses: actions/checkout@v4
         with:
+          # This is required to fetch the commit SHA of the forked PR
           ref: "${{ github.event.pull_request.merge_commit_sha }}"
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/esbuild-bundle-analyzer.yml
+++ b/.github/workflows/esbuild-bundle-analyzer.yml
@@ -1,6 +1,9 @@
 name: ESBuild Bundle Analyzer
 
-on: [pull_request_target]
+on:
+  push:
+    branches: [main]
+  pull_request_target:
 
 jobs:
   # PLEASE AVOID ADDING OTHER JOBS IN THIS FILE


### PR DESCRIPTION
fix #736

## やったこと

- mainへのpushをトリガーに追加
  - これがないから、比較元であるベースブランチの解析結果がからっぽだった。なので常に全部Addedだった！（はず）
- 一部のリファクタ
  - actionsのバージョンアップ
  - コメントやパーミッション設定を、公式ドキュメント通りにした