### PR TITLE
docker compose buildの失敗するのを修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ See the [deployment](https://github.com/momocus/sakazuki/wiki/Deployment).
 - Docker イメージのビルド
 
 ```console
-$ docker compose build --build-arg RUBY_VERSION=$(cat .ruby-version)
+$ docker compose build
 ...
 ```
 

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -3,7 +3,7 @@ ARG RUBY_VERSION
 
 FROM ruby:${RUBY_VERSION}-slim-bullseye
 
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]
 
 # Install build tools, posgresql-client, yarn and node
 RUN <<EOF

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -25,7 +25,7 @@ RUN <<EOF
 
   apt-get update -q
   DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
-    nodejs=18.* postgresql-client-13=13.* libpq-dev=16.* yarn=1.22.* \
+    nodejs=18.* postgresql-client-13=13.* libpq-dev=17.* yarn=1.22.* \
     imagemagick=8:6.9.*
 
   apt-get clean

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -56,8 +56,7 @@ RUN mkdir tmp/ log/
 COPY Gemfile Gemfile.lock .ruby-version ./
 RUN <<EOF
   gem update --system
-  gem install bundler:2.5.16
-  gem install foreman:0.88.1
+  gem install bundler:2.5.16 foreman:0.88.1
   bundle install
   rm -rf /usr/local/bundle/cache/*gem \
     /root/.bundle/cache/* /usr/local/lib/ruby/gems/*/cache/*

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -5,29 +5,41 @@ FROM ruby:${RUBY_VERSION}-slim-bullseye
 
 SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]
 
-# Install build tools, posgresql-client, yarn and node
+# Install build tools
+# hadolint ignore=DL3009
 RUN <<EOF
   apt-get update -q
   apt-get upgrade -y
   DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
-    curl=7.74.* build-essential=12.9 gnupg2=2.2.*
+    curl=7.74.* build-essential=12.9 gnupg2=2.2.* imagemagick=8:6.9.*
+EOF
 
+# Install posgresql-client
+# hadolint ignore=DL3009
+RUN <<EOF
   curl -sSL https://www.postgresql.org/media/keys/ACCC4CF8.asc -o /usr/share/keyrings/pgdg.asc
   echo "deb [signed-by=/usr/share/keyrings/pgdg.asc] http://apt.postgresql.org/pub/repos/apt bullseye-pgdg main" \
     > /etc/apt/sources.list.d/pgdg.list
+  apt-get update -q
+  DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends postgresql-client-13=13.* libpq-dev=17.*
+EOF
 
+# Install yarn
+# hadolint ignore=DL3009
+RUN <<EOF
   curl -sSL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor \
     > /usr/share/keyrings/yarnkey.gpg
   echo "deb [signed-by=/usr/share/keyrings/yarnkey.gpg] https://dl.yarnpkg.com/debian stable main" \
     > /etc/apt/sources.list.d/yarn.list
-
-  curl -sSL https://deb.nodesource.com/setup_18.x | bash -
-
   apt-get update -q
-  DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
-    nodejs=18.* postgresql-client-13=13.* libpq-dev=17.* yarn=1.22.* \
-    imagemagick=8:6.9.*
+  DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends yarn=1.22.*
+EOF
 
+# Install node
+RUN <<EOF
+  curl -sSL https://deb.nodesource.com/setup_18.x | bash -
+  apt-get update -q
+  DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends nodejs=18.*
   apt-get clean
   rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/* /tmp/* /var/tmp/*
   truncate -s 0 /var/log/**/*log

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker/dockerfile:1
-ARG RUBY_VERSION
+# default値での動作は保証されない
+ARG RUBY_VERSION=3
 
 FROM ruby:${RUBY_VERSION}-slim-bullseye
 

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.4
+# syntax=docker/dockerfile:1
 ARG RUBY_VERSION
 
 FROM ruby:${RUBY_VERSION}-slim-bullseye

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       context: .
       dockerfile: dev.Dockerfile
       args:
-        - RUBY_VERSION
+        - "${RUBY_VERSION:-$(< .ruby-version)}"
     command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
     ports:
       - "3000:3000"

--- a/fly.Dockerfile
+++ b/fly.Dockerfile
@@ -21,7 +21,7 @@ ARG RUBY_VERSION
 ARG VARIANT=jemalloc-bullseye-slim
 FROM quay.io/evl.ms/fullstaq-ruby:${RUBY_VERSION}-${VARIANT} AS base
 
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]
 
 # hadolint ignore=DL3048
 LABEL fly_launch_runtime="rails"

--- a/fly.Dockerfile
+++ b/fly.Dockerfile
@@ -17,8 +17,10 @@
 # We recommend using the highest patch level for better security and
 # performance.
 
-ARG RUBY_VERSION
+# GitHub Actionsで.ruby_versionが参照されるため、3.3が呼び出されることはない
+ARG RUBY_VERSION=3.3
 ARG VARIANT=jemalloc-bullseye-slim
+
 FROM quay.io/evl.ms/fullstaq-ruby:${RUBY_VERSION}-${VARIANT} AS base
 
 SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]


### PR DESCRIPTION
fix #821

## やったこと

- dev.Dockerfileで使うlibpq-devのバージョンを正しく指定した
- DockerfileのSHELLオプションに-eを追加し、heredoc内スクリプト失敗時にエラー停止するようにした
- dev.Dockerfileのsyntaxバージョン指定を1.4 -> 1に変更
  - 昔はheredocを使うために1.4指定が必要だったが、今は必要ない
- dev.Dockerfileにおけるpostgresql/yarn/nodeのインストールを分割した
  - 今まではインストールエラー時にどのインストールでエラーしたかわからなかった
  - どれがエラーしたかわかりやすい！
- dev.Dockerfileにおけるgem installの2行を1行にまとめた
- docker build checkの修正に伴い、docker compose buildをオプションなしで動くようにした