### PR TITLE
Fix: docker build checksが常に失敗するのを修正

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -54,6 +54,12 @@ jobs:
 
       # lint by docker build checks
       - name: Run Docker Build Checks for dev.Dockerfile
-        run: docker build --check --file dev.Dockerfile .
+        # > 複数行における改行をスペースに変換する
+        # - ブロック最後の改行を削除
+        run: >-
+          docker build --build-arg RUBY_VERSION="$(cat .ruby-version)"
+          --check --file dev.Dockerfile .
       - name: Run Docker Build Checks for fly.Dockerfile
-        run: docker build --check --file fly.Dockerfile .
+        run: >-
+          docker build --build-arg RUBY_VERSION="$(cat .ruby-version)"
+          --check --file fly.Dockerfile .

--- a/cli-scripts/run-all-checks.sh
+++ b/cli-scripts/run-all-checks.sh
@@ -69,7 +69,7 @@ message "##### Run Docker Build Checks"
 if type docker > /dev/null 2>&1; then
     files=$(git ls-files | grep "Dockerfile")
     for file in ${files}; do
-        docker build --check --file "${file}" .
+        docker build --build-arg RUBY_VERSION="$(cat .ruby-version)" --check --file "${file}" .
     done
 else
     warning "[SKIP] Docker Build Checks, Docker is required."


### PR DESCRIPTION
build時の引数RUBY_VERSIONを指定していないためエラーになっていた。
build checks時に引数を与えるようにした。

PR #759 とPR #755 の複合でエラーするようになった。
