### PR TITLE
まだレビューされてない酒がすべて炭酸なしになるのを修正

### DIFF
--- a/app/views/sakes/_form_review.html.erb
+++ b/app/views/sakes/_form_review.html.erb
@@ -49,7 +49,17 @@
                 </div>
                 <div class="col-12">
                   <%= form.label(:awa, class: "form-label") %>
-                  <%= form.text_field(:awa, class: "form-control", data: { testid: "sake_awa" }) %>
+                  <%= form.text_field(:awa,
+                                      class: "form-control",
+                                      autocomplete: "on",
+                                      list: "awa-list",
+                                      data: { testid: "sake_awa" }) %>
+                  <datalist id="awa-list">
+                    <option value="強炭酸"></option>
+                    <option value="炭酸"></option>
+                    <option value="微炭酸"></option>
+                    <option value="炭酸なし"></option>
+                  </datalist>
                 </div>
               </div>
             </div>

--- a/app/views/sakes/_show_review.html.erb
+++ b/app/views/sakes/_show_review.html.erb
@@ -71,7 +71,7 @@
               </div>
               <div class="text">
                 <div class="box">
-                  <%= empty_to_default(sake.awa, t(".no_awa")) %>
+                  <%= sake.awa %>
                 </div>
               </div>
             </div>

--- a/config/locales/views/sake.ja.yml
+++ b/config/locales/views/sake.ja.yml
@@ -26,7 +26,6 @@ ja:
       measurement: 計測
       unknown: 不明
     show_review:
-      no_awa: 炭酸なし
       review: レビュー
     drink_button:
       open: 開封する


### PR DESCRIPTION
close #742

## やったこと

- 酒ビューにて炭酸の文字列が空のとき炭酸なしと補完するのをやめた
- 酒フォームの炭酸項目に選択肢を追加した
