### PR TITLE
酒ビューの味・香り・ノートで改行を表示できない不具合を修正

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -157,7 +157,7 @@ h1 {
   > .text {
     @extend .col-12;
 
-    > div {
+    > .box {
       @extend .fs-5;
       @extend .border-light;
       @extend .border-1;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -164,6 +164,12 @@ h1 {
       @extend .border;
       @extend .rounded;
       @extend .p-2;
+
+      > p {
+        @extend .m-0;
+
+        white-space: pre-wrap;
+      }
     }
   }
 }

--- a/app/views/sakes/_show_review.html.erb
+++ b/app/views/sakes/_show_review.html.erb
@@ -15,7 +15,7 @@
             <%= Sake.human_attribute_name(:color) %>
           </div>
           <div class="text">
-            <div>
+            <div class="box">
               <%= empty_to_default(sake.color, "　") %>
             </div>
           </div>
@@ -27,7 +27,7 @@
             <%= Sake.human_attribute_name(:nigori) %>
           </div>
           <div class="text">
-            <div>
+            <div class="box">
               <%= empty_to_default(sake.nigori, "　") %>
             </div>
           </div>
@@ -46,7 +46,7 @@
                 <%= Sake.human_attribute_name(:aroma_impression) %>
               </div>
               <div class="text">
-                <div>
+                <div class="box">
                   <%= empty_to_default(sake.aroma_impression, "　") %>
                 </div>
               </div>
@@ -58,7 +58,7 @@
                 <%= Sake.human_attribute_name(:taste_impression) %>
               </div>
               <div class="text">
-                <div>
+                <div class="box">
                   <%= empty_to_default(sake.taste_impression, "　") %>
                 </div>
               </div>
@@ -70,7 +70,7 @@
                 <%= Sake.human_attribute_name(:awa) %>
               </div>
               <div class="text">
-                <div>
+                <div class="box">
                   <%= empty_to_default(sake.awa, t(".no_awa")) %>
                 </div>
               </div>
@@ -95,7 +95,7 @@
         <%= Sake.human_attribute_name(:note) %>
       </div>
       <div class="text">
-        <div>
+        <div class="box">
           <%= empty_to_default(sake.note, "　") %>
         </div>
       </div>

--- a/app/views/sakes/_show_review.html.erb
+++ b/app/views/sakes/_show_review.html.erb
@@ -43,7 +43,7 @@
           <div class="col-12">
             <div class="textbox">
               <div class="label">
-                <%= Sake.human_attribute_name(:aroma_impression) %>
+                <p><%= Sake.human_attribute_name(:aroma_impression) %></p>
               </div>
               <div class="text">
                 <div class="box">
@@ -55,7 +55,7 @@
           <div class="col-12">
             <div class="textbox">
               <div class="label">
-                <%= Sake.human_attribute_name(:taste_impression) %>
+                <p><%= Sake.human_attribute_name(:taste_impression) %></p>
               </div>
               <div class="text">
                 <div class="box">
@@ -96,7 +96,7 @@
       </div>
       <div class="text">
         <div class="box">
-          <%= empty_to_default(sake.note, "　") %>
+          <p><%= empty_to_default(sake.note, "　") %></p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
fix #741

酒ノートで改行がちゃんと表示できるよ！やったね！

## やったこと

- 酒ビューのtext要素（味・香り・ノート）で、改行を正しく表示できるようにした
- 酒ビューでテキストボックスのスタイルクラスに名前をつけた
  - 無名divを使ったよんたってやつが悪い！
