### PR TITLE
レビュー項にあった酒ノートを、新たな項にした

### DIFF
--- a/app/views/sakes/_form.html.erb
+++ b/app/views/sakes/_form.html.erb
@@ -7,5 +7,6 @@
     <%= render(partial: "form_abstract", locals: { sake:, form: }) %>
     <%= render(partial: "form_detail", locals: { sake:, form: }) %>
     <%= render(partial: "form_review", locals: { sake:, form: }) %>
+    <%= render(partial: "form_note", locals: { sake:, form: }) %>
   </div>
 <% end %>

--- a/app/views/sakes/_form_note.html.erb
+++ b/app/views/sakes/_form_note.html.erb
@@ -1,0 +1,23 @@
+<div class="accordion-item">
+  <h2 class="accordion-header" id="headingNote">
+    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
+      data-bs-target="#collapseNote" aria-expanded="false" aria-controls="collapseNote">
+      <%= t(".note") %>
+    </button>
+  </h2>
+  <div id="collapseNote" class="accordion-collapse collapse"
+    aria-labelledby="headingNote" role="row"
+    data-bs-parent="#accordionNote">
+    <div class="accordion-body">
+      <div class="row g-4">
+        <fieldset class="col-12">
+          <div class="row gx-3">
+            <div class="col-12">
+              <%= form.text_area(:note, class: "form-control", data: { testid: "sake_note" }) %>
+            </div>
+          </div>
+        </fieldset>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/sakes/_form_review.html.erb
+++ b/app/views/sakes/_form_review.html.erb
@@ -96,14 +96,6 @@
                                   testid: "sake_rating",
                                 }) %>
         </fieldset>
-        <fieldset class="col-12">
-          <div class="row gx-3">
-            <div class="col-12 col-lg-6">
-              <%= form.label(:note, class: "form-label") %>
-              <%= form.text_area(:note, class: "form-control", data: { testid: "sake_note" }) %>
-            </div>
-          </div>
-        </fieldset>
       </div>
     </div>
   </div>

--- a/app/views/sakes/_show_note.html.erb
+++ b/app/views/sakes/_show_note.html.erb
@@ -1,0 +1,15 @@
+<div class="row gy-3">
+  <div class="col-12">
+    <h2 class="fs-3 mb-0"><%= t(".note") %></h2>
+  </div>
+
+  <div class="col-12">
+    <div class="textbox">
+      <div class="text">
+        <div class="box">
+          <p><%= empty_to_default(sake.note, "　") %></p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/sakes/_show_review.html.erb
+++ b/app/views/sakes/_show_review.html.erb
@@ -88,17 +88,4 @@
       </div>
     </div>
   </div>
-
-  <div class="col-lg-6 col-12">
-    <div class="textbox">
-      <div class="label">
-        <%= Sake.human_attribute_name(:note) %>
-      </div>
-      <div class="text">
-        <div class="box">
-          <p><%= empty_to_default(sake.note, "　") %></p>
-        </div>
-      </div>
-    </div>
-  </div>
 </div>

--- a/app/views/sakes/show.html.erb
+++ b/app/views/sakes/show.html.erb
@@ -19,6 +19,10 @@
   </div>
 
   <div class="col-12">
+    <%= render(partial: "show_note", locals: { sake: @sake }) %>
+  </div>
+
+  <div class="col-12">
     <div class="row justify-content-center">
       <div class="col-auto">
         <%= link_to(t(".delete"),

--- a/config/locales/views/sake.ja.yml
+++ b/config/locales/views/sake.ja.yml
@@ -63,6 +63,8 @@ ja:
       measurement: :sakes.show_detail.measurement
     form_review:
       review: :sakes.show_review.review
+    form_note:
+      note: :sakes.show_note.note
     float_button:
       edit: :sakes.sake.edit
       copy: 複製

--- a/config/locales/views/sake.ja.yml
+++ b/config/locales/views/sake.ja.yml
@@ -28,6 +28,8 @@ ja:
     show_review:
       no_awa: 炭酸なし
       review: レビュー
+    show_note:
+      note: ノート
     drink_button:
       open: 開封する
       confirm_open: "%{name} の栓を開ける？"


### PR DESCRIPTION
after PR #747 
close Issue #748 

## やったこと

- 酒ビュー・フォームのノートを別フィールドセットにした

## 変更前

### モバイル

![image](https://github.com/momocus/sakazuki/assets/849256/19123921-2263-48f6-abf2-4d3353489df9)

### PC

![image](https://github.com/momocus/sakazuki/assets/849256/5bb59032-116b-4360-bb68-8a2d77d9e331)

## 変更後

### モバイル

![image](https://github.com/momocus/sakazuki/assets/849256/af3eddae-7e2d-4a12-984a-899bed19e719)

### PC

![image](https://github.com/momocus/sakazuki/assets/849256/210ccd99-d66f-4ae6-84c6-5b9bdf09cf62)
