### PR TITLE
docker compose buildが失敗するのを修正

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -5,7 +5,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Install build tools, posgresql-client, yarn and node
 RUN <<EOF
-  apt-get update -qq
+  apt-get update -q
   apt-get upgrade -y
   DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
     curl=7.74.* build-essential=12.9 gnupg2=2.2.*
@@ -21,7 +21,7 @@ RUN <<EOF
 
   curl -sSL https://deb.nodesource.com/setup_18.x | bash -
 
-  apt-get update -qq
+  apt-get update -q
   DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
     nodejs=18.* postgresql-client-13=13.* libpq-dev=16.* yarn=1.22.* \
     imagemagick=8:6.9.*

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -23,7 +23,7 @@ RUN <<EOF
 
   apt-get update -qq
   DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
-    nodejs=18.* postgresql-client-13=13.* libpq-dev=15.* yarn=1.22.* \
+    nodejs=18.* postgresql-client-13=13.* libpq-dev=16.* yarn=1.22.* \
     imagemagick=8:6.9.*
 
   apt-get clean

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.3-labs
+# syntax=docker/dockerfile:1.4
 FROM ruby:3.3.4-slim-bullseye
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/fly.Dockerfile
+++ b/fly.Dockerfile
@@ -64,7 +64,7 @@ ENV BUILD_PACKAGES ${BUILD_PACKAGES}
 # hadolint ignore=DL3008
 RUN --mount=type=cache,id=dev-apt-cache,sharing=locked,target=/var/cache/apt \
     --mount=type=cache,id=dev-apt-lib,sharing=locked,target=/var/lib/apt \
-    apt-get update -qq && \
+    apt-get update -q && \
     apt-get install --no-install-recommends -y ${BUILD_PACKAGES} \
     && rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
@@ -100,7 +100,7 @@ ENV DEPLOY_PACKAGES=${DEPLOY_PACKAGES}
 # hadolint ignore=DL3008
 RUN --mount=type=cache,id=prod-apt-cache,sharing=locked,target=/var/cache/apt \
     --mount=type=cache,id=prod-apt-lib,sharing=locked,target=/var/lib/apt \
-    apt-get update -qq && \
+    apt-get update -q && \
     apt-get install --no-install-recommends -y \
     ${DEPLOY_PACKAGES} \
     && rm -rf /var/lib/apt/lists /var/cache/apt/archives

--- a/fly.Dockerfile
+++ b/fly.Dockerfile
@@ -27,7 +27,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 LABEL fly_launch_runtime="rails"
 
 ARG NODE_VERSION=18.*
-ARG YARN_VERSION=3.1.1
+ARG YARN_VERSION=4.0.2
 ARG BUNDLER_VERSION=2.5.16
 
 ARG RAILS_ENV=production


### PR DESCRIPTION
fix #753

いつの間にかdocker開発環境が壊れていた！

## やったこと

- docker compose buildでビルド失敗するのを修正
  - libpq-devのバージョン指定に問題があった
- Dockerfileにおけるリファクタ
  - apt-getオプションを-qqから-qにした
  - Yarnのバージョンを正しく指定した
