### PR TITLE
Rubyのバージョン指定を.ruby-versionのみで行うようまとめた

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -21,6 +21,7 @@ app/assets/builds/*
 # required to bundle install
 !Gemfile
 !Gemfile.lock
+!.ruby-version
 
 # used only in development
 !entrypoint.sh

--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -11,7 +11,10 @@ jobs:
       group: fly-deploy
     steps:
       - uses: actions/checkout@v4
+      - name: Detect ruby version
+        id: ruby-version
+        run: echo "::set-output name=RUBY_VERSION::$(cat .ruby-version)"
       - uses: superfly/flyctl-actions/setup-flyctl@master
-      - run: flyctl deploy --remote-only --dockerfile fly.Dockerfile
+      - run: flyctl deploy --remote-only --dockerfile fly.Dockerfile --build-arg ${{ steps.ruby-version.outputs.RUBY_VERSION }}
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "3.3.4"
+ruby file: ".ruby-version"
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "= 7.1.3.4"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 ## Requirements
 
-- Ruby = 3.3.4
+- Ruby = (See .ruby-version file)
 - Bundler
 - Yarn🐈 >= 1.22.4
 - Node.js >= 12.20.1

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ See the [deployment](https://github.com/momocus/sakazuki/wiki/Deployment).
 - Docker イメージのビルド
 
 ```console
-$ docker compose build
+$ docker compose build --build-arg RUBY_VERSION=$(cat .ruby-version)
 ...
 ```
 

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,5 +1,7 @@
 # syntax=docker/dockerfile:1.4
-FROM ruby:3.3.4-slim-bullseye
+ARG RUBY_VERSION
+
+FROM ruby:${RUBY_VERSION}-slim-bullseye
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
@@ -39,7 +41,7 @@ WORKDIR /sakazuki
 RUN mkdir tmp/ log/
 
 # bundle install
-COPY Gemfile Gemfile.lock ./
+COPY Gemfile Gemfile.lock .ruby-version ./
 RUN <<EOF
   gem update --system
   gem install bundler:2.5.16

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,8 @@ services:
     build:
       context: .
       dockerfile: dev.Dockerfile
+      args:
+        - RUBY_VERSION
     command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
     ports:
       - "3000:3000"

--- a/fly.Dockerfile
+++ b/fly.Dockerfile
@@ -17,7 +17,7 @@
 # We recommend using the highest patch level for better security and
 # performance.
 
-ARG RUBY_VERSION=3.3.4
+ARG RUBY_VERSION
 ARG VARIANT=jemalloc-bullseye-slim
 FROM quay.io/evl.ms/fullstaq-ruby:${RUBY_VERSION}-${VARIANT} as base
 


### PR DESCRIPTION
fix #752 

after #727 #754 

## やったこと

- docker compose開発で使うDockerfileでのRubyバージョン指定を変更
  - コマンドが`docker compose build` -> `docker compose build --build-arg RUBY_VERSION=$(cat .ruby-version)`になった
  - READMEにも記載
  - dockerignoreに`.ruby-version`を追加
- fly deploy actionでのRubyバージョン指定を変更
  - 新たにDetect ruby versionというstepを追加
- GemfileでのRubyバージョン指定を変更
- READMEでのRubyバージョン表記を「See .ruby-version file」にした
