### PR TITLE
ImageMagickからVipsへ移行

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Install ImageMagick
+      - name: Install libvips
         run: |
           sudo apt-get update
-          sudo apt-get install --yes imagemagick
+          sudo apt-get install --yes libvips
       - uses: actions/setup-node@v4
         with:
           node-version: "22"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 - Bundler
 - Node.js >= 22
 - PostgreSQL >= 12.0
-- ImageMagick >= 6.9
+- libvips (devlopment only)
 
 ## Setup
 

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -2,7 +2,7 @@ class ImageUploader < CarrierWave::Uploader::Base
   if Rails.env.production?
     include Cloudinary::CarrierWave
   else
-    include CarrierWave::MiniMagick
+    include CarrierWave::Vips
     storage :file
   end
 

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -12,7 +12,7 @@ RUN <<EOF
   apt-get update -q
   apt-get upgrade -y
   DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
-    curl=7.74.* build-essential=12.9 gnupg2=2.2.* imagemagick=8:6.9.*
+    curl=7.74.* build-essential=12.9 gnupg2=2.2.* libvips42=8.*
 EOF
 
 # Install posgresql-client


### PR DESCRIPTION
close #944 

[メモリ消費も少なく速度も早いVipsへ！](https://github.com/libvips/libvips/wiki/Speed-and-memory-use)

## やったこと

- **Update: ImageMagickからlibvipsに移行した**
- **Update: READMEの要件をImageMagickからlibvipsに変更**
- **Update: dev環境DockerfileをImageMagick -> libvipsにした**
- **Remove: ActionsのテストからImageMagickを削除**
