### PR TITLE
GitHub ActionsでImageMagickがないためテストが失敗するのを修正

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Install ImageMagick
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes imagemagick
       - uses: actions/setup-node@v4
         with:
           node-version: "18"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           node-version: "18"
           cache: "yarn"
-      - name: Install Dependencies
+      - name: Install Yarn Dependencies
         run: yarn workspaces focus --all --production
       - name: Set up Ruby
         env:


### PR DESCRIPTION
PR #801 を修正しているときに、Testワークフローが落ちていたのを修正。

## やったこと

- ubuntu-latestがUbuntu24.04になり、ImageMagickがインストールされてなくてテストが失敗するのを修正
- 一部ワークフローのタイトルを微修正
