### PR TITLE
Codecovをv5にアップデート

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,9 @@ jobs:
         run: bundle exec rspec
 
       - name: Upload code coverage
-        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238
+        uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Keep screenshots from failed system tests
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
after #928

**オーナーによるレポジトリ設定の変更が必要！！**

## やったこと

- Codecovをv5にアップデート

## 背景

- GitHubの仕様変更？によりTOKENが必要に
- v4はトークン無しは不可になった。
- v5はトークン無しでも手段はある
  - トークンありの場合
    - Usageにあるように、Actionsで指定する
      - https://github.com/codecov/codecov-action?tab=readme-ov-file#usage
    - レポジトリ設定でトークンを設定する
      - https://docs.codecov.com/docs/codecov-tokens#example-github-actions--official-codecov-action
  - トークンなしの場合
    - 組織のトークン認証をオフにしているとできるらしい
      - https://docs.codecov.com/docs/codecov-tokens#uploading-without-a-token
    - SAKAZUKIでも設定できるかわからない
      - 組織ってあったっけ？
      - オーナーしか見れないレポジトリ設定らしい
    - 認証オフってセキュリティ的によくない設定？

## オーナーの必要な作業

**トークンありの設定をお願いします🙇**

- レポジトリの設定で、Codecov用のActions secretsの登録が必要
  - やり方
  - https://docs.codecov.com/docs/codecov-tokens#example-github-actions--official-codecov-action
