### PR TITLE
Dependabotがパッケージアップデート通知を行うための設定ファイルを追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # Maintain dependencies for Bundler
+  - package-ecosystem: "bundler" # See documentation for possible values
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  # Maintain dependencies for Yarn
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## 背景と問題点

dependabotには3つ機能がある。

1. 脆弱性のセキュリティ通知
2. 脆弱性対応のPRの自動生成
3. パッケージマネージャによるパッケージアップデートのPRの自動作成

レポジトリの設定のみで1と2は有効かされている。
実は3はレポジトリの設定＋設定ファイル`dependabot.yml`が必要。
今までは設定ファイルがないため3は動いていなかった。

## やったこと

- `.github/dependabot.yml`を追加

## 今後

- パッケージアップデートは頻繁にくるので、うざったいようならオフにするのもあり。
- 生のBundler/Yarnを利用しているが、Dockerやdevcontainerを利用してのアップデート通知もある。
  - 今後devcontainerを用意できたら移行できるとよりよい

## 参考

- https://docs.github.com/ja/code-security/dependabot/ecosystems-supported-by-dependabot/supported-ecosystems-and-repositories
- https://zenn.dev/camomile_cafe/articles/52d8e641ba732d
- https://qiita.com/yokawasa/items/38c6a4242cbe0fd5bbf0