### PR TITLE
JS処理が間に合わないフレーキーテストに対処した

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -23,6 +23,10 @@ Capybara.configure do |config|
 
   # "data-testid"をCapybaraのclick_linkなどで使えるように、Optional attributeに登録する
   config.test_id = "data-testid"
+
+  # Capybaraのアサーションが失敗したときに自動再試行する時間
+  # JS処理が間に合わないなどフレーキーなテストへの対応するため少し長くする
+  config.default_max_wait_time = 5
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
fix #745

CIがときどき落ちる、フレーキーテストが存在している。
原因はおそらくJSの処理が間に合っていない。

Capybaraアサーションが失敗したときに、Capybaraは自動で再試行を行う。
この再試行は、デフォルトで2秒まで待ってから実行してくれる。

そこでこのパッチにより、待つ時間を5秒まで許可するようにした。
失敗したときにのみ効果があるので、テスト全体が遅くなることもない。

## やったこと

- Capybaraアサーション失敗時の自動再試行時間をデフォルト２秒から５秒に変更した
