### PR TITLE
Fix: Playwright導入時にテストが壊れていたのを修正

### DIFF
--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -26,7 +26,11 @@ class ImageUploader < CarrierWave::Uploader::Base
   end
 
   def store_dir
-    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+    # テストでは画像アップロードパスを変更する
+    # carrierwave.rb によりテスト実行後に削除される
+    root_dir = Rails.application.config.x.uploads_dir.to_s
+    path = "#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+    Rails.public_path.join(root_dir, path).to_s
   end
 
   def extension_allowlist

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -29,8 +29,7 @@ class ImageUploader < CarrierWave::Uploader::Base
     # テストでは画像アップロードパスを変更する
     # carrierwave.rb によりテスト実行後に削除される
     root_dir = Rails.application.config.x.uploads_dir.to_s
-    path = "#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
-    Rails.public_path.join(root_dir, path).to_s
+    "#{root_dir}/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
   end
 
   def extension_allowlist

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -85,6 +85,8 @@ Rails.application.configure do
 
   # Feature flags
   config.x.cloudinary_enabled = false
+  config.x.uploads_dir = "uploads"
+  config.x.temp_uploads_dir_enabled = false
   config.x.adsense_enabled = false
   config.x.letter_opener_enabled = true
   config.x.fast_password_hashing = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -102,6 +102,8 @@ Rails.application.configure do
 
   # Feature flags
   config.x.cloudinary_enabled = true
+  config.x.uploads_dir = "uploads"
+  config.x.temp_uploads_dir_enabled = false
   config.x.adsense_enabled = true
   config.x.letter_opener_enabled = false
   config.x.fast_password_hashing = false

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -55,7 +55,7 @@ Rails.application.configure do
 
   # Feature flags
   config.x.cloudinary_enabled = false
-  config.x.uploads_dir = "uploads_test"
+  config.x.uploads_dir = "uploads#{ENV.fetch('TEST_ENV_NUMBER', '')}_test"
   config.x.temp_uploads_dir_enabled = true
   config.x.adsense_enabled = false
   config.x.letter_opener_enabled = false

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -55,6 +55,8 @@ Rails.application.configure do
 
   # Feature flags
   config.x.cloudinary_enabled = false
+  config.x.uploads_dir = "uploads_test"
+  config.x.temp_uploads_dir_enabled = true
   config.x.adsense_enabled = false
   config.x.letter_opener_enabled = false
   config.x.fast_password_hashing = true

--- a/spec/support/carrierwave.rb
+++ b/spec/support/carrierwave.rb
@@ -1,8 +1,9 @@
 # テストの画像アップロード先を削除する
+# 安全のため "_test" で終わるディレクトリのみ削除する
 RSpec.configure do |config|
   config.after(:suite) do
-    if Rails.application.config.x.temp_uploads_dir_enabled
-      temp_dir = Rails.application.config.x.uploads_dir
+    temp_dir = Rails.application.config.x.uploads_dir.to_s
+    if Rails.application.config.x.temp_uploads_dir_enabled && temp_dir.end_with?("_test")
       FileUtils.rm_rf(Rails.public_path.join(temp_dir))
     end
   end

--- a/spec/support/carrierwave.rb
+++ b/spec/support/carrierwave.rb
@@ -1,15 +1,9 @@
-# テスト中のアップロード先をpublic/uploadsからtmp以下に変更する
-# トランザクションのロールバックではCarrierWaveのファイル削除コールバックが動かないため、
-# public以下に保存するとテスト後にファイルが残り続ける
-CarrierWave.configure do |config|
-  config.root = Rails.root.join("tmp/carrierwave#{ENV.fetch('TEST_ENV_NUMBER', '')}")
-end
-
+# テストの画像アップロード先を削除する
 RSpec.configure do |config|
   config.after(:suite) do
-    root = CarrierWave::Uploader::Base.root&.to_s
-    next unless root&.start_with?(Rails.root.join("tmp/carrierwave").to_s)
-
-    FileUtils.rm_rf(root)
+    if Rails.application.config.x.temp_uploads_dir_enabled
+      temp_dir = Rails.application.config.x.uploads_dir
+      FileUtils.rm_rf(Rails.public_path.join(temp_dir))
+    end
   end
 end

--- a/spec/system/sake_search_with_empty_bottle_spec.rb
+++ b/spec/system/sake_search_with_empty_bottle_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe "Search With Empty Bottle" do
       fill_in("text_search", with: "生道井")
       click_button("submit_search")
     end
+    # HACK: 検索結果にしかないテキストを使いTurbo Frameの置換完了を待つ
+    find(:test_id, "total_sake", text: I18n.t("sakes.index.h1_with_search", search: "生道井", hit: 2))
   end
 
   # 検索ボタン経由（commit）はサーバ側でデフォルトON判定するため、JSなしで成立する


### PR DESCRIPTION
## 起きていたこと

- 画像アップロードテストが落ちている
  - テストuploadsフォルダを変えたのをCarrierWaveが認識できていなかった
- 検索後に空き瓶を含むのチェックボックスが見つからない
  - 検索後のTurbo置換の前の古いチェックボックスが使われていた

## やったこと

- 環境で upload パスを変更
  - テスト "uploads_test"
  - そのた "upldoas"
- テストのときは、uplaod_test をテスト後に削除
- 検索後にH1タイトルが検索用に切り替わるのを待つようにした