### PR TITLE
flakyなテストを改善

### DIFF
--- a/spec/system/sake_index_order_spec.rb
+++ b/spec/system/sake_index_order_spec.rb
@@ -16,12 +16,11 @@ RSpec.describe "Sake Index Order" do
     context "without checked 'show empty bottles'" do
       it "shows opened sakes before sealed sakes" do
         regexp = /#{sealed_new.name}.*#{sealed_old.name}.*#{opened_new.name}.*#{opened_old.name}/m
-        expect(page.text).to match(regexp)
+        expect(page).to have_text(regexp)
       end
 
       it "does not include empty sake" do
-        regexp = /#{empty.name}}/
-        expect(page.text).not_to match(regexp)
+        expect(page).to have_no_text(empty.name)
       end
     end
 
@@ -32,7 +31,7 @@ RSpec.describe "Sake Index Order" do
 
       it "shows sakes sorted by id" do
         regexp = /#{sealed_new.name}.*#{sealed_old.name}.*#{opened_new.name}.*#{opened_old.name}.*#{empty.name}/m
-        expect(page.text).to match(regexp)
+        expect(page).to have_text(regexp)
       end
     end
   end

--- a/spec/system/sake_index_pagination_spec.rb
+++ b/spec/system/sake_index_pagination_spec.rb
@@ -40,13 +40,11 @@ RSpec.describe "Sake Index Pagination" do
 
     describe "listed sakes" do
       it "includes 12th sake" do
-        regexp = /#{sealed12.name}/
-        expect(page.text).to match(regexp)
+        expect(page).to have_text(sealed12.name)
       end
 
       it "includes 13th sake" do
-        regexp = /#{sealed13.name}/
-        expect(page.text).to match(regexp)
+        expect(page).to have_text(sealed13.name)
       end
     end
   end
@@ -63,13 +61,11 @@ RSpec.describe "Sake Index Pagination" do
 
     context "with page 1" do
       it "includes 12th sake" do
-        regexp = /#{sealed12.name}/
-        expect(page.text).to match(regexp)
+        expect(page).to have_text(sealed12.name)
       end
 
       it "does not include 13th sake" do
-        regexp = /#{sealed13.name}/
-        expect(page.text).not_to match(regexp)
+        expect(page).to have_no_text(sealed13.name)
       end
     end
 
@@ -81,13 +77,11 @@ RSpec.describe "Sake Index Pagination" do
       end
 
       it "does not include 12th sake" do
-        regexp = /#{sealed12.name}/
-        expect(page.text).not_to match(regexp)
+        expect(page).to have_no_text(sealed12.name)
       end
 
       it "includes 13th sake" do
-        regexp = /#{sealed13.name}/
-        expect(page.text).to match(regexp)
+        expect(page).to have_text(sealed13.name)
       end
     end
   end

--- a/spec/system/sake_index_with_empty_bottle_spec.rb
+++ b/spec/system/sake_index_with_empty_bottle_spec.rb
@@ -23,18 +23,15 @@ RSpec.describe "With Empty Bottle" do
   describe "listed sakes" do
     context "without empty bottles" do
       it "includes sealed sake" do
-        regexp = /#{sealed.name}/
-        expect(page.text).to match(regexp)
+        expect(page).to have_text(sealed.name)
       end
 
       it "includes opened sake" do
-        regexp = /#{opened.name}/
-        expect(page.text).to match(regexp)
+        expect(page).to have_text(opened.name)
       end
 
       it "does not include empty sake" do
-        regexp = /#{empty.name}/
-        expect(page.text).not_to match(regexp)
+        expect(page).to have_no_text(empty.name)
       end
     end
   end
@@ -47,18 +44,15 @@ RSpec.describe "With Empty Bottle" do
 
     context "without empty bottles" do
       it "includes sealed sake" do
-        regexp = /#{sealed.name}/
-        expect(page.text).to match(regexp)
+        expect(page).to have_text(sealed.name)
       end
 
       it "includes opened sake" do
-        regexp = /#{opened.name}/
-        expect(page.text).to match(regexp)
+        expect(page).to have_text(opened.name)
       end
 
       it "includes empty sake" do
-        regexp = /#{empty.name}/
-        expect(page.text).to match(regexp)
+        expect(page).to have_text(empty.name)
       end
     end
   end


### PR DESCRIPTION
`match` は capybara の待機やリトライがきかない。
`have_text` が正規表現受け入れるのでこれを使え！

## やったこと

- match を have_text に変換した
