### PR TITLE
検索中のページタイトル・ヘッダーに検索情報を付加した

### DIFF
--- a/app/helpers/sakes_helper.rb
+++ b/app/helpers/sakes_helper.rb
@@ -168,21 +168,12 @@ module SakesHelper
     value.blank? || value == "unknown" ? "lowlight-value" : "highlight-value"
   end
 
-  # ヘッダタイトル用に検索ワードつきのタイトルを生成する
-  #
-  # @param search [String, nil] 検索ワード
-  # @return [String] ヘッダタイトル
-  def title_with_search(search)
-    prefix = search.present? ? "#{search} - " : ""
-    "#{prefix}#{t('sakes.index.title')}"
-  end
-
-  # 酒index用に酒の総量つきのタイトルを生成する
+  # 酒index用に酒の総量を尺貫法を使って返す
   #
   # @param include_empty [Boolean] trueなら空き瓶込みでカウントする
-  # @return [String] 酒の総量つきタイトル
-  def title_with_stock(include_empty)
-    stock = to_shakkan(Sake.alcohol_stock(include_empty:))
-    "#{t('sakes.index.title')} - #{stock}"
+  # @return [String] 尺貫法による酒の在庫量
+  def stock(include_empty)
+    ml = Sake.alcohol_stock(include_empty:)
+    to_shakkan(ml)
   end
 end

--- a/app/views/sakes/index.html.erb
+++ b/app/views/sakes/index.html.erb
@@ -1,62 +1,75 @@
 <%= render(partial: "float_button", locals: { sake: @sake }) %>
 
-<div class="row row-cols-1 g-3">
-  <div class="col">
-    <h1 class="mb-0" data-testid="total_sake">
-      <% with_search = title_with_search(params.dig(:q, :all_text_cont)) %>
-      <% with_stock = title_with_stock(include_empty?(params[:q])) %>
-      <%# ヘッダタイトルとページタイトル %>
-      <%= title(with_search, with_stock) %>
-    </h1>
-  </div>
-  <div class="col">
-    <%= search_form_for(@search, html: { data: { turbo_frame: "sakes" } }) do |f| %>
-      <div class="row mx-0 align-items-center">
-        <div class="col ps-0 input-group">
-          <%= f.label(:all_text_cont, "search word", class: "form-label visually-hidden") %>
-          <%= f.search_field(:all_text_cont,
-                             class: "form-control",
-                             value: params.dig(:q, :all_text_cont),
-                             data: { testid: "text_search" }) %>
-          <%= tag.button(tag.i(class: "bi-search"),
-                         type: "submit",
-                         class: "btn btn-primary",
-                         data: { testid: "submit_search" }) %>
-        </div>
-        <div class="col-auto">
-          <div class="form-check form-switch">
-            <%= f.check_box(:bottle_level_not_eq,
-                            { class: "form-check-input",
-                              id: "all_bottle_level",
-                              data: { testid: "check_empty_bottle" },
-                              onChange: "this.form.submit()", },
-                            Sake::BOTTOM_BOTTLE,
-                            Sake.bottle_levels["empty"]) %>
-            <%= f.label(t(".all_bottles"),
-                        class: "form-check-label",
-                        for: "all_bottle_level") %>
+<%# raise %>
+
+<%= turbo_frame_tag("sakes", target: "_top", data: { turbo_action: :advance }) do %>
+  <div class="row row-cols-1 g-3">
+    <div class="col">
+      <h1 class="mb-0" data-testid="total_sake">
+        <% searched_word = params.dig(:q, :all_text_cont) %>
+        <% if searched_word.present? then %>
+          <%# 検索中タイトル %>
+          <% header = t(".header_with_search", search: searched_word) %>
+          <% hit = @sakes.length.to_s %>
+          <% h1 = t(".h1_with_search", search: searched_word, hit:) %>
+        <% else %>
+          <%# 通常タイトル %>
+          <% header = t(".header") %>
+          <% include_empty = include_empty?(params[:q]) %>
+          <% h1 = t(".h1_with_stock", stock: stock(include_empty)) %>
+        <% end %>
+        <%= title(header, h1) %>
+      </h1>
+    </div>
+    <div class="col">
+      <%= search_form_for(@search, html: { data: { turbo_frame: "sakes" } }) do |f| %>
+        <div class="row mx-0 align-items-center">
+          <div class="col ps-0 input-group">
+            <%= f.label(:all_text_cont, "search word", class: "form-label visually-hidden") %>
+            <%= f.search_field(:all_text_cont,
+                               class: "form-control",
+                               value: params.dig(:q, :all_text_cont),
+                               data: { testid: "text_search" }) %>
+            <%= tag.button(tag.i(class: "bi-search"),
+                           type: "submit",
+                           class: "btn btn-primary",
+                           data: { testid: "submit_search" }) %>
           </div>
-        </div>
-        <div class="col-lg-4 d-none d-lg-block"></div>
-      </div>
-    <% end %>
-  </div>
-  <%= turbo_frame_tag("sakes", target: "_top", data: { turbo_action: :advance }, class: "col") do %>
-    <div class="row row-cols-1 g-3">
-      <div class="col">
-        <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-2" data-controller="simple-lightbox">
-          <%= render(partial: "sake", collection: @sakes) %>
-        </div>
-      </div>
-      <% if include_empty?(params[:q]) %>
-        <div class="col d-none d-sm-block">
-          <%= paginate(@sakes) %>
-        </div>
-        <div class="col d-sm-none d-block">
-          <%# 小さい画面 %>
-          <%= paginate(@sakes, window: 1) %>
+          <div class="col-auto">
+            <div class="form-check form-switch">
+              <%= f.check_box(:bottle_level_not_eq,
+                              { class: "form-check-input",
+                                id: "all_bottle_level",
+                                data: { testid: "check_empty_bottle" },
+                                onChange: "this.form.submit()", },
+                              Sake::BOTTOM_BOTTLE,
+                              Sake.bottle_levels["empty"]) %>
+              <%= f.label(t(".all_bottles"),
+                          class: "form-check-label",
+                          for: "all_bottle_level") %>
+            </div>
+          </div>
+          <div class="col-lg-4 d-none d-lg-block"></div>
         </div>
       <% end %>
     </div>
-  <% end %>
-</div>
+    <div class="col">
+      <div class="row row-cols-1 g-3">
+        <div class="col">
+          <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-2" data-controller="simple-lightbox">
+            <%= render(partial: "sake", collection: @sakes) %>
+          </div>
+        </div>
+        <% if include_empty?(params[:q]) %>
+          <div class="col d-none d-sm-block">
+            <%= paginate(@sakes) %>
+          </div>
+          <div class="col d-sm-none d-block">
+            <%# 小さい画面 %>
+            <%= paginate(@sakes, window: 1) %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/config/locales/views/sake.ja.yml
+++ b/config/locales/views/sake.ja.yml
@@ -1,7 +1,10 @@
 ja:
   sakes:
     index:
-      title: 日本酒リスト
+      header: 日本酒リスト
+      header_with_search: "検索: %{search}"
+      h1_with_stock: "日本酒リスト - %{stock}"
+      h1_with_search: "検索: %{search} - %{hit}件"
       all_bottles: 空瓶を表示
     sake:
       edit: 編集

--- a/spec/helpers/sakes_helper_spec.rb
+++ b/spec/helpers/sakes_helper_spec.rb
@@ -149,39 +149,20 @@ RSpec.describe SakesHelper do
     end
   end
 
-  describe "title_with_search" do
-    context "without search word" do
-      it "returns only title" do
-        title = I18n.t("sakes.index.title")
-        expect(title_with_search(nil)).to eq(title)
+  describe "stock" do
+    let!(:sealed_sake) { create(:sake, size: 720, bottle_level: "sealed") }
+    let!(:empty_sake) { create(:sake, size: 1800, bottle_level: "empty") }
+
+    context "without empty bottle" do
+      it "returns 4合" do
+        expect(stock(false)).to eq("4合")
       end
     end
 
-    context "with search word" do
-      it "returns title with search word" do
-        searched = "生道井"
-        title = "生道井 - #{I18n.t('sakes.index.title')}"
-        expect(title_with_search(searched)).to eq(title)
+    context "with empty bottle" do
+      it "returns 1升4合" do
+        expect(stock(true)).to eq("1升4合")
       end
-    end
-  end
-
-  describe "title_with_stock" do
-    before do
-      create(:sake, size: 720, bottle_level: "sealed")
-      create(:sake, size: 1800, bottle_level: "empty")
-    end
-
-    it "returns title with 4合" do
-      include_empty = false
-      title = "#{I18n.t('.sakes.index.title')} - 4合"
-      expect(title_with_stock(include_empty)).to eq(title)
-    end
-
-    it "returns title with 1升4合" do
-      include_empty = true
-      title = "#{I18n.t('.sakes.index.title')} - 1升4合"
-      expect(title_with_stock(include_empty)).to eq(title)
     end
   end
 end

--- a/spec/helpers/sakes_helper_spec.rb
+++ b/spec/helpers/sakes_helper_spec.rb
@@ -150,8 +150,10 @@ RSpec.describe SakesHelper do
   end
 
   describe "stock" do
-    let!(:sealed_sake) { create(:sake, size: 720, bottle_level: "sealed") }
-    let!(:empty_sake) { create(:sake, size: 1800, bottle_level: "empty") }
+    before do
+      create(:sake, size: 720, bottle_level: "sealed")
+      create(:sake, size: 1800, bottle_level: "empty")
+    end
 
     context "without empty bottle" do
       it "returns 4合" do

--- a/spec/views/sakes/index.html.erb_spec.rb
+++ b/spec/views/sakes/index.html.erb_spec.rb
@@ -29,41 +29,71 @@ RSpec.describe "sakes/index", type: :system do
   end
 
   describe "title" do
-    it "has title with total amount of sake" do
-      title = "#{I18n.t('sakes.index.title')} - 4合"
-      expect(page).to have_text(title)
+    context "without search" do
+      it "contains total amount of sake" do
+        h1 = I18n.t("sakes.index.h1_with_stock", stock: "4合")
+        expect(page).to have_text(h1)
+      end
+    end
+
+    context "with search" do
+      search = "ヒットしない検索語句"
+
+      before do
+        fill_in("text_search", with: search)
+        click_on("submit_search")
+      end
+
+      it "contains search word and hit count" do
+        h1 = I18n.t("sakes.index.h1_with_search", search:, hit: "0")
+        expect(page).to have_text(h1)
+      end
+    end
+
+    context "with empty search" do
+      before do
+        fill_in("text_search", with: "")
+        click_on("submit_search")
+      end
+
+      it "contains total amount of sake" do
+        h1 = I18n.t("sakes.index.h1_with_stock", stock: "4合")
+        expect(page).to have_text(h1)
+      end
     end
   end
 
   describe "title meta tag" do
-    context "when not searching" do
+    context "without search" do
       it "has title" do
-        title = "#{I18n.t('sakes.index.title')} - SAKAZUKI"
-        expect(page).to have_title(title)
+        header = "#{I18n.t('sakes.index.header')} - SAKAZUKI"
+        expect(page).to have_title(header)
       end
     end
 
-    context "when searching with some word" do
+    context "with search" do
+      search = "検索中の酒"
+
       before do
-        fill_in("text_search", with: "検索中の酒")
+        fill_in("text_search", with: search)
         click_on("submit_search")
       end
 
       it "has title with searching words" do
-        title = "検索中の酒 - #{I18n.t('sakes.index.title')} - SAKAZUKI"
-        expect(page).to have_title(title)
+        header = "#{I18n.t('sakes.index.header_with_search', search:)} - SAKAZUKI"
+        expect(page).to have_title(header)
       end
     end
 
-    context "when searching with empty word" do
+    context "with empty search" do
       before do
         fill_in("text_search", with: "")
         click_on("submit_search")
       end
 
       it "does not have title with searching words separator" do
-        title = "- #{I18n.t('sakes.index.title')} - SAKAZUKI"
-        expect(page).to have_no_title(title)
+        header = "- #{I18n.t('sakes.index.header')} - SAKAZUKI"
+        expect(page).to have_no_title(header)
       end
     end
   end


### PR DESCRIPTION
close #766 

## やったこと

- 酒indexで検索時のページタイトルとヘッダに検索情報を付加
- TurboFrameの範囲を拡大
  - 上記検索情報があるページタイトルもTurboFrameに含めるようにした
- テストを追加・更新

## 変更後スクリーンショット

![image](https://github.com/user-attachments/assets/6267455c-e2c9-422c-b408-32a4c4107ad7)

## 変更前スクリーンショット

![image](https://github.com/user-attachments/assets/4134fd6a-5a17-4f8d-9727-856c830f5df1)
