### PR TITLE
Fix: テスト時の画像保存先を変更してクリーンアップするようにした

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
   changes:
     name: changes
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     permissions:
       pull-requests: read # Needed to read changes to skip test or not
     outputs:

--- a/spec/support/carrierwave.rb
+++ b/spec/support/carrierwave.rb
@@ -1,0 +1,12 @@
+# テスト中のアップロード先をpublic/uploadsからtmp以下に変更する
+# トランザクションのロールバックではCarrierWaveのファイル削除コールバックが動かないため、
+# public以下に保存するとテスト後にファイルが残り続ける
+CarrierWave.configure do |config|
+  config.root = Rails.root.join("tmp/carrierwave#{ENV.fetch('TEST_ENV_NUMBER', '')}")
+end
+
+RSpec.configure do |config|
+  config.after(:suite) do
+    FileUtils.rm_rf(CarrierWave::Uploader::Base.root)
+  end
+end

--- a/spec/support/carrierwave.rb
+++ b/spec/support/carrierwave.rb
@@ -7,6 +7,8 @@ end
 
 RSpec.configure do |config|
   config.after(:suite) do
-    FileUtils.rm_rf(CarrierWave::Uploader::Base.root)
+    root = CarrierWave::Uploader::Base.root&.to_s
+    next unless root&.start_with?(Rails.root.join("tmp", "carrierwave").to_s)
+    FileUtils.rm_rf(root)
   end
 end

--- a/spec/support/carrierwave.rb
+++ b/spec/support/carrierwave.rb
@@ -8,7 +8,8 @@ end
 RSpec.configure do |config|
   config.after(:suite) do
     root = CarrierWave::Uploader::Base.root&.to_s
-    next unless root&.start_with?(Rails.root.join("tmp", "carrierwave").to_s)
+    next unless root&.start_with?(Rails.root.join("tmp/carrierwave").to_s)
+
     FileUtils.rm_rf(root)
   end
 end


### PR DESCRIPTION
テスト実行すると public/uploads が肥大化し続けていた

## やったこと

- test時の画像保存先を変更
- test後に画像保存先フォルダを削除するようにした