### PR TITLE
Feature/rails7.2/update ci

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Run Stylelint
         run: yarn run lint:stylelint
       - name: Run Markuplint
-        run: yarn run lint:markuplint
+        run: yarn run lint:markuplint --format GitHub
 
       # lint by rubocop
       - name: Set up Ruby
@@ -38,9 +38,9 @@ jobs:
         with:
           bundler-cache: true
       - name: Run Rubocop
-        run: bundle exec rubocop
+        run: bundle exec rubocop --format github
       - name: Run Rubocop ERB
-        run: bundle exec rubocop --config .rubocop-erb.yml
+        run: bundle exec rubocop --format github --config .rubocop-erb.yml
       - name: Run ERB Lint
         run: bundle exec erblint --lint-all
       - name: Run Brakeman

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,9 @@ jobs:
           RAILS_ENV: test
           POSTGRES_USERNAME: postgres
           POSTGRES_PASSWORD: password
-        run: bundle exec rails db:create
+        run: |
+          bundle exec rails db:create
+          bundle exec rails db:migrate
       - name: Assets precompile
         env:
           BUNDLE_WITHOUT: development

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,5 +58,14 @@ jobs:
           POSTGRES_USERNAME: postgres
           POSTGRES_PASSWORD: password
         run: bundle exec rspec
+
       - name: Upload code coverage
         uses: codecov/codecov-action@v4
+
+      - name: Keep screenshots from failed system tests
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: screenshots
+          path: ${{ github.workspace }}/tmp/screenshots
+          if-no-files-found: ignore


### PR DESCRIPTION
**featureブランチへのマージ**

これで最後！

## やったこと

- CI結果のフォーマットにgithubを指定した
  - 最近のツールのフォーマットはjsonやHTMLのようなファイル形式だけでなく、GitHub向けの専用フォーマットがある
- テスト前にdb:migrateをしていないのを修正
  - 必要な気がする。今まで動いてたのはなぜ？
- GitHub Actionsでテスト失敗時にスクリーンショットを保存する
  - テスト落ちた時にどの画面で何が表示されてたか見れる、便利。