### PR TITLE
🔍Actions用のLinter3種類を追加

### DIFF
--- a/.ghalint.yaml
+++ b/.ghalint.yaml
@@ -1,0 +1,10 @@
+excludes:
+  # GitHub管理のactionsは信頼する
+  - policy_name: action_ref_should_be_full_length_commit_sha
+    action_name: actions/checkout
+  - policy_name: action_ref_should_be_full_length_commit_sha
+    action_name: actions/setup-node
+  - policy_name: action_ref_should_be_full_length_commit_sha
+    action_name: actions/upload-artifact
+  - policy_name: action_ref_should_be_full_length_commit_sha
+    action_name: github/codeql-action/*

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   add-reviews:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
     steps:
       - uses: kentaro-m/auto-assign-action@f4648c0a9fdb753479e9e75fc251f507ce17bb7e
         with:

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -4,11 +4,12 @@ on:
   pull_request:
     types: [opened, ready_for_review]
 
+permissions: {}
+
 jobs:
   add-reviews:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    permissions: {}
     steps:
       - uses: kentaro-m/auto-assign-action@f4648c0a9fdb753479e9e75fc251f507ce17bb7e
         with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,11 +2,12 @@ name: Check
 
 on: [pull_request]
 
+permissions: {}
+
 jobs:
   check:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    permissions: {}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -71,3 +71,9 @@ jobs:
       # lint by actionlint
       - name: Run Actionlint
         uses: raven-actions/actionlint@01fce4f43a270a612932cb1c64d40505a029f821
+
+      # lint by ghalint
+      - name: Install ghalint
+        uses: Lucky3028/install-ghalint@b623e2c9f9238b88ba13dbf30fb3b65320c42ce9
+      - name: Run ghalint
+        run: ghalint run

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -81,3 +81,9 @@ jobs:
         uses: Lucky3028/install-ghalint@b623e2c9f9238b88ba13dbf30fb3b65320c42ce9
       - name: Run ghalint
         run: ghalint run
+
+      # lint by zizmor
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@22695119d769bdb6f7032ad67b9bca0ef8c4a174
+      - name: Run zizmor 🌈
+        run: uvx zizmor --offline --collect=default .

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -67,3 +67,7 @@ jobs:
         run: >-
           docker build --build-arg RUBY_VERSION="$(cat .ruby-version)"
           --check --file fly.Dockerfile .
+
+      # lint by actionlint
+      - name: Run Actionlint
+        uses: raven-actions/actionlint@01fce4f43a270a612932cb1c64d40505a029f821

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -87,4 +87,4 @@ jobs:
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@22695119d769bdb6f7032ad67b9bca0ef8c4a174
       - name: Run zizmor 🌈
-        run: uvx zizmor --offline --persona pedantic --collect default .
+        run: uvx zizmor --offline --persona auditor --collect default .

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -86,4 +86,4 @@ jobs:
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@22695119d769bdb6f7032ad67b9bca0ef8c4a174
       - name: Run zizmor 🌈
-        run: uvx zizmor --offline --collect=default .
+        run: uvx zizmor --offline --persona pedantic --collect default .

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,8 +5,12 @@ on: [pull_request]
 jobs:
   check:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       # lint by sh scripts
       - name: End of File with Newline

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,6 +18,7 @@ on:
 jobs:
   CodeQL:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     permissions:
       # required for all workflows
@@ -26,6 +27,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,6 +15,8 @@ on:
     #        *  * * * *
     - cron: "15 3 * * 6"
 
+permissions: {}
+
 jobs:
   CodeQL:
     runs-on: ubuntu-latest

--- a/.github/workflows/esbuild-bundle-analyzer.yml
+++ b/.github/workflows/esbuild-bundle-analyzer.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request_target:
 
+permissions: {}
+
 jobs:
   # PLEASE AVOID ADDING OTHER JOBS IN THIS FILE
   # BECAUSE THIS ACTION USE `pull_request_target` EVENT that grants write

--- a/.github/workflows/esbuild-bundle-analyzer.yml
+++ b/.github/workflows/esbuild-bundle-analyzer.yml
@@ -19,6 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           # This is required to fetch the commit SHA of the forked PR
           ref: "${{ github.event.pull_request.merge_commit_sha }}"
       - uses: actions/setup-node@v4

--- a/.github/workflows/fix-command.yml
+++ b/.github/workflows/fix-command.yml
@@ -5,9 +5,12 @@ on:
 jobs:
   fix:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
     steps:
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           ref: ${{ github.event.client_payload.pull_request.head.ref }}
 
       - uses: actions/setup-node@v4

--- a/.github/workflows/fix-command.yml
+++ b/.github/workflows/fix-command.yml
@@ -2,11 +2,13 @@ name: Fix Command
 on:
   repository_dispatch:
     types: [fix-command]
+
+permissions: {}
+
 jobs:
   fix:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    permissions: {}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -19,6 +19,7 @@ jobs:
         id: ruby-version
         run: echo "RUBY_VERSION=$(cat .ruby-version)" >> "$GITHUB_OUTPUT"
       - uses: superfly/flyctl-actions/setup-flyctl@63da3ecc5e2793b98a3f2519b3d75d4f4c11cec2
-      - run: flyctl deploy --remote-only --dockerfile fly.Dockerfile --build-arg RUBY_VERSION=${{ steps.ruby-version.outputs.RUBY_VERSION }}
+      - run: flyctl deploy --remote-only --dockerfile fly.Dockerfile --build-arg RUBY_VERSION="${RUBY_VERSION}"
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          RUBY_VERSION: ${{ steps.ruby-version.outputs.RUBY_VERSION }}

--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -7,13 +7,17 @@ jobs:
   deploy:
     name: Deploy app
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
     concurrency:
       group: fly-deploy
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Detect ruby version
         id: ruby-version
-        run: echo "::set-output name=RUBY_VERSION::$(cat .ruby-version)"
+        run: echo "RUBY_VERSION=$(cat .ruby-version)" >> "$GITHUB_OUTPUT"
       - uses: superfly/flyctl-actions/setup-flyctl@63da3ecc5e2793b98a3f2519b3d75d4f4c11cec2
       - run: flyctl deploy --remote-only --dockerfile fly.Dockerfile --build-arg RUBY_VERSION=${{ steps.ruby-version.outputs.RUBY_VERSION }}
         env:

--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -3,12 +3,14 @@ on:
   push:
     branches:
       - main
+
+permissions: {}
+
 jobs:
   deploy:
     name: Deploy app
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    permissions: {}
     concurrency:
       group: fly-deploy
     steps:

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -2,11 +2,13 @@ name: Slash Command Dispatch
 on:
   issue_comment:
     types: [created]
+
+permissions: {}
+
 jobs:
   slashCommandDispatch:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    permissions: {}
     steps:
       - name: Slash Command Dispatch
         uses: peter-evans/slash-command-dispatch@13bc09769d122a64f75aa5037256f6f2d78be8c4

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -5,6 +5,8 @@ on:
 jobs:
   slashCommandDispatch:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
     steps:
       - name: Slash Command Dispatch
         uses: peter-evans/slash-command-dispatch@13bc09769d122a64f75aa5037256f6f2d78be8c4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,12 +2,12 @@ name: Test
 
 on: [pull_request]
 
+permissions: {}
+
 jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    permissions: {}
-
     services:
       postgres:
         image: postgres:13

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,8 @@ on: [pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
 
     services:
       postgres:
@@ -22,6 +24,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Install libvips
         run: |
           sudo apt-get update

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,6 @@
+rules:
+  dangerous-triggers:
+    ignore:
+      # ignore line 3 in esbuild-bundle-analyzer.yml
+      # bundleサイズをコメントするためトリガーを変えられないので無視
+      - esbuild-bundle-analyzer.yml:3

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -4,3 +4,15 @@ rules:
       # ignore line 3 in esbuild-bundle-analyzer.yml
       # bundleサイズをコメントするためトリガーを変えられないので無視
       - esbuild-bundle-analyzer.yml:3
+  unpinned-uses:
+    ignore:
+      # バージョンのピン付けはghalintで検出している
+      # ghalintのほうがGitHub管理だけ許可などできるので、こちらは全ファイルで無視する。
+      - auto-assign.yml
+      - check.yml
+      - codeql.yml
+      - esbuild-bundle-analyzer.yml
+      - fix-command.yml
+      - fly.yml
+      - slash-command-dispatch.yml
+      - test.yml

--- a/cli-scripts/run-all-checks.sh
+++ b/cli-scripts/run-all-checks.sh
@@ -94,3 +94,10 @@ elif type docker > /dev/null 2>&1; then
 else
     warning "[SKIP] Actionlint, actionlint or Docker is required."
 fi
+
+message "##### Run ghalint"
+if type ghalint > /dev/null 2>&1; then
+    ghalint run
+else
+    warning "[SKIP] ghalint, ghalint is required."
+fi

--- a/cli-scripts/run-all-checks.sh
+++ b/cli-scripts/run-all-checks.sh
@@ -3,7 +3,7 @@
 # https://qiita.com/youcune/items/fcfb4ad3d7c1edf9dc96
 # -euでエラーか未定義変数でストップする
 
-cd $(cd $(dirname $0); pwd)/../ # cd to project root
+cd "$(cd "$(dirname "$0")"; pwd)/../" # cd to project root
 
 NORMAL=$(tput sgr0)
 YELLOW=$(tput setaf 3)
@@ -90,7 +90,7 @@ message "##### Run Actionlint"
 if type actionlint > /dev/null 2>&1; then
     actionlint
 elif type docker > /dev/null 2>&1; then
-    docker run --rm --mount type=bind,src=$(pwd),dst=/repo,readonly --workdir /repo rhysd/actionlint:latest -color
+    docker run --rm --mount type=bind,src="$(pwd)",dst=/repo,readonly --workdir /repo rhysd/actionlint:latest -color
 else
     warning "[SKIP] Actionlint, actionlint or Docker is required."
 fi

--- a/cli-scripts/run-all-checks.sh
+++ b/cli-scripts/run-all-checks.sh
@@ -108,13 +108,13 @@ fi
 
 message "##### Run zizmor"
 if type zizmor > /dev/null 2>&1; then
-    zizmor --offline --collect=default .
+    zizmor --offline --persona pedantic --collect default .
 elif type docker > /dev/null 2>&1; then
     docker run --rm --tty \
            --mount type=bind,src="$(pwd)",dst=/repo,readonly \
            --workdir /repo \
            ghcr.io/woodruffw/zizmor:latest \
-           --offline --collect=default .
+           --offline --persona pedantic --collect default .
 else
     warning "[SKIP] zizmor, zizmor or Docker is required."
 fi

--- a/cli-scripts/run-all-checks.sh
+++ b/cli-scripts/run-all-checks.sh
@@ -1,4 +1,7 @@
-#!/bin/bash
+#!/bin/bash -eu
+
+# https://qiita.com/youcune/items/fcfb4ad3d7c1edf9dc96
+# -euでエラーか未定義変数でストップする
 
 cd $(cd $(dirname $0); pwd)/../ # cd to project root
 

--- a/cli-scripts/run-all-checks.sh
+++ b/cli-scripts/run-all-checks.sh
@@ -83,3 +83,14 @@ if type docker > /dev/null 2>&1; then
 else
     warning "[SKIP] Docker Build Checks, Docker is required."
 fi
+
+# GitHub Actions
+
+message "##### Run Actionlint"
+if type actionlint > /dev/null 2>&1; then
+    actionlint
+elif type docker > /dev/null 2>&1; then
+    docker run --rm --mount type=bind,src=$(pwd),dst=/repo,readonly --workdir /repo rhysd/actionlint:latest -color
+else
+    warning "[SKIP] Actionlint, actionlint or Docker is required."
+fi

--- a/cli-scripts/run-all-checks.sh
+++ b/cli-scripts/run-all-checks.sh
@@ -90,7 +90,11 @@ message "##### Run Actionlint"
 if type actionlint > /dev/null 2>&1; then
     actionlint
 elif type docker > /dev/null 2>&1; then
-    docker run --rm --mount type=bind,src="$(pwd)",dst=/repo,readonly --workdir /repo rhysd/actionlint:latest -color
+    docker run --rm \
+           --mount type=bind,src="$(pwd)",dst=/repo,readonly \
+           --workdir /repo \
+           rhysd/actionlint:latest \
+           -color
 else
     warning "[SKIP] Actionlint, actionlint or Docker is required."
 fi
@@ -100,4 +104,17 @@ if type ghalint > /dev/null 2>&1; then
     ghalint run
 else
     warning "[SKIP] ghalint, ghalint is required."
+fi
+
+message "##### Run zizmor"
+if type zizmor > /dev/null 2>&1; then
+    zizmor --offline --collect=default .
+elif type docker > /dev/null 2>&1; then
+    docker run --rm --tty \
+           --mount type=bind,src="$(pwd)",dst=/repo,readonly \
+           --workdir /repo \
+           ghcr.io/woodruffw/zizmor:latest \
+           --offline --collect=default .
+else
+    warning "[SKIP] zizmor, zizmor or Docker is required."
 fi

--- a/cli-scripts/run-all-checks.sh
+++ b/cli-scripts/run-all-checks.sh
@@ -108,13 +108,13 @@ fi
 
 message "##### Run zizmor"
 if type zizmor > /dev/null 2>&1; then
-    zizmor --offline --persona pedantic --collect default .
+    zizmor --offline --persona auditor --collect default .
 elif type docker > /dev/null 2>&1; then
     docker run --rm --tty \
            --mount type=bind,src="$(pwd)",dst=/repo,readonly \
            --workdir /repo \
            ghcr.io/woodruffw/zizmor:latest \
-           --offline --persona pedantic --collect default .
+           --offline --persona auditor --collect default .
 else
     warning "[SKIP] zizmor, zizmor or Docker is required."
 fi


### PR DESCRIPTION
close #943

GitHub Actionsが攻撃を受けたし、Lintも入れておこう。

## やったこと

- Actionlintを追加
- ghalintを追加
  - GitHub管理のActionsは信頼してSHAピンではなくv4のようなピンでOKにした
- zizmorを追加
  - ピン留め設定がないため、ピンチェックはオフ
  - esbuild-bundle-analyzerの`on`イベントの`pull_request_target`は変えれなさそうなので、ここだけ一部ルールを無視
- それぞれ、
  - CLIスクリプト
  - GitHub Actions
- 新たなLinterに従い修正
