### PR TITLE
Add build date and commit number to footer

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -10,5 +10,8 @@
     <div class="my-1">
       <%= sanitize(t(".credit"), tags: %w[a img]) %>
     </div>
+    <div class="my-1">
+      Build Date: <%= ENV['BUILD_DATE'] %> | Commit: <%= ENV['COMMIT'] %>
+    </div>
   </div>
 </footer>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -82,5 +82,9 @@ Rails.application.configure do
 
   # DockerでBetterErrorsを動かすための設定
   BetterErrors::Middleware.allow_ip!("0.0.0.0/0")
+
+  # Set environment variables for build date and commit
+  ENV['BUILD_DATE'] = Time.now.to_s
+  ENV['COMMIT'] = `git rev-parse HEAD`.chomp
 end
 # rubocop:enable Metrics/BlockLength

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -104,4 +104,8 @@ Rails.application.configure do
   # ]
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+
+  # Set environment variables for build date and commit
+  ENV['BUILD_DATE'] = Time.now.to_s
+  ENV['COMMIT'] = `git rev-parse HEAD`.chomp
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -64,4 +64,8 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions.
   config.action_controller.raise_on_missing_callback_actions = true
+
+  # Set environment variables for build date and commit
+  ENV['BUILD_DATE'] = Time.now.to_s
+  ENV['COMMIT'] = `git rev-parse HEAD`.chomp
 end


### PR DESCRIPTION
Fixes #757

fotterにビルド番号を記入する

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/momocus/sakazuki/pull/853?shareId=7616fd5b-682e-4659-942b-d3792638c3a1).