### PR TITLE
Fly Deploy並列実行による失敗をマージキューで防ぐ

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,6 +1,6 @@
 name: Check
 
-on: [pull_request, workflow_call]
+on: [pull_request]
 
 jobs:
   check:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,6 +1,6 @@
 name: Check
 
-on: [pull_request]
+on: [pull_request, workflow_call]
 
 jobs:
   check:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,24 +1,9 @@
 name: Check
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
-  # Skip Duplicate Actions
-  check_skip:
-    runs-on: ubuntu-latest
-    outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
-    steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@v5
-        with:
-          cancel_others: "true"
-          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
-
   check:
-    needs: check_skip
-    if: needs.check_skip.outputs.should_skip != 'true'
-
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,8 +1,6 @@
 name: "Code Scanning - Action"
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
   schedule:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,6 +14,7 @@ on:
     #        │  │ │ │ │
     #        *  * * * *
     - cron: "15 3 * * 6"
+  workflow_call:
 
 jobs:
   CodeQL:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,7 +14,6 @@ on:
     #        │  │ │ │ │
     #        *  * * * *
     - cron: "15 3 * * 6"
-  workflow_call:
 
 jobs:
   CodeQL:

--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -1,20 +1,13 @@
 name: Fly Deploy
 on:
-  - merge_group
-
+  push:
+    branches:
+      - main
 env:
   FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 jobs:
-  check:
-    uses: ./.github/workflows/check.yml
-  test:
-    uses: ./.github/workflows/test.yml
-  codeql:
-    uses: ./.github/workflows/codeql.yml
   deploy:
     name: Deploy app
-    needs: [check, test, codeql]
-    if: ${{ success }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -3,8 +3,6 @@ on:
   push:
     branches:
       - main
-env:
-  FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 jobs:
   deploy:
     name: Deploy app
@@ -15,3 +13,5 @@ jobs:
       - uses: actions/checkout@v3
       - uses: superfly/flyctl-actions/setup-flyctl@master
       - run: flyctl deploy --remote-only --dockerfile fly.Dockerfile
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -9,6 +9,8 @@ jobs:
   deploy:
     name: Deploy app
     runs-on: ubuntu-latest
+    concurrency:
+      group: fly-deploy
     steps:
       - uses: actions/checkout@v3
       - uses: superfly/flyctl-actions/setup-flyctl@master

--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -1,13 +1,20 @@
 name: Fly Deploy
 on:
-  push:
-    branches:
-      - main
+  - merge_group
+
 env:
   FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 jobs:
+  check:
+    uses: ./.github/workflows/check.yml
+  test:
+    uses: ./.github/workflows/test.yml
+  codeql:
+    uses: ./.github/workflows/codeql.yml
   deploy:
     name: Deploy app
+    needs: [check, test, codeql]
+    if: ${{ success }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Test
 
-on: [pull_request, workflow_call]
+on: [pull_request]
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Test
 
-on: [pull_request]
+on: [pull_request, workflow_call]
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,24 +1,9 @@
 name: Test
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
-  # Skip Duplicate Actions
-  check_skip:
-    runs-on: ubuntu-latest
-    outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
-    steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@v5
-        with:
-          cancel_others: "true"
-          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
-
   test:
-    needs: check_skip
-    if: needs.check_skip.outputs.should_skip != 'true'
-
     runs-on: ubuntu-latest
 
     services:


### PR DESCRIPTION
fix #615 

## やったこと

- pushトリガーでのActions起動を削除した
  - そもそも必要ない
  - マージキュー化で邪魔なので削除
  - ついでにこれにより入れていたskip-duplicate-actionsも削除した
- ~~FlyへのデプロイをGitHubマージキューで行うようにした~~
- Actionsのconccurency設定をして、Flyへのデプロイを同時に1つまでに制限した
- ちょっとしたリファクタ

## 参考資料

- GitHub Actions doc
  - https://docs.github.com/ja/actions/using-jobs/using-concurrency
- Fly doc
  - https://fly.io/docs/app-guides/continuous-deployment-with-github-actions/

## 以下古い内容

### 必要な追加作業

1. ベースブランチの保護ルールで「マージキューを必須にする」
5. マージの制限、の、マージする pull request の最大数、を「1」にする
6. 他はデフォルトでよさそう？たぶん

- レポジトリオーナーのももかすにしかできない
- ドキュメント
  - https://docs.github.com/ja/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#managing-a-merge-queue

### 今後どうなるか

- 「Merge pull request」ボタンが「Merge when ready」ボタンに変わるらしい！
- ドキュメント
  - https://docs.github.com/ja/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/merging-a-pull-request-with-a-merge-queue
