### PR TITLE
製造年月で不明（nil）を許可

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,7 @@ User.create!(
 ```
 
 - DB の作成
-  - `bundle exec rails db:create`
-  - `bundle exec rails db:migrate`
+  - `bundle exec rails db:prepare`
   - `bundle exec rake parallel:setup`、並列テストを使う場合
 - 管理者ユーザの作成
   - `bundle exec rails db:seed`
@@ -94,16 +93,13 @@ $ docker compose build --build-arg RUBY_VERSION=$(cat .ruby-version)
 <!-- markdownlint-disable MD013 -->
 
 ```console
-$ docker compose run --rm web bundle exec rails db:create
+$ docker compose run --rm web bundle exec rails db:prepare
 Creating volume "sakazuki_db_storage" with local driver
 Creating sakazuki_db_1 ... done
 Creating sakazuki_web_run ... done
 Created database 'sakazuki_development'
 Created database 'sakazuki_test'
 $ docker compose run --rm web bundle exec rake parallel:setup
-...
-$ docker compose run --rm web bundle exec rails db:migrate
-Creating sakazuki_web_run ... done
 ...
 Model files unchanged.
 $ docker compose run --rm web bundle exec rails db:seed

--- a/app/controllers/sakes_controller.rb
+++ b/app/controllers/sakes_controller.rb
@@ -124,7 +124,8 @@ class SakesController < ApplicationController
   # @return [Hash{Symbol => Integer, Date}] デフォルト酒情報のハッシュ
   def default_attributes
     {
-      brewery_year: to_by(Time.current),
+      brewery_year: to_by(Date.current),
+      bindume_on: Date.current.beginning_of_month,
     }
   end
 

--- a/app/helpers/sakes_helper.rb
+++ b/app/helpers/sakes_helper.rb
@@ -45,6 +45,8 @@ module SakesHelper
 
   # BYの候補を作成する
   #
+  # フォーマットは 「2025 / 令和7年」
+  #
   # @return [Array<[String, String]>] BYセレクタで使う、表示用文字列と日付データ
   def by_collection
     collection = by_range.map { |d| [with_japanese_era(d), d.to_s] }
@@ -70,14 +72,17 @@ module SakesHelper
   # 製造年月の候補を作成する
   #
   # 現在の日付から30年分を生成する
+  # フォーマットは 「2025 / 令和7年 7月」
   #
   # @return [Array<[String, String]>] 製造年月セレクタで使う、表示用文字列と日付データ
   def bindume_collection
-    month_range.map { |d|
-      year = with_japanese_era(d)
-      month = I18n.l(d, format: "%B")
-      ["#{year} #{month}", d.to_s]
-    }
+    collection =
+      month_range.map { |d|
+        year = with_japanese_era(d)
+        month = I18n.l(d, format: "%B")
+        ["#{year} #{month}", d.to_s]
+      }
+    collection.push([I18n.t("sakes.form_abstract.unknown"), ""])
   end
 
   # @type [Array<String>]

--- a/app/models/sake.rb
+++ b/app/models/sake.rb
@@ -97,7 +97,6 @@ class Sake < ApplicationRecord
   after_initialize do |sake|
     sake.opened_at ||= Time.current
     sake.emptied_at ||= Time.current
-    sake.bindume_on ||= Time.current.to_date.beginning_of_month
   end
 
   # rubocop:disable Layout/LineLength

--- a/spec/helpers/sakes_helper_spec.rb
+++ b/spec/helpers/sakes_helper_spec.rb
@@ -80,12 +80,17 @@ RSpec.describe SakesHelper do
   end
 
   describe "bindume_collection" do
-    it "generates a range ending with current" do
+    it "generates a range ending with unknown" do
+      candidate = [I18n.t("sakes.form_abstract.unknown"), ""]
+      expect(by_collection.last).to eq(candidate)
+    end
+
+    it "generates a range having current in second from last" do
       date = Time.current.to_date.beginning_of_month
       year = with_japanese_era(date)
       month = I18n.l(date, format: "%B")
       candidate = ["#{year} #{month}", date.to_s]
-      expect(bindume_collection.last).to eq(candidate)
+      expect(bindume_collection[-2]).to eq(candidate)
     end
 
     it "generates a range starting with 30 years ago" do

--- a/spec/requests/sake_request_spec.rb
+++ b/spec/requests/sake_request_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "Sakes" do
   context "with logined user" do
     before do
       user = create(:user)
-      sign_in(user)
+      login_as(user)
     end
 
     describe "GET /sakes/[id]/edit (edit)" do

--- a/spec/system/bottle_state_timestamps_spec.rb
+++ b/spec/system/bottle_state_timestamps_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Bottle State Timestamps" do
 
   context "when creating a new sealed sake" do
     before do
-      sign_in(user)
+      login_as(user)
       create_sake("sealed")
     end
 
@@ -37,7 +37,7 @@ RSpec.describe "Bottle State Timestamps" do
 
   context "when creating a new opened sake" do
     before do
-      sign_in(user)
+      login_as(user)
       create_sake("opened")
     end
 
@@ -60,7 +60,7 @@ RSpec.describe "Bottle State Timestamps" do
 
   context "when creating a new empty sake" do
     before do
-      sign_in(user)
+      login_as(user)
       create_sake("empty")
     end
 
@@ -93,11 +93,11 @@ RSpec.describe "Bottle State Timestamps" do
     before do
       id =
         travel_to(7.days.ago) {
-          sign_in(user)
+          login_as(user)
           create_sake("sealed")
         }
       visit(current_path) # ページをリロードしないと再ログインできない
-      sign_in(user)
+      login_as(user)
       edit_bottle_level(id, "opened")
     end
 
@@ -121,11 +121,11 @@ RSpec.describe "Bottle State Timestamps" do
     before do
       id =
         travel_to(7.days.ago) {
-          sign_in(user)
+          login_as(user)
           create_sake("sealed")
         }
       visit(current_path)
-      sign_in(user)
+      login_as(user)
       edit_bottle_level(id, "empty")
     end
 
@@ -157,16 +157,16 @@ RSpec.describe "Bottle State Timestamps" do
     before do
       id =
         travel_to(7.days.ago) {
-          sign_in(user)
+          login_as(user)
           create_sake("sealed")
         }
       travel_to(4.days.ago) do
         visit(current_path)
-        sign_in(user)
+        login_as(user)
         edit_bottle_level(id, "opened")
       end
       visit(current_path)
-      sign_in(user)
+      login_as(user)
       edit_bottle_level(id, "empty")
     end
 

--- a/spec/system/copy_sakes_spec.rb
+++ b/spec/system/copy_sakes_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "Copy Sakes" do
   let(:user) { create(:user) }
 
   before do
-    sign_in(user)
+    login_as(user)
     visit sake_path(sake.id)
   end
 

--- a/spec/system/drink_buttons_spec.rb
+++ b/spec/system/drink_buttons_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe "Drink Buttons" do
 
   context "with login" do
     before do
-      sign_in(user)
+      login_as(user)
     end
 
     describe "clicking open button of sealed bottle", :js do

--- a/spec/system/edit_sake_spec.rb
+++ b/spec/system/edit_sake_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Edit Sake" do
 
   describe "updating name" do
     before do
-      sign_in(user)
+      login_as(user)
       visit edit_sake_path(sake.id)
       fill_in("sake_name", with: "ほしいずみ")
       click_button("form_submit")

--- a/spec/system/flash_message_spec.rb
+++ b/spec/system/flash_message_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "Flash Message" do
 
   context "with login" do
     before do
-      sign_in(user)
+      login_as(user)
     end
 
     # sake

--- a/spec/system/new_sake_spec.rb
+++ b/spec/system/new_sake_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "New Sake" do
 
   describe "create sake" do
     before do
-      sign_in(user)
+      login_as(user)
       visit new_sake_path
       fill_in("sake_name", with: sake_name)
       click_button("form_submit")

--- a/spec/system/sake_form_add_tax_spec.rb
+++ b/spec/system/sake_form_add_tax_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Sake Form Add Tax", :js do
   let(:user) { create(:user) }
 
   before do
-    sign_in(user)
+    login_as(user)
     visit new_sake_path
   end
 

--- a/spec/system/sake_form_bindume_date_spec.rb
+++ b/spec/system/sake_form_bindume_date_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Sake Form Bindume Date" do
   let(:user) { create(:user) }
 
   before do
-    sign_in user
+    login_as(user)
   end
 
   context "when visiting new sake page" do

--- a/spec/system/sake_form_bottle_level_spec.rb
+++ b/spec/system/sake_form_bottle_level_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Sake Form Bottle Level" do
   let(:empty_sake) { create(:sake, bottle_level: :empty) }
 
   before do
-    sign_in(user)
+    login_as(user)
   end
 
   describe "updating sake from sealed to opened" do

--- a/spec/system/sake_form_brewery_year_spec.rb
+++ b/spec/system/sake_form_brewery_year_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Sake Form Brew Year" do
   let(:user) { create(:user) }
 
   before do
-    sign_in(user)
+    login_as(user)
   end
 
   describe "brewery_year" do

--- a/spec/system/sake_form_kura_completion_spec.rb
+++ b/spec/system/sake_form_kura_completion_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Sake Form Kura Completion" do
   let(:user) { create(:user) }
 
   before do
-    sign_in(user)
+    login_as(user)
   end
 
   describe "autocompletion of kura form in new sake page", :js do

--- a/spec/system/sake_form_photos_spec.rb
+++ b/spec/system/sake_form_photos_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Sake Form Photos" do
   let(:user) { create(:user) }
 
   before do
-    sign_in(user)
+    login_as(user)
     visit new_sake_path
     fill_in("sake_name", with: "生道井")
   end

--- a/spec/system/sake_form_size_spec.rb
+++ b/spec/system/sake_form_size_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Sake Form Size", :js do
   let(:user) { create(:user) }
 
   before do
-    sign_in(user)
+    login_as(user)
   end
 
   context "when creating new sake" do

--- a/spec/system/sake_form_validation_spec.rb
+++ b/spec/system/sake_form_validation_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Sake Form Validation" do
   let(:user) { create(:user) }
 
   before do
-    sign_in(user)
+    login_as(user)
     visit new_sake_path
     fill_in("sake_name", with: "生道井")
   end

--- a/spec/system/user_invitation_spec.rb
+++ b/spec/system/user_invitation_spec.rb
@@ -20,13 +20,13 @@ RSpec.describe "User Invitation" do
 
     context "when sign in as user" do
       it "redirects to index page" do
-        sign_in(user)
+        login_as(user)
         visit new_user_invitation_path
         expect(page).to have_current_path root_path
       end
 
       it "has error message" do
-        sign_in(user)
+        login_as(user)
         visit new_user_invitation_path
         expect(page).to have_css(".alert-danger")
       end

--- a/spec/views/layouts/_header.html.erb_spec.rb
+++ b/spec/views/layouts/_header.html.erb_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "layouts/_header", type: :system do
       let(:user) { create(:user, admin: true) }
 
       before do
-        sign_in(user)
+        login_as(user)
         visit root_path
       end
 
@@ -46,7 +46,7 @@ RSpec.describe "layouts/_header", type: :system do
       let(:user) { create(:user, admin: false) }
 
       before do
-        sign_in(user)
+        login_as(user)
         visit root_path
       end
 


### PR DESCRIPTION
close #1040 

## やったこと

- 製造年月に不明の選択肢を追加
  - BY にすでにあったやつ
- ユニットテストを追加
- ローカルテストでログインできない問題を修正
  - Rails 8 にしたときに壊れてた？

<img width="2159" height="1391" alt="image" src="https://github.com/user-attachments/assets/2bb2e1fe-7beb-414e-aacd-44e0a6dc671c" />

## やってないこと

- BY との共通化
  - 微妙にフォーマット違うので後回し