### PR TITLE
酒編集画面の削除バツ記号の色をdanger色にした

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -100,7 +100,8 @@ h1 {
   @extend .text-danger;
   @extend .fs-1;
 
-  content: "✖";
+  content: "✕";
+  font-weight: bold;
   display: block;
   margin-top: -3ex;
   margin-left: 1ex;


### PR DESCRIPTION
close #973

絵文字バツは色が変更できない！

## やったこと

- バツを色つき絵文字から色なし記号に変更した
- 太さを指定した

## 変更前スクショ

![image](https://github.com/user-attachments/assets/b9fc22e3-3a78-44ec-bd28-f1b095388a15)

## 変更後スクショ

![image](https://github.com/user-attachments/assets/74738c11-5319-492f-a01d-dc53a5c419e9)


