### PR TITLE
Fix: playwrightをpostinstallから外した

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -22,7 +22,7 @@ jobs:
           node-version: "22"
           cache: "yarn"
       - name: Install Dependencies
-        run: yarn install --imutable
+        run: yarn install --immutable
       - name: Run ESLint
         run: yarn run lint:eslint
       - name: Run tsc

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -22,7 +22,7 @@ jobs:
           node-version: "22"
           cache: "yarn"
       - name: Install Dependencies
-        run: yarn install --immutable
+        run: yarn workspaces focus --all --production
       - name: Run ESLint
         run: yarn run lint:eslint
       - name: Run tsc

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -22,7 +22,7 @@ jobs:
           node-version: "22"
           cache: "yarn"
       - name: Install Dependencies
-        run: yarn workspaces focus --all --production
+        run: yarn install --imutable
       - name: Run ESLint
         run: yarn run lint:eslint
       - name: Run tsc

--- a/.github/workflows/esbuild-bundle-analyzer.yml
+++ b/.github/workflows/esbuild-bundle-analyzer.yml
@@ -35,7 +35,7 @@ jobs:
           cache: "yarn"
       - name: Install Dependencies
         # postinstall の praywrite インストールを避ける
-        run: YARN_ENABLE_SCRIPTS=false yarn workspaces focus --all --production
+        run: yarn workspaces focus --all --production
       - name: Run esbuld
         run: yarn run build:metafile
 

--- a/.github/workflows/esbuild-bundle-analyzer.yml
+++ b/.github/workflows/esbuild-bundle-analyzer.yml
@@ -34,7 +34,6 @@ jobs:
           node-version: "22"
           cache: "yarn"
       - name: Install Dependencies
-        # postinstall の praywrite インストールを避ける
         run: yarn workspaces focus --all --production
       - name: Run esbuld
         run: yarn run build:metafile

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 - Ruby = (See .ruby-version file)
 - Bundler
 - Node.js >= 22
+- Yarn 🐈 = 1.22
 - PostgreSQL >= 18
 - libvips (development only)
 
@@ -33,7 +34,8 @@
 
 - 依存関係のインストール
   - `bundle install`
-  - `corepack enable && yarn install`
+  - `yarn install`
+  - `yarn run playwright install firefox`（Test を走らせる場合）
 - .env ファイルの作成
   - PostgreSQL の設定
   - Google AdSense のクライアント ID の設定（Google AdSense を使う場合）

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "semi": false
   },
   "scripts": {
-    "postinstall": "playwright install firefox",
     "lint": "./cli-scripts/run-all-checks.sh",
     "lint:eslint": "eslint --max-warnings=0 ./app/javascript/",
     "lint:eslint:fix": "yarn run lint:eslint --fix",


### PR DESCRIPTION
postinstall に入れると必要ない場合も install が走って時間がかかる。
具体的には lint, formatter, esbundle analyzer のときとか。