### PR TITLE
酒のサイズをradioボタンで選択性にした

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -19,6 +19,9 @@ application.register("sake-kura", SakeKuraController)
 import SakeNameController from "./sake_name_controller"
 application.register("sake-name", SakeNameController)
 
+import SakeSizeController from "./sake_size_controller"
+application.register("sake-size", SakeSizeController)
+
 import ShareController from "./share_controller"
 application.register("share", ShareController)
 

--- a/app/javascript/controllers/sake_size_controller.js
+++ b/app/javascript/controllers/sake_size_controller.js
@@ -1,0 +1,7 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="sake-size"
+export default class extends Controller {
+  connect() {
+  }
+}

--- a/app/javascript/controllers/sake_size_controller.js
+++ b/app/javascript/controllers/sake_size_controller.js
@@ -1,7 +1,0 @@
-import { Controller } from "@hotwired/stimulus"
-
-// Connects to data-controller="sake-size"
-export default class extends Controller {
-  connect() {
-  }
-}

--- a/app/javascript/controllers/sake_size_controller.ts
+++ b/app/javascript/controllers/sake_size_controller.ts
@@ -8,15 +8,26 @@ export default class SakeSizeController extends Controller<HTMLDivElement> {
   declare readonly otherSizeTarget: HTMLInputElement
   declare readonly sizeTarget: HTMLInputElement
 
+  /**
+   * その他酒サイズの入力フォームのenable/disableを管理する
+   *
+   * その他radioボタンが選ばれているときは、入力フォームを有効化し値必須にする。
+   */
   updateOtherSizeEnablement(): void {
     this.otherSizeTarget.disabled = !this.otherRadioTarget.checked
     this.otherSizeTarget.required = this.otherRadioTarget.checked
   }
 
+  /** 本当の酒サイズフォームにその他酒サイズを書き込む */
   writeHiddenWithOtherSize(): void {
     this.sizeTarget.value = this.otherSizeTarget.value
   }
 
+  /**
+   * 本当の酒サイズフォームを押されたradioボタンの数値によって書き込む
+   *
+   * @param event - コントローラの呼び出し元イベント
+   */
   writeHiddenByRadio(event: Event): void {
     const elem = event.currentTarget as HTMLInputElement
     const size = elem.dataset.sakeSize
@@ -26,10 +37,12 @@ export default class SakeSizeController extends Controller<HTMLDivElement> {
     else this.sizeTarget.value = size
   }
 
+  /** その他酒サイズフォームに本当の酒サイズを書き込む */
   private writeOtherSizeWithHidden(): void {
     this.otherSizeTarget.value = this.sizeTarget.value
   }
 
+  /** 初期表示時に本当の酒サイズを読み込み、適切なradioにチェックをつける */
   private readHiddenSize(): void {
     const hiddenSize = this.sizeTarget.value
     const matchedRadio = this.radioTargets.find(

--- a/app/javascript/controllers/sake_size_controller.ts
+++ b/app/javascript/controllers/sake_size_controller.ts
@@ -53,7 +53,7 @@ export default class SakeSizeController extends Controller<HTMLDivElement> {
     if (matchedRadio == null) this.writeOtherSizeWithHidden()
 
     // 酒サイズに合うradioにチェックをつける
-    const radio = matchedRadio ?? this.otherSizeTarget
+    const radio = matchedRadio ?? this.otherRadioTarget
     radio.checked = true
 
     this.updateOtherSizeEnablement()

--- a/app/javascript/controllers/sake_size_controller.ts
+++ b/app/javascript/controllers/sake_size_controller.ts
@@ -1,0 +1,52 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="sake-size"
+export default class SakeSizeController extends Controller<HTMLDivElement> {
+  static targets = ["radio", "otherRadio", "otherSize", "size"]
+  declare readonly radioTargets: HTMLInputElement[]
+  declare readonly otherRadioTarget: HTMLInputElement
+  declare readonly otherSizeTarget: HTMLInputElement
+  declare readonly sizeTarget: HTMLInputElement
+
+  updateOtherSizeEnablement(): void {
+    this.otherSizeTarget.disabled = !this.otherRadioTarget.checked
+    this.otherSizeTarget.required = this.otherRadioTarget.checked
+  }
+
+  writeHiddenWithOtherSize(): void {
+    this.sizeTarget.value = this.otherSizeTarget.value
+  }
+
+  writeHiddenByRadio(event: Event): void {
+    const elem = event.currentTarget as HTMLInputElement
+    const size = elem.dataset.sakeSize
+    if (size == null) return // error
+
+    if (size == "other") this.writeHiddenWithOtherSize()
+    else this.sizeTarget.value = size
+  }
+
+  private writeOtherSizeWithHidden(): void {
+    this.otherSizeTarget.value = this.sizeTarget.value
+  }
+
+  private readHiddenSize(): void {
+    const hiddenSize = this.sizeTarget.value
+    const matchedRadio = this.radioTargets.find(
+      (elem) => elem.dataset.sakeSize == hiddenSize,
+    )
+
+    // 選択肢にないサイズでフォームを埋める
+    if (matchedRadio == null) this.writeOtherSizeWithHidden()
+
+    // 酒サイズに合うradioにチェックをつける
+    const radio = matchedRadio ?? this.otherSizeTarget
+    radio.checked = true
+
+    this.updateOtherSizeEnablement()
+  }
+
+  connect() {
+    this.readHiddenSize()
+  }
+}

--- a/app/views/sakes/_form_abstract.html.erb
+++ b/app/views/sakes/_form_abstract.html.erb
@@ -169,7 +169,7 @@
                 </div>
               <% end %>
             </div>
-            <div class="col-12 col-lg-3" data-controller="sake-size">
+            <div class="col-12 col-lg-3" data-controller="sake-size" data-testid="sake_size_div">
               <%= form.label(:size, { class: "form-label" }) %>
               <div class="row row-cols-auto gy-2">
                 <div class="col">

--- a/app/views/sakes/_form_abstract.html.erb
+++ b/app/views/sakes/_form_abstract.html.erb
@@ -169,12 +169,14 @@
                 </div>
               <% end %>
             </div>
-            <div class="col-12 col-lg-3">
+            <div class="col-12 col-lg-3" data-controller="sake-size">
               <%= form.label(:size, { class: "form-label" }) %>
               <div class="row row-cols-auto gy-2">
                 <div class="col">
                   <div class="form-check">
-                    <input class="form-check-input" type="radio" name="sake_size_check" id="sake_size_check_180">
+                    <input class="form-check-input" type="radio" name="sake_size_check" id="sake_size_check_180"
+                      data-sake-size-target="radio" data-sake-size="180"
+                      data-action="sake-size#updateOtherSizeEnablement sake-size#writeHiddenByRadio">
                     <label calss="form-check-label" for="sake_size_check_180">
                       180
                     </label>
@@ -182,7 +184,9 @@
                 </div>
                 <div class="col">
                   <div class="form-check">
-                    <input class="form-check-input" type="radio" name="sake_size_check" id="sake_size_check_300">
+                    <input class="form-check-input" type="radio" name="sake_size_check" id="sake_size_check_300"
+                      data-sake-size-target="radio" data-sake-size="300"
+                      data-action="sake-size#updateOtherSizeEnablement sake-size#writeHiddenByRadio">
                     <label calss="form-check-label" for="sake_size_check_300">
                       300
                     </label>
@@ -190,7 +194,9 @@
                 </div>
                 <div class="col">
                   <div class="form-check">
-                    <input class="form-check-input" type="radio" name="sake_size_check" id="sake_size_check_720">
+                    <input class="form-check-input" type="radio" name="sake_size_check" id="sake_size_check_720"
+                      data-sake-size-target="radio" data-sake-size="720"
+                      data-action="sake-size#updateOtherSizeEnablement sake-size#writeHiddenByRadio">
                     <label calss="form-check-label" for="sake_size_check_720">
                       720
                     </label>
@@ -198,7 +204,9 @@
                 </div>
                 <div class="col">
                   <div class="form-check">
-                    <input class="form-check-input" type="radio" name="sake_size_check" id="sake_size_check_1800">
+                    <input class="form-check-input" type="radio" name="sake_size_check" id="sake_size_check_1800"
+                      data-sake-size-target="radio" data-sake-size="1800"
+                      data-action="sake-size#updateOtherSizeEnablement sake-size#writeHiddenByRadio">
                     <label calss="form-check-label" for="sake_size_check_1800">
                       1800
                     </label>
@@ -206,11 +214,14 @@
                 </div>
                 <div class="col-12">
                   <div class="form-check d-flex ">
-                    <input class="form-check-input me-2" type="radio" name="sake_size_check" id="sake_size_check_other">
+                    <input class="form-check-input me-2" type="radio" name="sake_size_check" id="sake_size_check_other"
+                      data-sake-size-target="otherRadio" data-sake-size="other"
+                      data-action="sake-size#updateOtherSizeEnablement sake-size#writeHiddenByRadio">
                     <label calss="form-check-label w-auto" for="sake_size_check_other">
                       <%= t(".other_size") %>
                     </label>
-                    <input class="form-control ms-3 w-50" type="number" min="0" id="sake_size_check_other">
+                    <input class="form-control ms-3 w-50" type="number" min="0" disabled id="sake_size_other"
+                      data-sake-size-target="otherSize" data-action="sake-size#writeHiddenWithOtherSize">
                   </div>
                 </div>
               </div>
@@ -219,7 +230,10 @@
                                     required: true,
                                     class: "form-control",
                                     aria: { describedby: "sakeSizeValidationFeedback" },
-                                    data: { testid: "sake_size" }) %>
+                                    data: {
+                                      "sake-size-target": "size",
+                                      testid: "sake_size",
+                                    }) %>
               <% sake.errors.full_messages_for(:size).each do |message| %>
                 <div id="sakeSizeValidationFeedback" class="invalid-feedback" data-testid="sake_size_feedback">
                   <%= message %>

--- a/app/views/sakes/_form_abstract.html.erb
+++ b/app/views/sakes/_form_abstract.html.erb
@@ -228,7 +228,7 @@
                       <label class="visually-hidden" for="sake_size_other">
                         <%= t(".other_size") %>
                       </label>
-                      <input class="form-control" type="number" min="0" disabled id="sake_size_other"
+                      <input class="form-control" type="number" min="0" autocomplete="off" disabled id="sake_size_other"
                         data-sake-size-target="otherSize" data-action="sake-size#writeHiddenWithOtherSize">
                     </div>
                   </div>

--- a/app/views/sakes/_form_abstract.html.erb
+++ b/app/views/sakes/_form_abstract.html.erb
@@ -174,40 +174,40 @@
               <div class="row row-cols-auto gy-2">
                 <div class="col">
                   <div class="form-check">
-                    <input class="form-check-input" type="radio" name="sake_size_check" id="sake_size_check_180"
+                    <input class="form-check-input" type="radio" name="sake_size_radio" id="sake_size_radio_180"
                       data-sake-size-target="radio" data-sake-size="180"
                       data-action="sake-size#updateOtherSizeEnablement sake-size#writeHiddenByRadio">
-                    <label class="form-check-label" for="sake_size_check_180">
+                    <label class="form-check-label" for="sake_size_radio_180">
                       180
                     </label>
                   </div>
                 </div>
                 <div class="col">
                   <div class="form-check">
-                    <input class="form-check-input" type="radio" name="sake_size_check" id="sake_size_check_300"
+                    <input class="form-check-input" type="radio" name="sake_size_radio" id="sake_size_radio_300"
                       data-sake-size-target="radio" data-sake-size="300"
                       data-action="sake-size#updateOtherSizeEnablement sake-size#writeHiddenByRadio">
-                    <label class="form-check-label" for="sake_size_check_300">
+                    <label class="form-check-label" for="sake_size_radio_300">
                       300
                     </label>
                   </div>
                 </div>
                 <div class="col">
                   <div class="form-check">
-                    <input class="form-check-input" type="radio" name="sake_size_check" id="sake_size_check_720"
+                    <input class="form-check-input" type="radio" name="sake_size_radio" id="sake_size_radio_720"
                       data-sake-size-target="radio" data-sake-size="720"
                       data-action="sake-size#updateOtherSizeEnablement sake-size#writeHiddenByRadio">
-                    <label class="form-check-label" for="sake_size_check_720">
+                    <label class="form-check-label" for="sake_size_radio_720">
                       720
                     </label>
                   </div>
                 </div>
                 <div class="col">
                   <div class="form-check">
-                    <input class="form-check-input" type="radio" name="sake_size_check" id="sake_size_check_1800"
+                    <input class="form-check-input" type="radio" name="sake_size_radio" id="sake_size_radio_1800"
                       data-sake-size-target="radio" data-sake-size="1800"
                       data-action="sake-size#updateOtherSizeEnablement sake-size#writeHiddenByRadio">
-                    <label class="form-check-label" for="sake_size_check_1800">
+                    <label class="form-check-label" for="sake_size_radio_1800">
                       1800
                     </label>
                   </div>
@@ -216,10 +216,10 @@
                   <div class="row align-items-center">
                     <div class="col-auto">
                       <div class="form-check">
-                        <input class="form-check-input me-2" type="radio" name="sake_size_check" id="sake_size_check_other"
+                        <input class="form-check-input me-2" type="radio" name="sake_size_radio" id="sake_size_radio_other"
                           data-sake-size-target="otherRadio" data-sake-size="other"
                           data-action="sake-size#updateOtherSizeEnablement sake-size#writeHiddenByRadio">
-                        <label class="form-check-label" for="sake_size_check_other">
+                        <label class="form-check-label" for="sake_size_radio_other">
                           <%= t(".other_size") %>
                         </label>
                       </div>

--- a/app/views/sakes/_form_abstract.html.erb
+++ b/app/views/sakes/_form_abstract.html.erb
@@ -171,7 +171,51 @@
             </div>
             <div class="col-12 col-lg-3">
               <%= form.label(:size, { class: "form-label" }) %>
+              <div class="row row-cols-auto gy-2">
+                <div class="col">
+                  <div class="form-check">
+                    <input class="form-check-input" type="radio" name="sake_size_check" id="sake_size_check_180">
+                    <label calss="form-check-label" for="sake_size_check_180">
+                      180
+                    </label>
+                  </div>
+                </div>
+                <div class="col">
+                  <div class="form-check">
+                    <input class="form-check-input" type="radio" name="sake_size_check" id="sake_size_check_300">
+                    <label calss="form-check-label" for="sake_size_check_300">
+                      300
+                    </label>
+                  </div>
+                </div>
+                <div class="col">
+                  <div class="form-check">
+                    <input class="form-check-input" type="radio" name="sake_size_check" id="sake_size_check_720">
+                    <label calss="form-check-label" for="sake_size_check_720">
+                      720
+                    </label>
+                  </div>
+                </div>
+                <div class="col">
+                  <div class="form-check">
+                    <input class="form-check-input" type="radio" name="sake_size_check" id="sake_size_check_1800">
+                    <label calss="form-check-label" for="sake_size_check_1800">
+                      1800
+                    </label>
+                  </div>
+                </div>
+                <div class="col-12">
+                  <div class="form-check d-flex ">
+                    <input class="form-check-input me-2" type="radio" name="sake_size_check" id="sake_size_check_other">
+                    <label calss="form-check-label w-auto" for="sake_size_check_other">
+                      <%= t(".other_size") %>
+                    </label>
+                    <input class="form-control ms-3 w-50" type="number" min="0" id="sake_size_check_other">
+                  </div>
+                </div>
+              </div>
               <%= form.number_field(:size,
+                                    hidden: true,
                                     required: true,
                                     class: "form-control",
                                     aria: { describedby: "sakeSizeValidationFeedback" },

--- a/app/views/sakes/_form_abstract.html.erb
+++ b/app/views/sakes/_form_abstract.html.erb
@@ -177,7 +177,7 @@
                     <input class="form-check-input" type="radio" name="sake_size_check" id="sake_size_check_180"
                       data-sake-size-target="radio" data-sake-size="180"
                       data-action="sake-size#updateOtherSizeEnablement sake-size#writeHiddenByRadio">
-                    <label calss="form-check-label" for="sake_size_check_180">
+                    <label class="form-check-label" for="sake_size_check_180">
                       180
                     </label>
                   </div>
@@ -187,7 +187,7 @@
                     <input class="form-check-input" type="radio" name="sake_size_check" id="sake_size_check_300"
                       data-sake-size-target="radio" data-sake-size="300"
                       data-action="sake-size#updateOtherSizeEnablement sake-size#writeHiddenByRadio">
-                    <label calss="form-check-label" for="sake_size_check_300">
+                    <label class="form-check-label" for="sake_size_check_300">
                       300
                     </label>
                   </div>
@@ -197,7 +197,7 @@
                     <input class="form-check-input" type="radio" name="sake_size_check" id="sake_size_check_720"
                       data-sake-size-target="radio" data-sake-size="720"
                       data-action="sake-size#updateOtherSizeEnablement sake-size#writeHiddenByRadio">
-                    <label calss="form-check-label" for="sake_size_check_720">
+                    <label class="form-check-label" for="sake_size_check_720">
                       720
                     </label>
                   </div>
@@ -207,17 +207,17 @@
                     <input class="form-check-input" type="radio" name="sake_size_check" id="sake_size_check_1800"
                       data-sake-size-target="radio" data-sake-size="1800"
                       data-action="sake-size#updateOtherSizeEnablement sake-size#writeHiddenByRadio">
-                    <label calss="form-check-label" for="sake_size_check_1800">
+                    <label class="form-check-label" for="sake_size_check_1800">
                       1800
                     </label>
                   </div>
                 </div>
                 <div class="col-12">
-                  <div class="form-check d-flex ">
+                  <div class="form-check d-flex">
                     <input class="form-check-input me-2" type="radio" name="sake_size_check" id="sake_size_check_other"
                       data-sake-size-target="otherRadio" data-sake-size="other"
                       data-action="sake-size#updateOtherSizeEnablement sake-size#writeHiddenByRadio">
-                    <label calss="form-check-label w-auto" for="sake_size_check_other">
+                    <label class="form-check-label w-auto" for="sake_size_check_other">
                       <%= t(".other_size") %>
                     </label>
                     <input class="form-control ms-3 w-50" type="number" min="0" disabled id="sake_size_other"

--- a/app/views/sakes/_form_abstract.html.erb
+++ b/app/views/sakes/_form_abstract.html.erb
@@ -225,6 +225,9 @@
                       </div>
                     </div>
                     <div class="col-auto col-lg">
+                      <label class="visually-hidden" for="sake_size_other">
+                        <%= t(".other_size") %>
+                      </label>
                       <input class="form-control" type="number" min="0" disabled id="sake_size_other"
                         data-sake-size-target="otherSize" data-action="sake-size#writeHiddenWithOtherSize">
                     </div>

--- a/app/views/sakes/_form_abstract.html.erb
+++ b/app/views/sakes/_form_abstract.html.erb
@@ -226,7 +226,7 @@
                     </div>
                     <div class="col-auto col-lg">
                       <label class="visually-hidden" for="sake_size_other">
-                        <%= t(".other_size") %>
+                        <%= t(".other_size_label") %>
                       </label>
                       <input class="form-control" type="number" min="0" autocomplete="off" disabled id="sake_size_other"
                         data-sake-size-target="otherSize" data-action="sake-size#writeHiddenWithOtherSize">

--- a/app/views/sakes/_form_abstract.html.erb
+++ b/app/views/sakes/_form_abstract.html.erb
@@ -213,15 +213,21 @@
                   </div>
                 </div>
                 <div class="col-12">
-                  <div class="form-check d-flex">
-                    <input class="form-check-input me-2" type="radio" name="sake_size_check" id="sake_size_check_other"
-                      data-sake-size-target="otherRadio" data-sake-size="other"
-                      data-action="sake-size#updateOtherSizeEnablement sake-size#writeHiddenByRadio">
-                    <label class="form-check-label w-auto" for="sake_size_check_other">
-                      <%= t(".other_size") %>
-                    </label>
-                    <input class="form-control ms-3 w-50" type="number" min="0" disabled id="sake_size_other"
-                      data-sake-size-target="otherSize" data-action="sake-size#writeHiddenWithOtherSize">
+                  <div class="row align-items-center">
+                    <div class="col-auto">
+                      <div class="form-check">
+                        <input class="form-check-input me-2" type="radio" name="sake_size_check" id="sake_size_check_other"
+                          data-sake-size-target="otherRadio" data-sake-size="other"
+                          data-action="sake-size#updateOtherSizeEnablement sake-size#writeHiddenByRadio">
+                        <label class="form-check-label" for="sake_size_check_other">
+                          <%= t(".other_size") %>
+                        </label>
+                      </div>
+                    </div>
+                    <div class="col-auto col-lg">
+                      <input class="form-control" type="number" min="0" disabled id="sake_size_other"
+                        data-sake-size-target="otherSize" data-action="sake-size#writeHiddenWithOtherSize">
+                    </div>
                   </div>
                 </div>
               </div>

--- a/app/views/sakes/_show_abstract.html.erb
+++ b/app/views/sakes/_show_abstract.html.erb
@@ -89,7 +89,7 @@
     </div>
   </div>
 
-  <div class="col-12 fs-5">
+  <div class="col-12 fs-5" data-testid="sake_size_div">
     <%= sake.size %> ml
     <%= "‒ #{sake.price.to_fs(:delimited)} #{t('activerecord.attributes.sake.price_unit')}" if sake.price.present? %>
   </div>

--- a/config/locales/views/sake.ja.yml
+++ b/config/locales/views/sake.ja.yml
@@ -56,6 +56,7 @@ ja:
       badge:
         presence: 必須
       other_size: その他
+      other_size_label: その他の容量
     form_detail:
       detail: :sakes.show_detail.detail
       ingredient: :sakes.show_detail.ingredient

--- a/config/locales/views/sake.ja.yml
+++ b/config/locales/views/sake.ja.yml
@@ -55,6 +55,7 @@ ja:
       abstract: 概要
       badge:
         presence: 必須
+      other_size: その他
     form_detail:
       detail: :sakes.show_detail.detail
       ingredient: :sakes.show_detail.ingredient

--- a/spec/system/copy_sakes_spec.rb
+++ b/spec/system/copy_sakes_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe "Copy Sakes" do
 
     # nomarl case
     targets = %i[alcohol aminosando genryomai kakemai kobo name nihonshudo
-                 price roka sando season shibori size warimizu]
+                 price roka sando season shibori warimizu]
     targets.each do |key|
       describe key.to_s do
         it "has copied value" do
@@ -102,6 +102,14 @@ RSpec.describe "Copy Sakes" do
       it "has copied brewery_year" do
         by = with_japanese_era(sake.brewery_year)
         expect(page).to have_select(test_id: "sake_brewery_year", selected: by)
+      end
+    end
+
+    describe "size", :js do
+      it "has copied size" do
+        within(:test_id, "sake_size_div") do
+          expect(page).to have_checked_field("1800")
+        end
       end
     end
   end

--- a/spec/system/sake_form_size_spec.rb
+++ b/spec/system/sake_form_size_spec.rb
@@ -202,4 +202,78 @@ RSpec.describe "Sake Form Size", :js do
       end
     end
   end
+
+  describe "other size form enablement" do
+    before do
+      visit new_sake_path
+    end
+
+    context "when checked 180" do
+      before do
+        within(:test_id, "sake_size_div") do
+          # 1800と区別するため、正規表現を使う
+          find("label", text: /^180$/).click
+        end
+      end
+
+      it "is disabeld" do
+        input = find("input#sake_size_other")
+        expect(input).to be_disabled
+      end
+    end
+
+    context "when checked 300" do
+      before do
+        within(:test_id, "sake_size_div") do
+          find("label", text: "300").click
+        end
+      end
+
+      it "is disabeld" do
+        input = find("input#sake_size_other")
+        expect(input).to be_disabled
+      end
+    end
+
+    context "when checked 720" do
+      before do
+        within(:test_id, "sake_size_div") do
+          find("label", text: "720").click
+        end
+      end
+
+      it "is disabeld" do
+        input = find("input#sake_size_other")
+        expect(input).to be_disabled
+      end
+    end
+
+    context "when checked 1800" do
+      before do
+        within(:test_id, "sake_size_div") do
+          find("label", text: "1800").click
+        end
+      end
+
+      it "is disabeld" do
+        input = find("input#sake_size_other")
+        expect(input).to be_disabled
+      end
+    end
+
+    context "when checked other" do
+      before do
+        within(:test_id, "sake_size_div") do
+          # その他の容量、と区別するため正規表現を使う
+          label_regexp = /^#{I18n.t('sakes.form_abstract.other_size')}$/
+          find("label", text: label_regexp).click
+        end
+      end
+
+      it "is enabled" do
+        input = find("input#sake_size_other")
+        expect(input).not_to be_disabled
+      end
+    end
+  end
 end

--- a/spec/system/sake_form_size_spec.rb
+++ b/spec/system/sake_form_size_spec.rb
@@ -190,4 +190,16 @@ RSpec.describe "Sake Form Size", :js do
       end
     end
   end
+
+  describe "default size" do
+    before do
+      visit new_sake_path
+    end
+
+    it "is 720 ml" do
+      within(:test_id, "sake_size_div") do
+        expect(page).to have_checked_field("720")
+      end
+    end
+  end
 end

--- a/spec/system/sake_form_size_spec.rb
+++ b/spec/system/sake_form_size_spec.rb
@@ -1,0 +1,193 @@
+require "rails_helper"
+
+RSpec.describe "Sake Form Size", :js do
+  let(:user) { create(:user) }
+
+  before do
+    sign_in(user)
+  end
+
+  context "when creating new sake" do
+    before do
+      visit new_sake_path
+      fill_in("sake_name", with: "生道井")
+    end
+
+    context "with 180 ml size" do
+      before do
+        within(:test_id, "sake_size_div") do
+          # 1800と区別するため、正規表現を使う
+          find("label", text: /^180$/).click
+        end
+        click_on("form_submit")
+      end
+
+      it "creates 180 ml sake" do
+        within(:test_id, "sake_size_div") do
+          expect(page).to have_text("180 ml")
+        end
+      end
+    end
+
+    context "with 300 ml size" do
+      before do
+        within(:test_id, "sake_size_div") do
+          find("label", text: "300").click
+        end
+        click_on("form_submit")
+      end
+
+      it "creates 300 ml sake" do
+        within(:test_id, "sake_size_div") do
+          expect(page).to have_text("300 ml")
+        end
+      end
+    end
+
+    context "with 720 ml size" do
+      before do
+        within(:test_id, "sake_size_div") do
+          find("label", text: "720").click
+        end
+        click_on("form_submit")
+      end
+
+      it "creates 720 ml sake" do
+        within(:test_id, "sake_size_div") do
+          expect(page).to have_text("720 ml")
+        end
+      end
+    end
+
+    context "with 1800 ml size" do
+      before do
+        within(:test_id, "sake_size_div") do
+          find("label", text: "1800").click
+        end
+        click_on("form_submit")
+      end
+
+      it "creates 1800 ml sake" do
+        within(:test_id, "sake_size_div") do
+          expect(page).to have_text("1800 ml")
+        end
+      end
+    end
+
+    context "with 500 ml (other) size" do
+      before do
+        within(:test_id, "sake_size_div") do
+          # その他の容量、と区別するため正規表現を使う
+          label_regexp = /^#{I18n.t('sakes.form_abstract.other_size')}$/
+          find("label", text: label_regexp).click
+          fill_in("sake_size_other", with: "500")
+        end
+        click_on("form_submit")
+      end
+
+      it "creates 500 ml sake" do
+        within(:test_id, "sake_size_div") do
+          expect(page).to have_text("500 ml")
+        end
+      end
+    end
+
+    context "with 720 ml size after click and fill other" do
+      before do
+        within(:test_id, "sake_size_div") do
+          # その他の容量、と区別するため正規表現を使う
+          label_regexp = /^#{I18n.t('sakes.form_abstract.other_size')}$/
+          find("label", text: label_regexp).click
+          fill_in("sake_size_other", with: "500")
+          find("label", text: "720").click
+        end
+        click_on("form_submit")
+      end
+
+      it "creates 720 ml sake" do
+        within(:test_id, "sake_size_div") do
+          expect(page).to have_text("720 ml")
+        end
+      end
+    end
+  end
+
+  context "when editing sake" do
+    context "with 180 ml size" do
+      let(:sake) { create(:sake, size: 180) }
+
+      before do
+        visit edit_sake_path(sake.id)
+      end
+
+      it "checks 180 ml radio" do
+        within(:test_id, "sake_size_div") do
+          expect(page).to have_checked_field("180")
+        end
+      end
+    end
+
+    context "with 300 ml size" do
+      let(:sake) { create(:sake, size: 300) }
+
+      before do
+        visit edit_sake_path(sake.id)
+      end
+
+      it "checks 300 ml radio" do
+        within(:test_id, "sake_size_div") do
+          expect(page).to have_checked_field("300")
+        end
+      end
+    end
+
+    context "with 720 ml size" do
+      let(:sake) { create(:sake, size: 720) }
+
+      before do
+        visit edit_sake_path(sake.id)
+      end
+
+      it "checks 720 ml radio" do
+        within(:test_id, "sake_size_div") do
+          expect(page).to have_checked_field("720")
+        end
+      end
+    end
+
+    context "with 1800 ml size" do
+      let(:sake) { create(:sake, size: 1800) }
+
+      before do
+        visit edit_sake_path(sake.id)
+      end
+
+      it "checks 1800 ml radio" do
+        within(:test_id, "sake_size_div") do
+          expect(page).to have_checked_field("1800")
+        end
+      end
+    end
+
+    context "with 500 ml size (other)" do
+      let(:sake) { create(:sake, size: 500) }
+
+      before do
+        visit edit_sake_path(sake.id)
+      end
+
+      it "checks other radio" do
+        within(:test_id, "sake_size_div") do
+          expect(page).to have_checked_field(I18n.t("sakes.form_abstract.other_size"))
+        end
+      end
+
+      it "has 500 text" do
+        within(:test_id, "sake_size_div") do
+          input = find('input#sake_size_other[type="number"]')
+          expect(input[:value]).to eq("500")
+        end
+      end
+    end
+  end
+end

--- a/spec/system/sake_form_validation_spec.rb
+++ b/spec/system/sake_form_validation_spec.rb
@@ -112,19 +112,24 @@ RSpec.describe "Sake Form Validation" do
     end
   end
 
-  describe "size" do
+  describe "size", :js do
     context "with negative value" do
       before do
-        fill_in("sake_size", with: "-1")
+        within(:test_id, "sake_size_div") do
+          # その他の容量、と区別するため正規表現を使う
+          label_regexp = /^#{I18n.t('sakes.form_abstract.other_size')}$/
+          find("label", text: label_regexp).click
+          fill_in("sake_size_other", with: "-1")
+        end
         click_on("form_submit")
       end
 
-      it "has style for invalid" do
-        expect(find(:test_id, "sake_size").first(:xpath, "..")).to have_css(".is-invalid")
+      it "does not move page" do
+        expect(page).to have_current_path(new_sake_path)
       end
 
-      it "has error message" do
-        expect(page).to have_selector(:test_id, "sake_size_feedback")
+      it "does not have flash message" do
+        expect(page).to have_no_selector(:test_id, "flash_message")
       end
     end
   end


### PR DESCRIPTION
close #804 

酒サイズを選択性に！
そんなに数も多くないので、セレクトフォームよりもラジオインプットで実装した。

## やったこと

- 酒の内容量を自由入力欄からラジオボタンで選ぶようにした
  - ラジオボタンのみが見えている
  - 内部では隠しinputがありTSで同期している
  - 選択肢その他で自由入力欄も用意した
- テストを追加
- 既存酒サイズに関するテストを調整

## スクリーンショット（変更後）

### モバイル

![image](https://github.com/user-attachments/assets/3f393f03-169f-4340-bb6c-9d33e0b3e31f)

### PC

![image](https://github.com/user-attachments/assets/5a6a2210-2ddf-4c7c-b4b1-7794e4209bdf)

## スクリーンショット（変更前）

### モバイル

![image](https://github.com/user-attachments/assets/07f5fbbd-3a8b-4b2e-810c-31387218a1e5)

### PC

![image](https://github.com/user-attachments/assets/1c02c0b6-a3c1-416e-a8ee-0fb6c3b693c7)
