### PR TITLE
サードパーティー製Actionsをタグ指定からSHA指定にした

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -8,6 +8,6 @@ jobs:
   add-reviews:
     runs-on: ubuntu-latest
     steps:
-      - uses: kentaro-m/auto-assign-action@v2.0.0
+      - uses: kentaro-m/auto-assign-action@f4648c0a9fdb753479e9e75fc251f507ce17bb7e
         with:
           configuration-path: ".github/auto_assign_configs.yml"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -34,7 +34,7 @@ jobs:
 
       # lint by rubocop
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@922ebc4c5262cd14e07bb0e1db020984b6c064fe
         with:
           bundler-cache: true
       - name: Run Rubocop
@@ -48,11 +48,11 @@ jobs:
 
       # lint by hadolint
       - name: Run Hadolint for dev.Dockerfile
-        uses: hadolint/hadolint-action@v3.1.0
+        uses: hadolint/hadolint-action@54c9adbab1582c2ef04b2016b760714a4bfde3cf
         with:
           dockerfile: dev.Dockerfile
       - name: Run Hadolint for fly.Dockerfile
-        uses: hadolint/hadolint-action@v3.1.0
+        uses: hadolint/hadolint-action@54c9adbab1582c2ef04b2016b760714a4bfde3cf
         with:
           dockerfile: fly.Dockerfile
 

--- a/.github/workflows/esbuild-bundle-analyzer.yml
+++ b/.github/workflows/esbuild-bundle-analyzer.yml
@@ -33,6 +33,6 @@ jobs:
       # Call this action after the build
       - name: Analyze esbuild bundle size
         # uses: exoego/esbuild-bundle-analyzer@main # If you prefer nightly!
-        uses: exoego/esbuild-bundle-analyzer@v1
+        uses: exoego/esbuild-bundle-analyzer@57891f264e6d0536d890e99267cb88890f4b67d7
         with:
           metafiles: "meta.json"

--- a/.github/workflows/fix-command.yml
+++ b/.github/workflows/fix-command.yml
@@ -18,7 +18,7 @@ jobs:
         run: yarn install --immutable
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@922ebc4c5262cd14e07bb0e1db020984b6c064fe
         with:
           bundler-cache: true
 

--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Detect ruby version
         id: ruby-version
         run: echo "::set-output name=RUBY_VERSION::$(cat .ruby-version)"
-      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - uses: superfly/flyctl-actions/setup-flyctl@63da3ecc5e2793b98a3f2519b3d75d4f4c11cec2
       - run: flyctl deploy --remote-only --dockerfile fly.Dockerfile --build-arg RUBY_VERSION=${{ steps.ruby-version.outputs.RUBY_VERSION }}
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Slash Command Dispatch
-        uses: peter-evans/slash-command-dispatch@v4
+        uses: peter-evans/slash-command-dispatch@13bc09769d122a64f75aa5037256f6f2d78be8c4
         with:
           token: ${{ secrets.PAT }}
           commands: fix

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Ruby
         env:
           BUNDLE_WITHOUT: development
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@922ebc4c5262cd14e07bb0e1db020984b6c064fe
         with:
           bundler-cache: true
       - name: Setup Database
@@ -60,7 +60,7 @@ jobs:
         run: bundle exec rspec
 
       - name: Upload code coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238
 
       - name: Keep screenshots from failed system tests
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
close #927 

## やったこと

- サードパーティー製ActionsをSHA指定にした
- DependaBotのアップデート対象にActionsを追加

## やってないこと・わからないこと

- たつのさんが言ってた、SHAをDependaBotがアップデートできるか、SHAとタグバージョンの関係を表示してくれるか、不明
  - 運用しながら見ていこう