### PR TITLE
テストをFirefoxからChromiumに変更

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Install Yarn Dependencies
         run: yarn install --immutable
       - name: Install Playwright browsers
-        run: yarn run playwright install firefox
+        run: yarn run playwright install chromium
       - name: Set up Ruby
         env:
           BUNDLE_WITHOUT: development

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.src == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 5
     services:
       postgres:
         # postgres:18.0-trixie

--- a/Dockerfile
+++ b/Dockerfile
@@ -122,7 +122,7 @@ RUN yarn install && yarn cache clean
 
 # Install Playwright browsers and system dependencies for system tests
 # hadolint ignore=DL3060 # not yarn install
-RUN yarn run playwright install firefox
+RUN yarn run playwright install chromium
 
 # Copy application code
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -120,7 +120,7 @@ COPY package.json yarn.lock .yarnrc.yml ./
 COPY .yarn/releases/ ./.yarn/releases/
 RUN yarn install && yarn cache clean
 
-# Install Playwright browsers and system dependencies for system tests
+# Install Playwright browsers for system tests
 # hadolint ignore=DL3060 # not yarn install
 RUN yarn run playwright install chromium
 

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -7,9 +7,4 @@ css: yarn build:css --watch
 # You need PostgreSQL configurations.
 # See also dotenv.example file.
 #
-# db: docker run --rm --name db --network sakazuki_net --env-file .env --publish 5432:5432 --mount type=volume,src=sakazuki_db,dst=/var/lib/postgresql/data postgres:13-alpine
-#
-# You need remote driver configurations.
-# See also dotenv.example file.
-#
-# selenium: docker run --rm --name selenium --network host --env-file .env --publish 4444:4444 selenium/standalone-firefox:latest
+# db: docker run --rm --name db --network sakazuki_net --env-file .env --publish 5432:5432 --mount type=volume,src=sakazuki_db,dst=/var/lib/postgresql/data postgres:18-alpine

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 - 依存関係のインストール
   - `bundle install`
   - `yarn install`
-  - `yarn run playwright install firefox`（Test を走らせる場合）
+  - `yarn run playwright install chromium`（Test を走らせる場合）
 - .env ファイルの作成
   - PostgreSQL の設定
   - Google AdSense のクライアント ID の設定（Google AdSense を使う場合）

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 - Ruby = (See .ruby-version file)
 - Bundler
 - Node.js >= 22
-- Yarn 🐈 = 1.22
+- Yarn 🐈 = 1.22.22
 - PostgreSQL >= 18
 - libvips (development only)
 

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -18,7 +18,7 @@ RSpec.configure do |config|
   config.before(:each, type: :system) do |example|
     if example.metadata[:js]
       # Rails標準のPlaywrightサポートを使う
-      driven_by(:playwright, options: { browser_type: :firefox, headless: true })
+      driven_by(:playwright, options: { browser_type: :chromium, headless: true })
     else
       driven_by(:rack_test)
     end


### PR DESCRIPTION
fix #1329

## 原因

- Firefoxが遅い

## やったこと

- Chromiumでテストまわすようにした
- Procfile.devを更新
- テストタイムアウトを10m -> 5mに戻した

## Fable 調査結果

原因

Playwright自体ではなく、Playwright + Firefox の組み合わせが遅さの正体でした。

1. テストごとのブラウザコンテキスト再作成（driverの設計差）: Seleniumは1つのブラウザセッションを全テストで使い回します（テスト間はCookie削除のみ、HTTPキャッシュも温かいまま）。一方Playwright driverはテストごとに新品のブラウザコンテキストを作り、毎回コールドキャッシュでページを読み直します。
2. PlaywrightのFirefoxビルドはこれが特に重い: 最小限のspec（ログインページをvisitするだけ）で計測したところ、1例あたり0.62秒の固定費がかかっていました（rack_testは0.01秒）。:js の例は113個あるので、固定費だけで約70秒。さらにCPU消費が激しく（フルスイートのCPU時間: Firefox約3分40秒 vs Chromium 58秒）、操作の多いフォーム系specでは1例あたりの遅延がさらに膨らんでいました。

なお、移行時のspec変更・:js の数・wait設定はselenium時代と同一で、これらは無関係でした。Selenium時代もFirefoxでしたが、上記の「セッション使い回し」のおかげで遅さが顕在化していなかった形です。

対策（実施済み）

Chromiumに切り替えました。計測値（同一マシン・同一スイート）:

```
┌───────────────────────────┬────────────┬───────────┐
│           構成            │ フルテスト │ 固定費/例 │
├───────────────────────────┼────────────┼───────────┤
│ Playwright + Firefox      │ 3m45s      │ 0.62s     │
├───────────────────────────┼────────────┼───────────┤
│ Playwright + Chromium     │ 1m45s      │ 0.35s     │
├───────────────────────────┼────────────┼───────────┤
│ (参考) Selenium + Firefox │ 1m25s      │ –         │
└───────────────────────────┴────────────┴───────────┘
```

変更ファイル: spec/support/capybara.rb（browser_type: :chromium）、package.json（postinstall）、.github/workflows/test.yml、Dockerfile。フルスイートを2回実行してどちらも0 failuresを確認しています。

補足

- Capybara.disable_animation = true を足すとさらに約4秒縮み（1m41s）、Bootstrapのフェード待ち由来のフレーキーさも減ります。挙動変更を伴うので今回は入れていませんが、おすすめではあります。
- Seleniumとの残差約20秒は、Playwrightがテストごとにコンテキストを分離するコスト（その分テスト間の独立性は高い）です。さらに縮めたい場合は rake parallel:spec が効きます。
- もし「Firefoxで検証したい」という意図があってFirefoxを選んでいた場合は言ってください。ローカルはChromium・CIのみFirefoxのような構成も可能です。