### PR TITLE
Flyの設定ファイルを新しく設定しなおした

### DIFF
--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -15,6 +15,6 @@ jobs:
         id: ruby-version
         run: echo "::set-output name=RUBY_VERSION::$(cat .ruby-version)"
       - uses: superfly/flyctl-actions/setup-flyctl@63da3ecc5e2793b98a3f2519b3d75d4f4c11cec2
-      - run: flyctl deploy --remote-only --dockerfile fly.Dockerfile --build-arg RUBY_VERSION=${{ steps.ruby-version.outputs.RUBY_VERSION }}
+      - run: flyctl deploy --build-arg RUBY_VERSION=${{ steps.ruby-version.outputs.RUBY_VERSION }}
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,9 @@ Rails.application.routes.draw do
     get :menu, on: :collection
   end
 
+  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
+  # Can be used by load balancers and uptime monitors to verify that the app is live.
+  get "up", to: "rails/health#show", as: :rails_health_check
+
   mount LetterOpenerWeb::Engine, at: "/letter_opener" unless Rails.env.production?
 end

--- a/fly.toml
+++ b/fly.toml
@@ -24,8 +24,8 @@ swap_size_mb = 512
 
 [[http_service.checks]]
   grace_period = "10s"
-  interval = "15s"
-  timeout = "2s"
+  interval = "30s"
+  timeout = "5s"
   method = "GET"
   path = "/up"
   protocol = "http"

--- a/fly.toml
+++ b/fly.toml
@@ -5,7 +5,7 @@
 
 app = "sakazuki"
 primary_region = "nrt"
-console_command = "/rails/bin/rails console"
+console_command = "/app/bin/rails console"
 swap_size_mb = 512
 
 [build]

--- a/fly.toml
+++ b/fly.toml
@@ -1,52 +1,41 @@
-# fly.toml file generated for sakazuki on 2022-11-10T22:48:21+09:00
+# fly.toml app configuration file generated for sakazuki on 2025-03-30T19:16:47+09:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
 
 app = "sakazuki"
-kill_signal = "SIGINT"
-kill_timeout = 5
-processes = []
+primary_region = "nrt"
+console_command = "/rails/bin/rails console"
 swap_size_mb = 512
 
 [build]
-  [build.args]
-    BUILD_COMMAND = "bin/rails fly:build"
-    SERVER_COMMAND = "bin/rails fly:server"
+  dockerfile = "fly.Dockerfile"
 
 [deploy]
-  release_command = "bin/rails fly:release"
+  release_command = "./bin/rails db:prepare"
 
-[env]
-  PORT = "8080"
-
-[experimental]
-  allowed_public_ports = []
-  auto_rollback = true
-
-[[services]]
-  http_checks = []
-  internal_port = 8080
+[http_service]
   processes = ["app"]
-  protocol = "tcp"
-  script_checks = []
-  [services.concurrency]
-    hard_limit = 25
-    soft_limit = 20
-    type = "connections"
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = "off"
+  auto_start_machines = true
+  min_machines_running = 0
 
-  [[services.ports]]
-    force_https = true
-    handlers = ["http"]
-    port = 80
+[[http_service.checks]]
+  grace_period = "10s"
+  interval = "15s"
+  timeout = "2s"
+  method = "GET"
+  path = "/up"
+  protocol = "http"
 
-  [[services.ports]]
-    handlers = ["tls", "http"]
-    port = 443
-
-  [[services.tcp_checks]]
-    grace_period = "1s"
-    interval = "15s"
-    restart_limit = 0
-    timeout = "2s"
+[http_service.checks.headers]
+  X-Forwarded-Proto = "https"
 
 [[statics]]
   guest_path = "/app/public"
   url_prefix = "/"
+
+[[vm]]
+  size = "shared-cpu-1x"


### PR DESCRIPTION
fix #956

## やったこと

- fly.tomlを最新のドキュメントに従い更新
  - 普通のウェブアプリは`http_service`を使いシンプルに設定できるようになった
  - 変更点
    - すでに存在しない設定を削除した
    - 日本リージョンを明示的に指定した
    - コンソールコマンドを指定
    - 新しいRailsで使える`db:prepare`でDB準備をするようにした
    - マシン起動を待つgrace_periodを1s->10sに伸ばした
    - vmのCPU・メモリを明示的に指定した
- Actionsの`fly deploy`コマンドから必要ないオプションを削除
  - コマンドでなくfly.tomlファイルで指定するようにした
- ヘルスチェック用のルーティング`/up`を追加
  - Rails7で追加された便利な機能

## 参考

- [fly.toml](https://fly.io/docs/reference/configuration/)
- [class Rails::HealthController](https://edgeapi.rubyonrails.org/classes/Rails/HealthController.html)
