### PR TITLE
devise セッションを1週間記憶するようにした

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -28,7 +28,7 @@
         <% if devise_mapping.rememberable? %>
           <div class="col mx-2 mt-2">
             <div class="form-check">
-              <%= f.checkbox(:remember_me, class: "form-check-input") %>
+              <%= f.checkbox(:remember_me, class: "form-check-input", checked: true) %>
               <%= f.label(:remember_me, class: "form-check-label") %>
             </div>
           </div>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -222,7 +222,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :rememberable
   # The time the user will be remembered without asking for credentials again.
-  # config.remember_for = 2.weeks
+  config.remember_for = 1.week
 
   # Invalidates all the remember me tokens when the user signs out.
   config.expire_all_remember_me_on_sign_out = true

--- a/config/locales/views/devise.ja.yml
+++ b/config/locales/views/devise.ja.yml
@@ -1,4 +1,8 @@
 ja:
+  activerecord:
+    attributes:
+      user:
+        remember_me: ログインを1週間記憶する
   devise:
     registrations:
       edit:


### PR DESCRIPTION
## 背景

- ログインセッション保存してなかった
- 今まではブラウザ再起動ごとにセッションが切れてた

## やったこと

- デフォルトでログイン記憶のチェックボックスをオンにした
  - これがオンだと端末ごとのcookieに保存されログインが1週間記憶される
  - オフにすれば今まで通りログインセッションはブラウザ再起動で消える
  - ログアウトすると全端末のログイン記憶が無効化される
- ログイン画面の表記に「1週間記憶する」と期間を明示した