### PR TITLE
FirefoxをDockerコンテナで実行するときのドキュメントを追加

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -3,7 +3,13 @@ js: yarn build --watch
 css: yarn build:css --watch
 
 # Reccomend development runner with Docker
+#
 # You need PostgreSQL configurations.
 # See also dotenv.example file.
 #
 # db: docker run --rm --name db --network sakazuki_net --env-file .env --publish 5432:5432 --mount type=volume,src=sakazuki_db,dst=/var/lib/postgresql/data postgres:13-alpine
+#
+# You need remote dirver configurations.
+# See also dotenv.example file.
+#
+# selenium: docker run --rm --name selenium --network host --env-file .env --publish 4444:4444 selenium/standalone-firefox:latest

--- a/dotenv.example
+++ b/dotenv.example
@@ -16,10 +16,14 @@ POSTGRES_PASSWORD=
 # To test using a remote firefox, configure the following.
 # Refer to "capybara.rb" and "docker-compose.yml" in this repository.
 #
-# CAPYBARA_APP_HOST=http://host.docker.internal
-# CAPYBARA_SERVER_HOST=0.0.0.0
 # REMOTE_DRIVER_HOST=localhost
 # REMOTE_DRIVER_PORT=4444
+#
+# If you are using WSL, the following settings might also be necessary.
+#
+# CAPYBARA_APP_HOST=http://host.docker.internal
+# CAPYBARA_SERVER_HOST=0.0.0.0
+
 
 ### Google AdSense
 


### PR DESCRIPTION
新規環境で苦労したのでドキュメント追加した

- **Add: Procfile.devにFirefoxコンテナを使う場合のコマンド例を追加**
- **Update: dotenv.exampleにてCapybaraの設定値を用途に応じて分けた**
